### PR TITLE
Fix memory_allocation_test w/o custom allocators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Next
 - BREAKING: Improved bool support [[Fixes #63]](https://github.com/PJK/libcbor/issues/63)
     - Rename `cbor_ctrl_is_bool` to `cbor_get_bool` and fix the behavior
     - Add `cbor_set_bool`
+- Fix memory_allocation_test breaking the build without CBOR_CUSTOM_ALLOC [[Fixes #128]](https://github.com/PJK/libcbor/issues/128) (by [panlinux](https://github.com/panlinux))
 
 0.6.0 (2020-03-15)
 ---------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(MINGW)
     # https://github.com/PJK/libcbor/issues/13
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 elseif(NOT MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -pedantic")
 endif()
 
 if(MSVC)
@@ -68,8 +68,8 @@ if(MSVC)
 else()
     set(CBOR_RESTRICT_SPECIFIER "restrict")
 
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -Wall -pedantic -g -ggdb -DDEBUG=true")
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -flto -Wall -pedantic -DNDEBUG")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -Wall -g -ggdb -DDEBUG=true")
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -flto -Wall -DNDEBUG")
 
     if(SANITIZE)
         set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 file(GLOB TESTS "*_test.c")
 
+if(NOT CBOR_CUSTOM_ALLOC)
+    # Memory allocation test requires custom allocator support to instrument it.
+    list(REMOVE_ITEM TESTS ${CMAKE_CURRENT_SOURCE_DIR}/memory_allocation_test.c)
+endif(NOT CBOR_CUSTOM_ALLOC)
+
 find_package(CMocka REQUIRED)
 
 message(STATUS "CMocka vars: ${CMOCKA_LIBRARIES} ${CMOCKA_INCLUDE_DIR}")

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -255,7 +255,6 @@ static void test_map_add(void **state) {
 }
 
 int main(void) {
-#if CBOR_CUSTOM_ALLOC
   cbor_set_allocs(instrumented_malloc, instrumented_realloc, free);
 
   // TODO: string chunks realloc test
@@ -273,10 +272,6 @@ int main(void) {
       cmocka_unit_test(test_array_push),
       cmocka_unit_test(test_map_add),
   };
-#else
-  // Can't do anything without a custom allocator
-  const struct CMUnitTest tests[] = {};
-#endif
 
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Always be -pedantic to catch similar issues faster, there is no reason not to be.

Fixes #128 