### PR TITLE
Remove printf

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -92,8 +92,6 @@ cbor_item_t *cbor_load(cbor_data source, size_t source_size,
         }
     }
 
-    printf("\nres: %d\n", context.syntax_error);
-
     if (context.creation_failed) {
       /* Most likely unsuccessful allocation - our callback has failed */
       result->error.code = CBOR_ERR_MEMERROR;


### PR DESCRIPTION
Libraries shouldn't be printing things to stdout, it should be up to callers if they want to.