### PR TITLE
Use CMake for big-endian test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ if(HAVE_ENDIAN_H)
     add_definitions(-DHAVE_ENDIAN_H=1)
 endif()
 
+include(TestBigEndian)
+TEST_BIG_ENDIAN(BIG_ENDIAN)
+if(BIG_ENDIAN)
+    add_definitions(-DIS_BIG_ENDIAN=1)
+endif()
+
 SET(CPACK_GENERATOR "DEB" "TGZ" "RPM")
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "Pavel Kalvoda")

--- a/src/cbor/internal/encoders.c
+++ b/src/cbor/internal/encoders.c
@@ -9,9 +9,6 @@
 
 #ifdef HAVE_ENDIAN_H
 #include <endian.h>
-#else
-// Props to http://esr.ibiblio.org/?p=5095
-#define IS_BIG_ENDIAN (*(uint16_t *)"\0\xff" < 0x100)
 #endif
 
 size_t _cbor_encode_uint8(uint8_t value, unsigned char *buffer, size_t buffer_size, uint8_t offset)

--- a/src/cbor/internal/loaders.c
+++ b/src/cbor/internal/loaders.c
@@ -10,9 +10,6 @@
 
 #ifdef HAVE_ENDIAN_H
 #include <endian.h>
-#else
-// Props to http://esr.ibiblio.org/?p=5095
-#define IS_BIG_ENDIAN (*(uint16_t *)"\0\xff" < 0x100)
 #endif
 
 uint8_t _cbor_load_uint8(cbor_data source)


### PR DESCRIPTION
The test that was in the source code itself was not working on OSX and incorrectly used big-endian. As CMake is already used, I changed the code to use that.