### PR TITLE
Fix possible memory corruption bug on repeated cbor_(byte)string_add_chunk calls with intermittently failing realloc calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Next
     when memory allocation fails
   - It is up to the client to handle such cases
 - Globally enforced code style [#83]
+- Fix issue possible memory corruption bug on repeated 
+  cbor_(byte)string_add_chunk calls with intermittently failing realloc calls
 
 0.5.0 (2017-02-06)
 ---------------------

--- a/misc/hooks/pre-commit
+++ b/misc/hooks/pre-commit
@@ -15,8 +15,11 @@ cd ..
 
 # Run clang-format and add modified files
 MODIFIED_UNSTAGED=$(git -C . diff --name-only)
+MODIFIED_STAGED=$(git -C . diff --name-only --cached)
 
 ./clang-format.sh
+
+git add ${MODIFIED_STAGED}
 
 if [[ ${MODIFIED_UNSTAGED} != $(git -C . diff --name-only) ]]; then
   echo "WARNING: Non-staged files were reformatted. Please review and/or add" \

--- a/src/cbor/arrays.c
+++ b/src/cbor/arrays.c
@@ -59,6 +59,7 @@ bool cbor_array_push(cbor_item_t *array, cbor_item_t *pushee) {
     /* Exponential realloc */
     if (metadata->end_ptr >= metadata->allocated) {
       // Check for overflows first
+      // TODO: Explicitly test this
       if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, metadata->allocated)) {
         return false;
       }

--- a/src/cbor/bytestrings.c
+++ b/src/cbor/bytestrings.c
@@ -93,12 +93,14 @@ bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
   assert(cbor_bytestring_is_indefinite(item));
   struct cbor_indefinite_string_data *data =
       (struct cbor_indefinite_string_data *)item->data;
+  printf("growin!\n");
   if (data->chunk_count == data->chunk_capacity) {
     /* We need more space */
     if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
       return false;
     }
 
+    printf("growin!\n");
     data->chunk_capacity = data->chunk_capacity == 0
                                ? 1
                                : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
@@ -107,6 +109,7 @@ bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
         data->chunks, sizeof(cbor_item_t *), data->chunk_capacity);
 
     if (new_chunks_data == NULL) {
+      printf("fail!\n");
       return false;
     }
 

--- a/src/cbor/bytestrings.c
+++ b/src/cbor/bytestrings.c
@@ -95,17 +95,17 @@ bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
       (struct cbor_indefinite_string_data *)item->data;
   if (data->chunk_count == data->chunk_capacity) {
     /* We need more space */
-    data->chunk_capacity = data->chunk_capacity == 0
-                               ? 1
-                               : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
+    size_t new_chunk_capacity =
+        data->chunk_capacity == 0 ? 1
+                                  : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
 
     cbor_item_t **new_chunks_data = _cbor_realloc_multiple(
-        data->chunks, sizeof(cbor_item_t *), data->chunk_capacity);
+        data->chunks, sizeof(cbor_item_t *), new_chunk_capacity);
 
     if (new_chunks_data == NULL) {
       return false;
     }
-
+    data->chunk_capacity = new_chunk_capacity;
     data->chunks = new_chunks_data;
   }
   data->chunks[data->chunk_count++] = cbor_incref(chunk);

--- a/src/cbor/bytestrings.c
+++ b/src/cbor/bytestrings.c
@@ -93,14 +93,8 @@ bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
   assert(cbor_bytestring_is_indefinite(item));
   struct cbor_indefinite_string_data *data =
       (struct cbor_indefinite_string_data *)item->data;
-  printf("growin!\n");
   if (data->chunk_count == data->chunk_capacity) {
     /* We need more space */
-    if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
-      return false;
-    }
-
-    printf("growin!\n");
     data->chunk_capacity = data->chunk_capacity == 0
                                ? 1
                                : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
@@ -109,7 +103,6 @@ bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
         data->chunks, sizeof(cbor_item_t *), data->chunk_capacity);
 
     if (new_chunks_data == NULL) {
-      printf("fail!\n");
       return false;
     }
 

