### PR TITLE
Improve ci

### DIFF
--- a/.travis-qemu.sh
+++ b/.travis-qemu.sh
@@ -116,7 +116,7 @@ else
 	clang-format -version
 	clang-format-8 -version
 	./clang-format.sh
-	git status | grep "nothing to commit, working tree clean"
+	git diff-index --quiet HEAD
 
 	cmake \
 		-DCBOR_CUSTOM_ALLOC=ON \

--- a/.travis-qemu.sh
+++ b/.travis-qemu.sh
@@ -113,18 +113,18 @@ else
 	echo "Running tests"
 	cppcheck . --error-exitcode=1 --suppressions cppcheck_suppressions.txt --force
 
-    clang-format -version
-    clang-format-8 -version
+	clang-format -version
+	clang-format-8 -version
 	./clang-format.sh
-    git status | grep "nothing to commit, working tree clean"
+	git status | grep "nothing to commit, working tree clean"
 
 	cmake \
-	    -DCBOR_CUSTOM_ALLOC=ON \
-	    -DCMAKE_BUILD_TYPE=Debug \
-	    -DSANITIZE=OFF \
-	    -DWITH_TESTS=ON \
-	    -DCMAKE_PREFIX_PATH=${HOME}/usr/local \
-	    .
+		-DCBOR_CUSTOM_ALLOC=ON \
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DSANITIZE=OFF \
+		-DWITH_TESTS=ON \
+		-DCMAKE_PREFIX_PATH=${HOME}/usr/local \
+		.
 	make VERBOSE=1
 
 	ctest -VV

--- a/clang-format.sh
+++ b/clang-format.sh
@@ -3,8 +3,8 @@
 # TravisCI workaround to use new clang-format while avoiding painful aliasing
 # into the subshell
 if which clang-format-8; then
-    clang-format-8 -style=file -i **/*.c **/*.h **/*.cpp
+    clang-format-8 --verbose -style=file -i **/*.c **/*.h **/*.cpp
 else
-    clang-format -style=file -i **/*.c **/*.h **/*.cpp
+    clang-format --verbose -style=file -i **/*.c **/*.h **/*.cpp
 fi
 


### PR DESCRIPTION
Fixes for #104 :

- `clang-format` output is set to verbose
- use `git diff-index` to check uncommited changes