### PR TITLE
Fixed allocation of zero size definite map and array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 2.8)
 project(libcbor)
 include(CTest)
 


### PR DESCRIPTION
`libcbor` crashes when a definite map or array is of size zero (because of `malloc(0)`).