--- a/src/cbor/bytestrings.c
+++ b/src/cbor/bytestrings.c
@@ -94,7 +94,11 @@ bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
   struct cbor_indefinite_string_data *data =
       (struct cbor_indefinite_string_data *)item->data;
   if (data->chunk_count == data->chunk_capacity) {
-    /* We need more space */
+    // TODO: Add a test for this
+    if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
+      return false;
+    }
+
     size_t new_chunk_capacity =
         data->chunk_capacity == 0 ? 1
                                   : CBOR_BUFFER_GROWTH * (data->chunk_capacity);

--- a/src/cbor/maps.c
+++ b/src/cbor/maps.c
@@ -66,6 +66,7 @@ bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key) {
     if (metadata->end_ptr >= metadata->allocated) {
       /* Exponential realloc */
       // Check for overflows first
+      // TODO: Explicitly test this
       if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, metadata->allocated)) {
         return false;
       }

--- a/src/cbor/strings.c
+++ b/src/cbor/strings.c
@@ -86,6 +86,11 @@ bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
   struct cbor_indefinite_string_data *data =
       (struct cbor_indefinite_string_data *)item->data;
   if (data->chunk_count == data->chunk_capacity) {
+    // TODO: Add a test for this
+    if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
+      return false;
+    }
+
     size_t new_chunk_capacity = data->chunk_capacity == 0
                                ? 1
                                : CBOR_BUFFER_GROWTH * (data->chunk_capacity);

