### PR TITLE
Remove unnecessary copying of pointer before return in cbor_load()

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -100,9 +100,7 @@ cbor_item_t *cbor_load(cbor_data source, size_t source_size,
     }
   } while (stack.size > 0);
 
-  /* Move the result before free */
-  cbor_item_t *result_item = context.root;
-  return result_item;
+  return context.root;
 
 error:
   result->error.position = result->read;


### PR DESCRIPTION


## Description

When building with the TI ARM Clang compiler the initialization of `result_item` in `cbor_load()` generated a warning because of the `goto error` statements earlier in the function:

```
error #548-D: transfer of control bypasses initialization of...
```

This warning can of course be suppressed but since the copying of `context.root` is unnecessary, we can simplify things and return the member right away.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes? If so, are they documented?
- [ ] Does this PR introduce any platform specific code? If so, is this captured in the description?
- [ ] Security: Does this PR potentially affect security? If so, is this captured in the description?
- [ ] Performance: Does this PR potentially affect performance? If so, is this captured in the description?
