### PR TITLE
Do not read from unallocated memory

### DIFF
--- a/examples/streaming_parser.c
+++ b/examples/streaming_parser.c
@@ -28,11 +28,12 @@ bool key_found = false;
 void find_string(void * _ctx, cbor_data buffer, size_t len)
 {
 	if (key_found) {
-		char *tmp = strndup(buffer, len);
+		char *tmp = calloc(1, len + 1);
 		if (!tmp) {
-			fprintf(stderr, "strndup failed\n");
+			fprintf(stderr, "calloc failed\n");
 			exit(1);
 		}
+		memcpy(tmp, buffer, len);
 		printf("Found the value: %s\n", tmp);
 		free(tmp);
 		key_found = false;

--- a/examples/streaming_parser.c
+++ b/examples/streaming_parser.c
@@ -28,7 +28,13 @@ bool key_found = false;
 void find_string(void * _ctx, cbor_data buffer, size_t len)
 {
 	if (key_found) {
-		printf("Found the value: %*s\n", (int) len, buffer);
+		char *tmp = strndup(buffer, len);
+		if (!tmp) {
+			fprintf(stderr, "strndup failed\n");
+			exit(1);
+		}
+		printf("Found the value: %s\n", tmp);
+		free(tmp);
 		key_found = false;
 	} else if (len == strlen(key)) {
 		key_found = (memcmp(key, buffer, len) == 0);


### PR DESCRIPTION
Basically, the width specifier in the format string caused printf to
read outside the buffer.

Fix by using strndup so we get a guaranteed null terminated buffer.

Fixes issue #67