### PR TITLE
build: Fix pkg-config paths

### DIFF
--- a/CMakeModules/JoinPaths.cmake
+++ b/CMakeModules/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES cbor.c cbor/streaming.c cbor/internal/encoders.c cbor/internal/builder_callbacks.c cbor/internal/loaders.c cbor/internal/memory_utils.c cbor/internal/stack.c cbor/internal/unicode.c cbor/encoding.c cbor/serialization.c cbor/arrays.c cbor/common.c cbor/floats_ctrls.c cbor/bytestrings.c cbor/callbacks.c cbor/strings.c cbor/maps.c cbor/tags.c cbor/ints.c)
 
 include(GNUInstallDirs)
+include(JoinPaths)
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 
 if (CBOR_CUSTOM_ALLOC)
@@ -28,6 +29,8 @@ set_target_properties(cbor PROPERTIES
 		MACHO_COMPATIBILITY_VERSION ${CBOR_VERSION_MAJOR}.${CBOR_VERSION_MINOR}.0
 		SOVERSION ${CBOR_VERSION_MAJOR}.${CBOR_VERSION_MINOR})
 
+join_paths(libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file(libcbor.pc.in libcbor.pc @ONLY)
 
 # http://www.cmake.org/Wiki/CMake:Install_Commands
@@ -42,4 +45,4 @@ install(DIRECTORY cbor DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 install(FILES cbor.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libcbor.pc"
-	DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+	DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/src/libcbor.pc.in
+++ b/src/libcbor.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_NAME@ - CBOR protocol implementation


### PR DESCRIPTION
It is not generally true that `CMAKE_INSTALL_<dir>` variables are relative paths:

https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files

When they are absolute, it leads to broken paths with duplicated prefix.
