### PR TITLE
Add assert on decref

### DIFF
--- a/src/cbor/common.c
+++ b/src/cbor/common.c
@@ -99,6 +99,7 @@ cbor_item_t * cbor_incref(cbor_item_t *item)
 void cbor_decref(cbor_item_t **item_ref)
 {
 	cbor_item_t * item = *item_ref;
+	assert(item->refcount > 0);
 	if (--item->refcount == 0) {
 		switch (item->type) {
 		case CBOR_TYPE_UINT:


### PR DESCRIPTION
If you made decref your object when refcount is "0" you need to incref it two times and decref to deallocate. Otherwise, it will leak. For me, this kind of behavior was unexpected