### PR TITLE
Huge headers arithmetic overflow fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Next
 - fixed static header declarations (by cedric-d)
 - improved documentation (by Michael Richardson)
 - improved `examples/readfile.c`
+- reworked (re)allocation to handle huge inputs and overflows in size_t [#16]
 
 0.4.0 (2015-12-25)
 ---------------------

--- a/examples/readfile.c
+++ b/examples/readfile.c
@@ -39,27 +39,33 @@ int main(int argc, char * argv[])
 	if (result.error.code != CBOR_ERR_NONE) {
 		printf("There was an error while reading the input near byte %zu (read %zu bytes in total): ", result.error.position, result.read);
 		switch (result.error.code) {
-			case CBOR_ERR_MALFORMATED: {
+			case CBOR_ERR_MALFORMATED:
+			{
 				printf("Malformed data\n");
 				break;
 			}
-			case CBOR_ERR_MEMERROR: {
+			case CBOR_ERR_MEMERROR:
+			{
 				printf("Memory error -- perhaps the input is too large?\n");
 				break;
 			}
-			case CBOR_ERR_NODATA: {
+			case CBOR_ERR_NODATA:
+			{
 				printf("The input is empty\n");
 				break;
 			}
-			case CBOR_ERR_NOTENOUGHDATA: {
+			case CBOR_ERR_NOTENOUGHDATA:
+			{
 				printf("Data seem to be missing -- is the input complete?\n");
 				break;
 			}
-			case CBOR_ERR_SYNTAXERROR: {
+			case CBOR_ERR_SYNTAXERROR:
+			{
 				printf("Syntactically malformed data -- see http://tools.ietf.org/html/rfc7049\n");
 				break;
 			}
-			case CBOR_ERR_NONE: {
+			case CBOR_ERR_NONE:
+			{
 				// GCC's cheap dataflow analysis gag
 				break;
 			}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SOURCES cbor.c cbor/streaming.c cbor/internal/encoders.c cbor/internal/builder_callbacks.c cbor/internal/loaders.c cbor/internal/stack.c cbor/internal/unicode.c cbor/encoding.c cbor/serialization.c cbor/arrays.c cbor/common.c cbor/floats_ctrls.c cbor/bytestrings.c cbor/callbacks.c cbor/strings.c cbor/maps.c cbor/tags.c cbor/ints.c)
+set(SOURCES cbor.c cbor/streaming.c cbor/internal/encoders.c cbor/internal/builder_callbacks.c cbor/internal/loaders.c cbor/internal/memory_utils.c cbor/internal/stack.c cbor/internal/unicode.c cbor/encoding.c cbor/serialization.c cbor/arrays.c cbor/common.c cbor/floats_ctrls.c cbor/bytestrings.c cbor/callbacks.c cbor/strings.c cbor/maps.c cbor/tags.c cbor/ints.c)
 
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 

--- a/src/cbor/arrays.c
+++ b/src/cbor/arrays.c
@@ -56,8 +56,9 @@ bool cbor_array_push(cbor_item_t *array, cbor_item_t *pushee)
 	cbor_item_t **data = (cbor_item_t **) array->data;
 	if (cbor_array_is_definite(array)) {
 		/* Do not reallocate definite arrays */
-		if (metadata->end_ptr >= metadata->allocated)
+		if (metadata->end_ptr >= metadata->allocated) {
 			return false;
+		}
 		data[metadata->end_ptr++] = pushee;
 	} else {
 		/* Exponential realloc */
@@ -67,12 +68,12 @@ bool cbor_array_push(cbor_item_t *array, cbor_item_t *pushee)
 				return false;
 			}
 
-			size_t new_allocation = CBOR_BUFFER_GROWTH * (metadata->allocated);
-			new_allocation = new_allocation ? new_allocation : 1;
+			size_t new_allocation = metadata->allocated == 0 ? 1 : CBOR_BUFFER_GROWTH * metadata->allocated;
 
 			unsigned char * new_data = _cbor_realloc_multiple(array->data, sizeof(cbor_item_t *), new_allocation);
-			if (new_data == NULL)
+			if (new_data == NULL) {
 				return false;
+			}
 
 			array->data = new_data;
 			metadata->allocated = new_allocation;

--- a/src/cbor/arrays.c
+++ b/src/cbor/arrays.c
@@ -7,6 +7,7 @@
 
 #include <string.h>
 #include "arrays.h"
+#include "internal/memory_utils.h"
 
 size_t cbor_array_size(const cbor_item_t *item)
 {
@@ -98,10 +99,11 @@ cbor_item_t **cbor_array_handle(const cbor_item_t *item)
 cbor_item_t *cbor_new_definite_array(size_t size)
 {
 	cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
-	if (item == NULL)
+	if (item == NULL) {
 		return NULL;
+	}
 
-	cbor_item_t ** data = _CBOR_MALLOC(sizeof(cbor_item_t *) * size);
+	cbor_item_t ** data = _cbor_alloc_multiple(sizeof(cbor_item_t *), size);
 	if (data == NULL) {
 		_CBOR_FREE(item);
 		return NULL;

--- a/src/cbor/internal/memory_utils.c
+++ b/src/cbor/internal/memory_utils.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2016 Pavel Kalvoda <me@pavelkalvoda.com>
+ *
+ * libcbor is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include "memory_utils.h"
+#include "cbor/common.h"
+#include <stdbool.h>
+
+// TODO: Consider builtins (https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html)
+
+/** Highest on bit position */
+size_t _cbor_highest_bit(size_t number) {
+	size_t bit = 0;
+	while (number != 0) {
+		bit++;
+		number >>= 1;
+	}
+
+	return bit;
+}
+
+bool _cbor_safe_to_multiply(size_t a, size_t b) {
+	return _cbor_highest_bit(a) + _cbor_highest_bit(b) <= sizeof(size_t);
+}
+
+void * _cbor_alloc_multiple(size_t item_size, size_t item_count) {
+	if (_cbor_safe_to_multiply(item_size, item_count)) {
+		return _CBOR_MALLOC(item_size * item_count);
+	} else {
+		return NULL;
+	}
+}

--- a/src/cbor/internal/memory_utils.c
+++ b/src/cbor/internal/memory_utils.c
@@ -24,7 +24,7 @@ size_t _cbor_highest_bit(size_t number)
 
 bool _cbor_safe_to_multiply(size_t a, size_t b)
 {
-	return _cbor_highest_bit(a) + _cbor_highest_bit(b) <= sizeof(size_t);
+	return _cbor_highest_bit(a) + _cbor_highest_bit(b) <= sizeof(size_t) * 8;
 }
 
 void * _cbor_alloc_multiple(size_t item_size, size_t item_count)

--- a/src/cbor/internal/memory_utils.c
+++ b/src/cbor/internal/memory_utils.c
@@ -7,7 +7,6 @@
 
 #include "memory_utils.h"
 #include "cbor/common.h"
-#include <stdbool.h>
 
 // TODO: Consider builtins (https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html)
 
@@ -39,5 +38,9 @@ void * _cbor_alloc_multiple(size_t item_size, size_t item_count)
 
 void * _cbor_realloc_multiple(void * pointer, size_t item_size, size_t item_count)
 {
-
+	if (_cbor_safe_to_multiply(item_size, item_count)) {
+		return _CBOR_REALLOC(pointer, item_size * item_count);
+	} else {
+		return NULL;
+	}
 }

--- a/src/cbor/internal/memory_utils.c
+++ b/src/cbor/internal/memory_utils.c
@@ -12,7 +12,8 @@
 // TODO: Consider builtins (https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html)
 
 /** Highest on bit position */
-size_t _cbor_highest_bit(size_t number) {
+size_t _cbor_highest_bit(size_t number)
+{
 	size_t bit = 0;
 	while (number != 0) {
 		bit++;
@@ -22,14 +23,21 @@ size_t _cbor_highest_bit(size_t number) {
 	return bit;
 }
 
-bool _cbor_safe_to_multiply(size_t a, size_t b) {
+bool _cbor_safe_to_multiply(size_t a, size_t b)
+{
 	return _cbor_highest_bit(a) + _cbor_highest_bit(b) <= sizeof(size_t);
 }
 
-void * _cbor_alloc_multiple(size_t item_size, size_t item_count) {
+void * _cbor_alloc_multiple(size_t item_size, size_t item_count)
+{
 	if (_cbor_safe_to_multiply(item_size, item_count)) {
 		return _CBOR_MALLOC(item_size * item_count);
 	} else {
 		return NULL;
 	}
+}
+
+void * _cbor_realloc_multiple(void * pointer, size_t item_size, size_t item_count)
+{
+
 }

--- a/src/cbor/internal/memory_utils.h
+++ b/src/cbor/internal/memory_utils.h
@@ -18,4 +18,14 @@
  */
 void * _cbor_alloc_multiple(size_t item_size, size_t item_count);
 
+
+/** Overflow-proof contiguous array reallocation
+ *
+ * @param pointer
+ * @param item_size
+ * @param item_count
+ * @return Realloc'd of item_size * item_count bytes, or NULL if the total size overflows size_t or the underlying allocator failed
+ */
+void * _cbor_realloc_multiple(void * pointer, size_t item_size, size_t item_count);
+
 #endif //LIBCBOR_MEMORY_UTILS_H

--- a/src/cbor/internal/memory_utils.h
+++ b/src/cbor/internal/memory_utils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2014-2016 Pavel Kalvoda <me@pavelkalvoda.com>
+ *
+ * libcbor is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#ifndef LIBCBOR_MEMORY_UTILS_H
+#define LIBCBOR_MEMORY_UTILS_H
+
+#include <string.h>
+
+/** Overflow-proof contiguous array allocation
+ *
+ * @param item_size
+ * @param item_count
+ * @return Region of item_size * item_count bytes, or NULL if the total size overflows size_t or the underlying allocator failed
+ */
+void * _cbor_alloc_multiple(size_t item_size, size_t item_count);
+
+#endif //LIBCBOR_MEMORY_UTILS_H

--- a/src/cbor/internal/memory_utils.h
+++ b/src/cbor/internal/memory_utils.h
@@ -9,6 +9,10 @@
 #define LIBCBOR_MEMORY_UTILS_H
 
 #include <string.h>
+#include <stdbool.h>
+
+/** Can a and b be multiplied without overflowing size_t? */
+bool _cbor_safe_to_multiply(size_t a, size_t b);
 
 /** Overflow-proof contiguous array allocation
  *
@@ -20,6 +24,8 @@ void * _cbor_alloc_multiple(size_t item_size, size_t item_count);
 
 
 /** Overflow-proof contiguous array reallocation
+ *
+ * This implements the OpenBSD `reallocarray` functionality.
  *
  * @param pointer
  * @param item_size

--- a/src/cbor/maps.c
+++ b/src/cbor/maps.c
@@ -6,6 +6,7 @@
  */
 
 #include "maps.h"
+#include "internal/memory_utils.h"
 
 size_t cbor_map_size(const cbor_item_t *item)
 {
@@ -32,7 +33,7 @@ cbor_item_t *cbor_new_definite_map(size_t size)
 			.type = _CBOR_METADATA_DEFINITE,
 			.end_ptr = 0
 		}},
-		.data = _CBOR_MALLOC(sizeof(struct cbor_pair) * size)
+		.data = _cbor_alloc_multiple(sizeof(struct cbor_pair), size)
 	};
 	if (item->data == NULL) {
 		_CBOR_FREE(item);

--- a/src/cbor/maps.c
+++ b/src/cbor/maps.c
@@ -23,8 +23,9 @@ size_t cbor_map_allocated(const cbor_item_t *item)
 cbor_item_t *cbor_new_definite_map(size_t size)
 {
 	cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
-	if (item == NULL)
+	if (item == NULL) {
 		return NULL;
+	}
 	*item = (cbor_item_t) {
 		.refcount = 1,
 		.type = CBOR_TYPE_MAP,
@@ -83,8 +84,7 @@ bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key)
 				return false;
 			}
 
-			size_t new_allocation = CBOR_BUFFER_GROWTH * (metadata->allocated);
-			new_allocation = new_allocation ? new_allocation : 1;
+			size_t new_allocation = metadata->allocated == 0 ? 1 : CBOR_BUFFER_GROWTH * metadata->allocated;
 
 			unsigned char * new_data = _cbor_realloc_multiple(item->data, sizeof(struct cbor_pair), new_allocation);
 

--- a/src/cbor/strings.c
+++ b/src/cbor/strings.c
@@ -7,6 +7,7 @@
 
 #include <string.h>
 #include "strings.h"
+#include "internal/memory_utils.h"
 
 cbor_item_t *cbor_new_definite_string()
 {
@@ -85,13 +86,18 @@ bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk)
 	struct cbor_indefinite_string_data *data = (struct cbor_indefinite_string_data *) item->data;
 	if (data->chunk_count == data->chunk_capacity) {
 		/* We need more space */
-		data->chunk_capacity = data->chunk_capacity == 0 ? 1 : (size_t)(CBOR_BUFFER_GROWTH * (data->chunk_capacity));
-		cbor_item_t **new_chunks_data =
-			_CBOR_REALLOC(data->chunks, data->chunk_capacity * sizeof(cbor_item_t *));
-		if (new_chunks_data == NULL)
+		if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
 			return false;
-		else
-			data->chunks = new_chunks_data;
+		}
+
+		data->chunk_capacity = data->chunk_capacity == 0 ? 1 : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
+		cbor_item_t **new_chunks_data = _cbor_realloc_multiple(data->chunks, sizeof(cbor_item_t *), data->chunk_capacity);
+
+		if (new_chunks_data == NULL) {
+			return false;
+		}
+
+		data->chunks = new_chunks_data;
 	}
 	data->chunks[data->chunk_count++] = cbor_incref(chunk);
 	return true;

--- a/test/bad_inputs_test.c
+++ b/test/bad_inputs_test.c
@@ -78,6 +78,15 @@ static void test_6(void **state)
 	assert_int_equal(res.error.position, 2);
 }
 
+/* Extremely high size value (overflows size_t in representation size) */
+unsigned char data7[] = {0xA2, 0x9B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+static void test_7(void **state)
+{
+	item = cbor_load(data7, 16, &res);
+	assert_null(item);
+	assert_true(res.error.code == CBOR_ERR_MEMERROR);
+	assert_int_equal(res.error.position, 10);
+}
 
 
 int main(void)
@@ -90,7 +99,8 @@ int main(void)
 		unit_test(test_4),
 		unit_test(test_5),
 #endif
-		unit_test(test_6)
+		unit_test(test_6),
+		unit_test(test_7),
 	};
 	return run_tests(tests);
 }


### PR DESCRIPTION
Fixes problems revealed by #16, where big enough size header could would overflow `size_t` when multiplied by the size of in-memory representation of subitems.

This is a major attack vector that allows an attacker to crash any existing libcbor client application.