--- a/src/cbor/strings.c
+++ b/src/cbor/strings.c
@@ -95,7 +95,7 @@ bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
                                ? 1
                                : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
     cbor_item_t **new_chunks_data = _cbor_realloc_multiple(
-        data->chunks, sizeof(cbor_item_t *), data->chunk_capacity);
+        data->chunks, sizeof(cbor_item_t *), new_chunk_capacity);
 
     if (new_chunks_data == NULL) {
       return false;

--- a/src/cbor/strings.c
+++ b/src/cbor/strings.c
@@ -86,12 +86,7 @@ bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
   struct cbor_indefinite_string_data *data =
       (struct cbor_indefinite_string_data *)item->data;
   if (data->chunk_count == data->chunk_capacity) {
-    /* We need more space */
-    if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
-      return false;
-    }
-
-    data->chunk_capacity = data->chunk_capacity == 0
+    size_t new_chunk_capacity = data->chunk_capacity == 0
                                ? 1
                                : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
     cbor_item_t **new_chunks_data = _cbor_realloc_multiple(
@@ -101,6 +96,7 @@ bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
       return false;
     }
 
+    data->chunk_capacity = new_chunk_capacity;
     data->chunks = new_chunks_data;
   }
   data->chunks[data->chunk_count++] = cbor_incref(chunk);

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -146,7 +146,7 @@ static void test_serialize_indefinite_string(void **state) {
   strncpy((char *)data, "Hello world!", 12);
   cbor_string_set_handle(chunk, data, 12);
 
-  cbor_string_add_chunk(item, cbor_move(chunk));
+  assert_true(cbor_string_add_chunk(item, cbor_move(chunk)));
   assert_int_equal(cbor_string_chunk_count(item), 1);
 
   assert_int_equal(15, cbor_serialize(item, buffer, 512));

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -188,6 +188,11 @@ static void test_bytestring_add_chunk(void **state) {
         cbor_item_t *chunk = cbor_build_bytestring(bytes, 4);
 
         assert_false(cbor_bytestring_add_chunk(bytestring, chunk));
+        assert_int_equal(cbor_bytestring_length(bytestring), 0);
+        assert_int_equal(
+            ((struct cbor_indefinite_string_data *)bytestring->data)
+                ->chunk_capacity,
+            0);
       },
       5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -224,7 +224,7 @@ static void test_array_push(void **state) {
         cbor_item_t *array = cbor_new_indefinite_array();
         cbor_item_t *string = cbor_build_string("Hello!");
 
-        assert_false(cbor_array_push(array, cbor_move(string)));
+        assert_false(cbor_array_push(array, string));
         assert_int_equal(cbor_array_allocated(array), 0);
         assert_null(array->data);
         assert_int_equal(array->metadata.array_metadata.end_ptr, 0);
@@ -233,6 +233,27 @@ static void test_array_push(void **state) {
         cbor_decref(&array);
       },
       4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
+}
+
+static void test_map_add(void **state) {
+  WITH_MOCK_MALLOC(
+          {
+            cbor_item_t *map = cbor_new_indefinite_map();
+            cbor_item_t *key = cbor_build_uint8(0);
+            cbor_item_t *value = cbor_build_bool(true);
+
+            assert_false(cbor_map_add(map, (struct cbor_pair) {
+                    .key = key,
+                    .value = value
+            }));
+            assert_int_equal(cbor_map_allocated(map), 0);
+            assert_null(map->data);
+
+            cbor_decref(&map);
+            cbor_decref(&key);
+            cbor_decref(&value);
+          },
+          4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
 int main(void) {
@@ -252,6 +273,7 @@ int main(void) {
       cmocka_unit_test(test_bytestring_add_chunk),
       cmocka_unit_test(test_string_add_chunk),
       cmocka_unit_test(test_array_push),
+      cmocka_unit_test(test_map_add),
   };
 #else
   // Can't do anything without a custom allocator

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -202,21 +202,20 @@ static void test_bytestring_add_chunk(void **state) {
 
 static void test_string_add_chunk(void **state) {
   WITH_MOCK_MALLOC(
-          {
-            cbor_item_t *string = cbor_new_indefinite_string();
-            cbor_item_t *chunk = cbor_build_string("Hello!");
+      {
+        cbor_item_t *string = cbor_new_indefinite_string();
+        cbor_item_t *chunk = cbor_build_string("Hello!");
 
-            assert_false(cbor_string_add_chunk(string, chunk));
-            assert_int_equal(cbor_string_length(string), 0);
-            assert_int_equal(
-                    ((struct cbor_indefinite_string_data *)string->data)
-                            ->chunk_capacity,
-                    0);
+        assert_false(cbor_string_add_chunk(string, chunk));
+        assert_int_equal(cbor_string_length(string), 0);
+        assert_int_equal(((struct cbor_indefinite_string_data *)string->data)
+                             ->chunk_capacity,
+                         0);
 
-            cbor_decref(&chunk);
-            cbor_decref(&string);
-          },
-          5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
+        cbor_decref(&chunk);
+        cbor_decref(&string);
+      },
+      5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
 int main(void) {

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -188,7 +188,7 @@ static void test_bytestring_add_chunk(void **state) {
         cbor_item_t *chunk = cbor_build_bytestring(bytes, 4);
 
         assert_false(cbor_bytestring_add_chunk(bytestring, chunk));
-        assert_int_equal(cbor_bytestring_length(bytestring), 0);
+        assert_int_equal(cbor_bytestring_chunk_count(bytestring), 0);
         assert_int_equal(
             ((struct cbor_indefinite_string_data *)bytestring->data)
                 ->chunk_capacity,
@@ -207,7 +207,7 @@ static void test_string_add_chunk(void **state) {
         cbor_item_t *chunk = cbor_build_string("Hello!");
 
         assert_false(cbor_string_add_chunk(string, chunk));
-        assert_int_equal(cbor_string_length(string), 0);
+        assert_int_equal(cbor_string_chunk_count(string), 0);
         assert_int_equal(((struct cbor_indefinite_string_data *)string->data)
                              ->chunk_capacity,
                          0);

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -229,6 +229,7 @@ static void test_array_push(void **state) {
         assert_null(array->data);
         assert_int_equal(array->metadata.array_metadata.end_ptr, 0);
 
+        cbor_decref(&string);
         cbor_decref(&array);
       },
       4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -237,23 +237,21 @@ static void test_array_push(void **state) {
 
 static void test_map_add(void **state) {
   WITH_MOCK_MALLOC(
-          {
-            cbor_item_t *map = cbor_new_indefinite_map();
-            cbor_item_t *key = cbor_build_uint8(0);
-            cbor_item_t *value = cbor_build_bool(true);
+      {
+        cbor_item_t *map = cbor_new_indefinite_map();
+        cbor_item_t *key = cbor_build_uint8(0);
+        cbor_item_t *value = cbor_build_bool(true);
 
-            assert_false(cbor_map_add(map, (struct cbor_pair) {
-                    .key = key,
-                    .value = value
-            }));
-            assert_int_equal(cbor_map_allocated(map), 0);
-            assert_null(map->data);
+        assert_false(
+            cbor_map_add(map, (struct cbor_pair){.key = key, .value = value}));
+        assert_int_equal(cbor_map_allocated(map), 0);
+        assert_null(map->data);
 
-            cbor_decref(&map);
-            cbor_decref(&key);
-            cbor_decref(&value);
-          },
-          4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
+        cbor_decref(&map);
+        cbor_decref(&key);
+        cbor_decref(&value);
+      },
+      4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
 int main(void) {

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -220,17 +220,18 @@ static void test_string_add_chunk(void **state) {
 
 static void test_array_push(void **state) {
   WITH_MOCK_MALLOC(
-          {
-            cbor_item_t *array = cbor_new_indefinite_array();
-            cbor_item_t *string = cbor_build_string("Hello!");
+      {
+        cbor_item_t *array = cbor_new_indefinite_array();
+        cbor_item_t *string = cbor_build_string("Hello!");
 
-            assert_false(cbor_array_push(array, cbor_move(string)));
-            assert_int_equal(cbor_array_allocated(array), 0);
-            assert_null(array->data);
-            assert_int_equal(array->metadata.array_metadata.end_ptr, 0);
+        assert_false(cbor_array_push(array, cbor_move(string)));
+        assert_int_equal(cbor_array_allocated(array), 0);
+        assert_null(array->data);
+        assert_int_equal(array->metadata.array_metadata.end_ptr, 0);
 
-            cbor_decref(&array);
-          }, 4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
+        cbor_decref(&array);
+      },
+      4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
 int main(void) {

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -119,8 +119,8 @@ static void test_bytestring_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_bytestring()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); }, 2, MALLOC,
-                   MALLOC_FAIL);
+  WITH_MOCK_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); }, 2,
+                   MALLOC, MALLOC_FAIL);
 
   unsigned char bytes[] = {0, 0, 0xFF, 0xAB};
 
@@ -137,22 +137,26 @@ static void test_string_creation(void **state) {
                    MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_string("Test")); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_build_string("Test")); }, 2, MALLOC, MALLOC_FAIL);
+  WITH_MOCK_MALLOC({ assert_null(cbor_build_string("Test")); }, 2, MALLOC,
+                   MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_stringn("Test", 4)); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_build_stringn("Test", 4)); }, 2, MALLOC, MALLOC_FAIL);
+  WITH_MOCK_MALLOC({ assert_null(cbor_build_stringn("Test", 4)); }, 2, MALLOC,
+                   MALLOC_FAIL);
 }
 
 static void test_array_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_array(42)); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_array(42)); }, 2, MALLOC, MALLOC_FAIL);
+  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_array(42)); }, 2, MALLOC,
+                   MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_array()); });
 }
 
 static void test_map_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_map(42)); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_map(42)); }, 2, MALLOC, MALLOC_FAIL);
