### PR TITLE
Fails gracefully when allocation fails during array/map construction

### DIFF
--- a/src/cbor/internal/builder_callbacks.c
+++ b/src/cbor/internal/builder_callbacks.c
@@ -17,6 +17,8 @@
 #include "../tags.h"
 #include "unicode.h"
 
+// This function maintains the invariant that no memory reachable by ctx->stack
+// and item would be leaked.
 void _cbor_builder_append(cbor_item_t *item,
                           struct _cbor_decoder_context *ctx) {
   if (ctx->stack->size == 0) {


### PR DESCRIPTION
# Fails gracefully when allocation fails during array/map construction

## Description

Return values of `cbor_array_push`, `_cbor_map_add_key` and `_cbor_map_add_value` are unchecked. An unchecked `false` return value here implies potential out-of-bound memory access.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [x] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [x] Are there any breaking changes? If so, are they documented?
   No
- [X] Does this PR introduce any platform specific code? If so, is this captured in the description?
   No
- [X] Security: Does this PR potentially affect security? If so, is this captured in the description?
   No
- [X] Performance: Does this PR potentially affect performance? If so, is this captured in the description?
   No
