### PR TITLE
CMakeLists.txt: Reduce required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 2.8)
 project(libcbor)
 include(CTest)
 


### PR DESCRIPTION
The current `CMakeLists.txt` require version 3.2 while 2.8 is enough.  
This change is required to build `libcbor` on Ubuntu 14.02 LTS.