+  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_map(42)); }, 2, MALLOC,
+                   MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_map()); });
 }
@@ -185,7 +189,7 @@ static void test_bytestring_add_chunk(void **state) {
 
         assert_false(cbor_bytestring_add_chunk(bytestring, chunk));
       },
-      3, true, true, false);
+      5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
 int main(void) {

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -19,41 +19,74 @@
 //
 // WARNING: The test only works with CBOR_CUSTOM_ALLOC
 
-// How many malloc calls we expect
-int malloc_calls_expected;
-// How many malloc calls we got
-int malloc_calls;
+typedef enum call_expectation {
+  MALLOC,
+  MALLOC_FAIL,
+  REALLOC,
+  REALLOC_FAIL
+} call_expectation;
+
+// How many alloc calls we expect
+int alloc_calls_expected;
+// How many alloc calls we got
+int alloc_calls;
 // Array of booleans indicating whether to return a block or fail with NULL
-bool *should_succeed;
+call_expectation *expectations;
 
 void set_mock_malloc(int calls, ...) {
   va_list args;
   va_start(args, calls);
-  malloc_calls_expected = calls;
-  malloc_calls = 0;
-  should_succeed = malloc(calls * sizeof(bool));
+  alloc_calls_expected = calls;
+  alloc_calls = 0;
+  expectations = calloc(calls, sizeof(expectations));
   for (int i = 0; i < calls; i++) {
     // Promotable types, baby
-    should_succeed[i] = (bool)va_arg(args, int);
+    expectations[i] = va_arg(args, call_expectation);
   }
   va_end(args);
 }
 
 void finalize_mock_malloc() {
-  assert_int_equal(malloc_calls, malloc_calls_expected);
-  free(should_succeed);
+  assert_int_equal(alloc_calls, alloc_calls_expected);
+  free(expectations);
 }
 
 void *instrumented_malloc(size_t size) {
-  if (malloc_calls >= malloc_calls_expected) {
-    // We failed to properly mock a call
-    fail();
+  if (alloc_calls >= alloc_calls_expected) {
+    goto error;
   }
-  if (should_succeed[malloc_calls++]) {
+
+  if (expectations[alloc_calls] == MALLOC) {
+    alloc_calls++;
     return malloc(size);
-  } else {
+  } else if (expectations[alloc_calls] == MALLOC_FAIL) {
+    alloc_calls++;
     return NULL;
   }
+
+error:
+  print_error("Unexpected call to malloc");
+  fail();
+  return NULL;
+}
+
+void *instrumented_realloc(void *ptr, size_t size) {
+  if (alloc_calls >= alloc_calls_expected) {
+    goto error;
+  }
+
+  if (expectations[alloc_calls] == REALLOC) {
+    alloc_calls++;
+    return realloc(ptr, size);
+  } else if (expectations[alloc_calls] == REALLOC_FAIL) {
+    alloc_calls++;
+    return NULL;
+  }
+
+error:
+  print_error("Unexpected call to realloc");
+  fail();
+  return NULL;
 }
 
 #define WITH_MOCK_MALLOC(block, malloc_calls, ...) \
@@ -63,7 +96,7 @@ void *instrumented_malloc(size_t size) {
     finalize_mock_malloc();                        \
   } while (0)
 
-#define WITH_FAILING_MALLOC(block) WITH_MOCK_MALLOC(block, 1, false)
+#define WITH_FAILING_MALLOC(block) WITH_MOCK_MALLOC(block, 1, MALLOC_FAIL)
 
 static void test_int_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int8()); });
