### PR TITLE
Do not build two shared libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT DEFINED CMAKE_MACOSX_RPATH)
 	set(CMAKE_MACOSX_RPATH 0)
 endif()
 
-add_library(cbor ${SOURCES})
+add_library(cbor STATIC ${SOURCES})
 add_library(cbor_shared SHARED ${SOURCES})
 
 set_target_properties(cbor_shared PROPERTIES OUTPUT_NAME cbor VERSION ${CBOR_VERSION})
@@ -20,7 +20,7 @@ configure_file(libcbor.pc.in libcbor.pc @ONLY)
 
 #http://www.cmake.org/Wiki/CMake:Install_Commands
 
-install(TARGETS cbor  cbor_shared
+install(TARGETS cbor_shared
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	RUNTIME DESTINATION bin)


### PR DESCRIPTION
Without this patch, when building with `make -j1`
cmake would create and install two shared libraries
`libcbor.so` and `libcbor.so.0.0.0`
instead of creating `libcbor.so` as a symlink.
This broke verification of reproducible builds.

See https://reproducible-builds.org/ for why this matters.

Also, (like before) do not install libcbor.a
because static linking is bad for maintainability
(because all programs have to be re-built with fixed libraries)

This PR was done while working on reproducible builds for openSUSE.