### PR TITLE
Remove static declaration of the dummy callback bundle from header

### DIFF
--- a/src/cbor/callbacks.c
+++ b/src/cbor/callbacks.c
@@ -56,3 +56,49 @@ void cbor_null_undefined_callback(void *_ctx) CBOR_DUMMY_CALLBACK
 void cbor_null_boolean_callback(void *_ctx, bool _val) CBOR_DUMMY_CALLBACK
 
 void cbor_null_indef_break_callback(void *_ctx) CBOR_DUMMY_CALLBACK
+
+const struct cbor_callbacks cbor_empty_callbacks = {
+	/* Type 0 - Unsigned integers */
+	.uint8 = cbor_null_uint8_callback,
+	.uint16 = cbor_null_uint16_callback,
+	.uint32 = cbor_null_uint32_callback,
+	.uint64 = cbor_null_uint64_callback,
+
+	/* Type 1 - Negative integers */
+	.negint8 = cbor_null_negint8_callback,
+	.negint16 = cbor_null_negint16_callback,
+	.negint32 = cbor_null_negint32_callback,
+	.negint64 = cbor_null_negint64_callback,
+
+	/* Type 2 - Byte strings */
+	.byte_string = cbor_null_byte_string_callback,
+	.byte_string_start = cbor_null_byte_string_start_callback,
+
+	/* Type 3 - Strings */
+	.string = cbor_null_string_callback,
+	.string_start = cbor_null_string_start_callback,
+
+	/* Type 4 - Arrays */
+	.array_start = cbor_null_array_start_callback,
+	.indef_array_start = cbor_null_indef_array_start_callback,
+
+	/* Type 5 - Maps */
+	.map_start = cbor_null_map_start_callback,
+	.indef_map_start = cbor_null_indef_map_start_callback,
+
+	/* Type 6 - Tags */
+	.tag = cbor_null_tag_callback,
+
+	/* Type 7 - Floats & misc */
+	/* Type names cannot be member names */
+	.float2 = cbor_null_float2_callback,
+	/* 2B float is not supported in standard C */
+	.float4 = cbor_null_float4_callback,
+	.float8 = cbor_null_float8_callback,
+	.undefined = cbor_null_undefined_callback,
+	.null = cbor_null_null_callback,
+	.boolean = cbor_null_boolean_callback,
+
+	/* Shared indefinites */
+	.indef_break = cbor_null_indef_break_callback,
+};

--- a/src/cbor/callbacks.h
+++ b/src/cbor/callbacks.h
@@ -177,51 +177,7 @@ void cbor_null_boolean_callback(void *, bool);
 void cbor_null_indef_break_callback(void *);
 
 /** Dummy callback bundle - does nothing */
-static const struct cbor_callbacks cbor_empty_callbacks = {
-	/* Type 0 - Unsigned integers */
-	.uint8 = cbor_null_uint8_callback,
-	.uint16 = cbor_null_uint16_callback,
-	.uint32 = cbor_null_uint32_callback,
-	.uint64 = cbor_null_uint64_callback,
-
-	/* Type 1 - Negative integers */
-	.negint8 = cbor_null_negint8_callback,
-	.negint16 = cbor_null_negint16_callback,
-	.negint32 = cbor_null_negint32_callback,
-	.negint64 = cbor_null_negint64_callback,
-
-	/* Type 2 - Byte strings */
-	.byte_string = cbor_null_byte_string_callback,
-	.byte_string_start = cbor_null_byte_string_start_callback,
-
-	/* Type 3 - Strings */
-	.string = cbor_null_string_callback,
-	.string_start = cbor_null_string_start_callback,
-
-	/* Type 4 - Arrays */
-	.array_start = cbor_null_array_start_callback,
-	.indef_array_start = cbor_null_indef_array_start_callback,
-
-	/* Type 5 - Maps */
-	.map_start = cbor_null_map_start_callback,
-	.indef_map_start = cbor_null_indef_map_start_callback,
-
-	/* Type 6 - Tags */
-	.tag = cbor_null_tag_callback,
-
-	/* Type 7 - Floats & misc */
-	/* Type names cannot be member names */
-	.float2 = cbor_null_float2_callback,
-	/* 2B float is not supported in standard C */
-	.float4 = cbor_null_float4_callback,
-	.float8 = cbor_null_float8_callback,
-	.undefined = cbor_null_undefined_callback,
-	.null = cbor_null_null_callback,
-	.boolean = cbor_null_boolean_callback,
-
-	/* Shared indefinites */
-	.indef_break = cbor_null_indef_break_callback,
-};
+extern const struct cbor_callbacks cbor_empty_callbacks;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
With dummy callback bundle declared as static variable in the header file, some projects do not link with the static library due to `cbor_null_*_callback` symbols being unresolved.

Declaring the bundle `extern` in the header file and defining it in the source file resolved this problem.