@@ -86,42 +119,40 @@ static void test_bytestring_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_bytestring()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); }, 2, true,
-                   false);
+  WITH_MOCK_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); }, 2, MALLOC,
+                   MALLOC_FAIL);
 
   unsigned char bytes[] = {0, 0, 0xFF, 0xAB};
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_bytestring(bytes, 4)); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_build_bytestring(bytes, 4)); }, 2, true,
-                   false);
+  WITH_MOCK_MALLOC({ assert_null(cbor_build_bytestring(bytes, 4)); }, 2, MALLOC,
+                   MALLOC_FAIL);
 }
 
 static void test_string_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_string()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_string()); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_new_indefinite_string()); }, 2, true,
-                   false);
+  WITH_MOCK_MALLOC({ assert_null(cbor_new_indefinite_string()); }, 2, MALLOC,
+                   MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_string("Test")); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_build_string("Test")); }, 2, true, false);
+  WITH_MOCK_MALLOC({ assert_null(cbor_build_string("Test")); }, 2, MALLOC, MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_stringn("Test", 4)); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_build_stringn("Test", 4)); }, 2, true,
-                   false);
+  WITH_MOCK_MALLOC({ assert_null(cbor_build_stringn("Test", 4)); }, 2, MALLOC, MALLOC_FAIL);
 }
 
 static void test_array_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_array(42)); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_array(42)); }, 2, true,
-                   false);
+  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_array(42)); }, 2, MALLOC, MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_array()); });
 }
 
 static void test_map_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_map(42)); });
