### PR TITLE
Add parenthesis with | operator

### DIFF
--- a/src/cbor/encoding.c
+++ b/src/cbor/encoding.c
@@ -161,9 +161,9 @@ size_t cbor_encode_half(float value, unsigned char *buffer,
          value is lost. This is an implementation decision that works around the
          absence of standard half-float in the language. */
       res = (uint16_t)((val & 0x80000000u) >> 16u) |  // Extract sign bit
-            (uint16_t)(1u << (24u + logical_exp)) +
+            ((uint16_t)(1u << (24u + logical_exp)) +
                 (uint16_t)(((mant >> (-logical_exp - 2)) + 1) >>
-                           1);  // Round half away from zero for simplicity
+                           1));  // Round half away from zero for simplicity
     } else {
       res = (uint16_t)((val & 0x80000000u) >> 16u |
                        ((((uint8_t)logical_exp) + 15u) << 10u) |

--- a/src/cbor/encoding.c
+++ b/src/cbor/encoding.c
@@ -162,8 +162,8 @@ size_t cbor_encode_half(float value, unsigned char *buffer,
          absence of standard half-float in the language. */
       res = (uint16_t)((val & 0x80000000u) >> 16u) |  // Extract sign bit
             ((uint16_t)(1u << (24u + logical_exp)) +
-                (uint16_t)(((mant >> (-logical_exp - 2)) + 1) >>
-                           1));  // Round half away from zero for simplicity
+             (uint16_t)(((mant >> (-logical_exp - 2)) + 1) >>
+                        1));  // Round half away from zero for simplicity
     } else {
       res = (uint16_t)((val & 0x80000000u) >> 16u |
                        ((((uint8_t)logical_exp) + 15u) << 10u) |


### PR DESCRIPTION
# PR: Short description of change

## Description

Address GCC warning:

  _deps/libcbor-src/src/cbor/encoding.c:164:51: warning: suggest parentheses around arithmetic in operand of '|' [-Wparentheses]

## Checklist

- [ ] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes? If so, are they documented?
- [x] Does this PR introduce any platform specific code? If so, is this captured in the description?
- [ ] Security: Does this PR potentially affect security? If so, is this captured in the description?
- [ ] Performance: Does this PR potentially affect performance? If so, is this captured in the description?
