### PR TITLE
build: enable use of versioned SONAME

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 add_library(cbor ${SOURCES})
 add_library(cbor_shared SHARED ${SOURCES})
 
-set_target_properties(cbor_shared PROPERTIES OUTPUT_NAME cbor)
+set_target_properties(cbor_shared PROPERTIES OUTPUT_NAME cbor VERSION "0.0.0" SOVERSION 0)
 
 #http://www.cmake.org/Wiki/CMake:Install_Commands
 


### PR DESCRIPTION
Most libraries are using a versioned SONAME to track API changes. When
they don't, we usually use a SOVERSION of 0. When willing to commit to
some API stability, SOVERSION and VERSION should be updated to more
adequate values (VERSION could match the library version, assuming it
follows the major.minor.patch convention and SOVERSION could be
major.minor since CMake doesn't support libtool versioning scheme with
age).

With this change CMake will install the library as
libcbor.so.0.0.0. libcbor.so.0 will be a symlink to the library for
other applications, to be found with the dynamic linker. libcbor.so will
be a symlink to libcbor.so.0 for use by the linker (ld).