-  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_map(42)); }, 2, true, false);
+  WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_map(42)); }, 2, MALLOC, MALLOC_FAIL);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_map()); });
 }
@@ -145,9 +176,21 @@ static void test_float_ctrl_creation(void **state) {
   WITH_FAILING_MALLOC({ assert_null(cbor_build_ctrl(0xAF)); });
 }
 
+static void test_bytestring_add_chunk(void **state) {
+  unsigned char bytes[] = {0, 0, 0xFF, 0xAB};
+  WITH_MOCK_MALLOC(
+      {
+        cbor_item_t *bytestring = cbor_new_indefinite_bytestring();
+        cbor_item_t *chunk = cbor_build_bytestring(bytes, 4);
+
+        assert_false(cbor_bytestring_add_chunk(bytestring, chunk));
+      },
+      3, true, true, false);
+}
+
 int main(void) {
 #if CBOR_CUSTOM_ALLOC
-  cbor_set_allocs(instrumented_malloc, realloc, free);
+  cbor_set_allocs(instrumented_malloc, instrumented_realloc, free);
 
   // TODO: string chunks realloc test
   const struct CMUnitTest tests[] = {
@@ -158,6 +201,8 @@ int main(void) {
       cmocka_unit_test(test_map_creation),
       cmocka_unit_test(test_tag_creation),
       cmocka_unit_test(test_float_ctrl_creation),
+
+      cmocka_unit_test(test_bytestring_add_chunk),
   };
 #else
   // Can't do anything without a custom allocator

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -193,10 +193,30 @@ static void test_bytestring_add_chunk(void **state) {
             ((struct cbor_indefinite_string_data *)bytestring->data)
                 ->chunk_capacity,
             0);
+
         cbor_decref(&chunk);
         cbor_decref(&bytestring);
       },
       5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
+}
+
+static void test_string_add_chunk(void **state) {
+  WITH_MOCK_MALLOC(
+          {
+            cbor_item_t *string = cbor_new_indefinite_string();
+            cbor_item_t *chunk = cbor_build_string("Hello!");
+
+            assert_false(cbor_string_add_chunk(string, chunk));
+            assert_int_equal(cbor_string_length(string), 0);
+            assert_int_equal(
+                    ((struct cbor_indefinite_string_data *)string->data)
+                            ->chunk_capacity,
+                    0);
+
+            cbor_decref(&chunk);
+            cbor_decref(&string);
+          },
+          5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
 int main(void) {
@@ -214,6 +234,7 @@ int main(void) {
       cmocka_unit_test(test_float_ctrl_creation),
 
       cmocka_unit_test(test_bytestring_add_chunk),
+      cmocka_unit_test(test_string_add_chunk),
   };
 #else
   // Can't do anything without a custom allocator

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -218,6 +218,21 @@ static void test_string_add_chunk(void **state) {
       5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
+static void test_array_push(void **state) {
+  WITH_MOCK_MALLOC(
+          {
+            cbor_item_t *array = cbor_new_indefinite_array();
+            cbor_item_t *string = cbor_build_string("Hello!");
+
+            assert_false(cbor_array_push(array, cbor_move(string)));
+            assert_int_equal(cbor_array_allocated(array), 0);
+            assert_null(array->data);
+            assert_int_equal(array->metadata.array_metadata.end_ptr, 0);
+
+            cbor_decref(&array);
+          }, 4, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
+}
+
 int main(void) {
 #if CBOR_CUSTOM_ALLOC
   cbor_set_allocs(instrumented_malloc, instrumented_realloc, free);
@@ -234,6 +249,7 @@ int main(void) {
 
       cmocka_unit_test(test_bytestring_add_chunk),
       cmocka_unit_test(test_string_add_chunk),
+      cmocka_unit_test(test_array_push),
   };
 #else
   // Can't do anything without a custom allocator

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -193,6 +193,8 @@ static void test_bytestring_add_chunk(void **state) {
             ((struct cbor_indefinite_string_data *)bytestring->data)
                 ->chunk_capacity,
             0);
+        cbor_decref(&chunk);
+        cbor_decref(&bytestring);
       },
       5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }


### PR DESCRIPTION
Fixes #87 