### PR TITLE
Half-float preserve more bits for denormals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Next
 ---------------------
+- Improved half-float encoding for denormalized numbers.
 
 0.9.0 (2021-11-14)
 ---------------------

--- a/src/cbor/encoding.c
+++ b/src/cbor/encoding.c
@@ -158,7 +158,8 @@ size_t cbor_encode_half(float value, unsigned char *buffer,
          value is lost. This is an implementation decision that works around the
          absence of standard half-float in the language. */
       res = (uint16_t)((val & 0x80000000u) >> 16u) |  // Extract sign bit
-            (uint16_t)(1u << (24u + logical_exp));
+            (uint16_t)(1u << (24u + logical_exp)) +
+            (uint16_t)(((mant >> (-logical_exp - 2)) + 1) >> 1);  // Round half away from zero for simplicity
     } else {
       res = (uint16_t)((val & 0x80000000u) >> 16u |
                        ((((uint8_t)logical_exp) + 15u) << 10u) |

--- a/test/float_ctrl_encoders_test.c
+++ b/test/float_ctrl_encoders_test.c
@@ -65,6 +65,15 @@ static void test_half(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(3, cbor_encode_half(5.960464477539062e-8f, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x00, 0x01}), 3);
 
+  assert_int_equal(3, cbor_encode_half(4.172325134277344e-7f, buffer, 512));
+  assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x00, 0x07}), 3);
+
+  assert_int_equal(3, cbor_encode_half(6.097555160522461e-5f, buffer, 512));
+  assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x03, 0xff}), 3);
+
+  assert_int_equal(3, cbor_encode_half(6.100535392761231e-5f, buffer, 512));
+  assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x04, 0x00}), 3);
+
   /* Smaller than the smallest and even the magnitude cannot be represented,
      round off to zero */
   assert_int_equal(3, cbor_encode_half(1e-25f, buffer, 512));


### PR DESCRIPTION
# PR: Half-float preserve more bits for denormals

## Description

Encoding of half-float values that is in range of denormalized numbers had been trimmed the whole mantissa bits.
This patch improves it by reflecting some bits to the encoded value.

Some examples:
```
binary32  before  after   before     after
38000000  0x0200  0x0200  3.0518e-5  3.0518e-5
38004000  0x0200  0x0201  3.0518e-5  3.0577e-5
38008000  0x0200  0x0202  3.0518e-5  3.0637e-5
387f8000  0x0200  0x03fe  3.0518e-5  6.0916e-5
387fc000  0x0200  0x03ff  3.0518e-5  6.0976e-5
```

I used "round half away from zero" instead of "round to even" because it is simple and doesn't need an execution branch.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [x] I have added tests
	- [ ] I have updated the documentation
	- [x] I have updated the CHANGELOG
- [ ] Are there any breaking changes? If so, are they documented?
- [ ] Does this PR introduce any platform specific code? If so, is this captured in the description?
- [ ] Security: Does this PR potentially affect security? If so, is this captured in the description?
- [x] Performance: Does this PR potentially affect performance? If so, is this captured in the description?
