### PR TITLE
CBOR_DECODER_NEDATA: return required bytes

### DIFF
--- a/src/cbor/data.h
+++ b/src/cbor/data.h
@@ -203,6 +203,9 @@ struct cbor_decoder_result {
 	size_t                   read;
 	/** The result */
 	enum cbor_decoder_status status;
+	/** When status == CBOR_DECODER_NEDATA,
+	 *  the minimum number of bytes required to continue parsing */
+	size_t                   required;
 };
 
 #ifdef __cplusplus

--- a/src/cbor/streaming.c
+++ b/src/cbor/streaming.c
@@ -15,9 +15,11 @@ bool static _cbor_claim_bytes(size_t required,
 		/* We need to keep all the metadata if parsing is to be resumed */
 		result->read = 0;
 		result->status = CBOR_DECODER_NEDATA;
+		result->required = required;
 		return false;
 	} else {
 		result->read += required;
+		result->required = 0;
 		return true;
 	}
 }

--- a/test/assertions.c
+++ b/test/assertions.c
@@ -39,4 +39,12 @@ void assert_decoder_result(size_t read, enum cbor_decoder_status status, struct 
 {
 	assert_true(read == result.read);
 	assert_true(status == result.status);
+	assert_true(0 == result.required);
+}
+
+void assert_decoder_result_nedata(size_t required, struct cbor_decoder_result result)
+{
+	assert_true(0 == result.read);
+	assert_true(CBOR_DECODER_NEDATA == result.status);
+	assert_int_equal((int)required, (int)result.required);
 }

--- a/test/assertions.h
+++ b/test/assertions.h
@@ -12,5 +12,6 @@ void assert_uint32(cbor_item_t * item, uint32_t num);
 void assert_uint64(cbor_item_t * item, uint64_t num);
 
 void assert_decoder_result(size_t, enum cbor_decoder_status, struct cbor_decoder_result);
+void assert_decoder_result_nedata(size_t, struct cbor_decoder_result);
 
 #endif

--- a/test/cbor_stream_decode_test.c
+++ b/test/cbor_stream_decode_test.c
@@ -509,6 +509,33 @@ static void test_indef_map_decoding_1(void **state)
 	);
 }
 
+unsigned char map_nedata[] = { 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x19, 0x01, 0xf4, 0x01 };
+static void test_nedata_map_decoding(void **state)
+{
+	assert_decoder_result_nedata(8,
+		decode(map_nedata, 1)
+	);
+
+	assert_map_start(1);
+	assert_decoder_result(9, CBOR_DECODER_FINISHED,
+		decode(map_nedata, 9)
+	);
+
+	assert_decoder_result_nedata(2,
+		decode(map_nedata + 9, 1)
+	);
+
+	assert_uint16_eq(500);
+	assert_decoder_result(3, CBOR_DECODER_FINISHED,
+		decode(map_nedata + 9, 3)
+	);
+
+	assert_uint8_eq(1);
+	assert_decoder_result(1, CBOR_DECODER_FINISHED,
+		decode(map_nedata + 12, 1)
+	);
+}
+
 unsigned char embedded_tag_data[] = { 0xC1 };
 static void test_embedded_tag_decoding(void **state)
 {
@@ -668,6 +695,7 @@ int main(void)
 		cmocka_unit_test(test_map_int32_decoding),
 		cmocka_unit_test(test_map_int64_decoding),
 		cmocka_unit_test(test_indef_map_decoding_1),
+		cmocka_unit_test(test_nedata_map_decoding),
 
 		cmocka_unit_test(test_embedded_tag_decoding),
 		cmocka_unit_test(test_int8_tag_decoding),


### PR DESCRIPTION
This PR adds the minimum number of bytes required by cbor_stream_decode to continue parsing when that function returns CBOR_DECODER_NEDATA as the status in the cbor_decoder_result.

This is useful when using a byte stream transport such as a raw TCP socket or UNIX pipe and blocking I/O.

I'm not sure if this is the best way to expose this information in the API, but it seemed to do the trick. 