### PR TITLE
Make the buffer_size optional in cbor_serialize_alloc()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Next
 ---------------------
+- Make the buffer_size optional in `cbor_serialize_alloc` [[#205]](https://github.com/PJK/libcbor/pull/205) (by [hughsie@](https://github.com/hughsie))
 
 0.9.0 (2021-11-14)
 ---------------------

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -67,7 +67,8 @@ size_t cbor_serialize_alloc(const cbor_item_t *item, unsigned char **buffer,
     bfr = tmp_bfr;
   }
   *buffer = bfr;
-  *buffer_size = bfr_size;
+  if (buffer_size != NULL)
+    *buffer_size = bfr_size;
   return written;
 }
 

--- a/src/cbor/serialization.h
+++ b/src/cbor/serialization.h
@@ -40,7 +40,7 @@ CBOR_EXPORT size_t cbor_serialize(const cbor_item_t *item,
  *
  * @param item[borrow] A data item
  * @param buffer[out] Buffer containing the result
- * @param buffer_size[out] Size of the \p buffer
+ * @param buffer_size[out] Size of the \p buffer, or ``NULL``
  * @return Length of the result. 0 on failure, in which case \p buffer is
  * ``NULL``.
  */

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -295,6 +295,16 @@ static void test_auto_serialize(void **_CBOR_UNUSED(_state)) {
   _CBOR_FREE(output);
 }
 
+static void test_auto_serialize_no_size(void **_CBOR_UNUSED(_state)) {
+  cbor_item_t *item = cbor_build_uint8(1);
+
+  unsigned char *output;
+  assert_int_equal(1, cbor_serialize_alloc(item, &output, NULL));
+  assert_memory_equal(output, ((unsigned char[]){0x01}), 1);
+  cbor_decref(&item);
+  _CBOR_FREE(output);
+}
+
 int main(void) {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_serialize_uint8),
@@ -319,6 +329,7 @@ int main(void) {
       cmocka_unit_test(test_serialize_double),
       cmocka_unit_test(test_serialize_ctrl),
       cmocka_unit_test(test_serialize_long_ctrl),
-      cmocka_unit_test(test_auto_serialize)};
+      cmocka_unit_test(test_auto_serialize),
+      cmocka_unit_test(test_auto_serialize_no_size)};
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
# PR: Make the buffer_size optional in cbor_serialize_alloc()

## Description

In my case I don't care exactly how many bytes were allocated, I just need the number of bytes the CBOR item serialized to.

## Checklist

- [X] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [X] I have added tests
	- [X] I have updated the documentation
	- [x] I have updated the CHANGELOG
