### PR TITLE
Only run OSX CI on master and when linux job succeeded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
       - build-and-test
       - build-and-test-clang
       - build-and-test-arm
-      - build-and-test-osx
+      - build-and-test-osx:
           requires:
             - build-and-test
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,4 +106,10 @@ workflows:
       - build-and-test-clang
       - build-and-test-arm
       - build-and-test-osx
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only:
+                - master
       - build-bazel


### PR DESCRIPTION
Mac builds are much more expensive and platform-specific breakage is quite unlikely