### PR TITLE
Remove invalid param for cbor_new_indefinite_map()

### DIFF
--- a/src/cbor/maps.h
+++ b/src/cbor/maps.h
@@ -44,8 +44,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_definite_map(size_t size);
 
 /** Create a new indefinite map
  *
- * @param size The number of slots to preallocate
- * @return **new** definite map. `NULL` on malloc failure.
+ * @return **new** indefinite map. `NULL` on malloc failure.
  */
 CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map();
 


### PR DESCRIPTION
# PR: Doc typo fix

## Description

Fixes the doc output for `cbor_new_indefinite_map()`
