### PR TITLE
Fix clang 15 -Wstrict-prototype warnings

### DIFF
--- a/examples/bazel/src/hello.h
+++ b/examples/bazel/src/hello.h
@@ -3,6 +3,6 @@
 
 #include <cstdint>
 
-uint8_t cbor_version();
+uint8_t cbor_version(void);
 
 #endif  // HELLO_H_

--- a/examples/cjson2cbor.c
+++ b/examples/cjson2cbor.c
@@ -110,7 +110,7 @@ void cjson_cbor_stream_decode(cJSON *source,
   }
 }
 
-void usage() {
+void usage(void) {
   printf("Usage: cjson [input JSON file]\n");
   exit(1);
 }

--- a/examples/create_items.c
+++ b/examples/create_items.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "cbor.h"
 
-int main() {
+int main(void) {
   /* Preallocate the map structure */
   cbor_item_t* root = cbor_new_definite_map(2);
   /* Add the content */

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "cbor.h"
 
-int main() {
+int main(void) {
   printf("Hello from libcbor %s\n", CBOR_VERSION);
   printf("Custom allocation support: %s\n", CBOR_CUSTOM_ALLOC ? "yes" : "no");
   printf("Pretty-printer support: %s\n", CBOR_PRETTY_PRINTER ? "yes" : "no");

--- a/examples/readfile.c
+++ b/examples/readfile.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "cbor.h"
 
-void usage() {
+void usage(void) {
   printf("Usage: readfile [input file]\n");
   exit(1);
 }

--- a/examples/sort.c
+++ b/examples/sort.c
@@ -26,7 +26,7 @@ int compareUint(const void *a, const void *b) {
     return 1;
 }
 
-int main() {
+int main(void) {
   cbor_item_t *array = cbor_new_definite_array(4);
   cbor_array_push(array, cbor_move(cbor_build_uint8(4)));
   cbor_array_push(array, cbor_move(cbor_build_uint8(3)));

--- a/examples/streaming_array.c
+++ b/examples/streaming_array.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include "cbor.h"
 
-void usage() {
+void usage(void) {
   printf("Usage: streaming_array <N>\n");
   printf("Prints out serialized array [0, ..., N-1]\n");
   exit(1);

--- a/examples/streaming_parser.c
+++ b/examples/streaming_parser.c
@@ -15,7 +15,7 @@
 #define UNUSED(x) x
 #endif
 
-void usage() {
+void usage(void) {
   printf("Usage: streaming_parser [input file]\n");
   exit(1);
 }

--- a/src/cbor/arrays.c
+++ b/src/cbor/arrays.c
@@ -116,7 +116,7 @@ cbor_item_t *cbor_new_definite_array(size_t size) {
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_array() {
+cbor_item_t *cbor_new_indefinite_array(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 

--- a/src/cbor/arrays.h
+++ b/src/cbor/arrays.h
@@ -97,7 +97,7 @@ CBOR_EXPORT cbor_item_t* cbor_new_definite_array(size_t size);
  *
  * @return **new** array or `NULL` upon malloc failure
  */
-CBOR_EXPORT cbor_item_t* cbor_new_indefinite_array();
+CBOR_EXPORT cbor_item_t* cbor_new_indefinite_array(void);
 
 /** Append to the end
  *

--- a/src/cbor/bytestrings.c
+++ b/src/cbor/bytestrings.c
@@ -28,7 +28,7 @@ bool cbor_bytestring_is_indefinite(const cbor_item_t *item) {
   return !cbor_bytestring_is_definite(item);
 }
 
-cbor_item_t *cbor_new_definite_bytestring() {
+cbor_item_t *cbor_new_definite_bytestring(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){
@@ -39,7 +39,7 @@ cbor_item_t *cbor_new_definite_bytestring() {
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_bytestring() {
+cbor_item_t *cbor_new_indefinite_bytestring(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){

--- a/src/cbor/bytestrings.h
+++ b/src/cbor/bytestrings.h
@@ -104,7 +104,7 @@ CBOR_EXPORT bool cbor_bytestring_add_chunk(cbor_item_t *item,
  *
  * @return **new** definite bytestring. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_definite_bytestring();
+CBOR_EXPORT cbor_item_t *cbor_new_definite_bytestring(void);
 
 /** Creates a new indefinite byte string
  *
@@ -112,7 +112,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_definite_bytestring();
  *
  * @return **new** indefinite bytestring. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_indefinite_bytestring();
+CBOR_EXPORT cbor_item_t *cbor_new_indefinite_bytestring(void);
 
 /** Creates a new byte string and initializes it
  *

--- a/src/cbor/floats_ctrls.c
+++ b/src/cbor/floats_ctrls.c
@@ -93,7 +93,7 @@ void cbor_set_bool(cbor_item_t *item, bool value) {
       value ? CBOR_CTRL_TRUE : CBOR_CTRL_FALSE;
 }
 
-cbor_item_t *cbor_new_ctrl() {
+cbor_item_t *cbor_new_ctrl(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 
@@ -106,7 +106,7 @@ cbor_item_t *cbor_new_ctrl() {
   return item;
 }
 
-cbor_item_t *cbor_new_float2() {
+cbor_item_t *cbor_new_float2(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t) + 4);
   _CBOR_NOTNULL(item);
 
@@ -118,7 +118,7 @@ cbor_item_t *cbor_new_float2() {
   return item;
 }
 
-cbor_item_t *cbor_new_float4() {
+cbor_item_t *cbor_new_float4(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t) + 4);
   _CBOR_NOTNULL(item);
 
@@ -130,7 +130,7 @@ cbor_item_t *cbor_new_float4() {
   return item;
 }
 
-cbor_item_t *cbor_new_float8() {
+cbor_item_t *cbor_new_float8(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t) + 8);
   _CBOR_NOTNULL(item);
 
@@ -142,14 +142,14 @@ cbor_item_t *cbor_new_float8() {
   return item;
 }
 
-cbor_item_t *cbor_new_null() {
+cbor_item_t *cbor_new_null(void) {
   cbor_item_t *item = cbor_new_ctrl();
   _CBOR_NOTNULL(item);
   cbor_set_ctrl(item, CBOR_CTRL_NULL);
   return item;
 }
 
-cbor_item_t *cbor_new_undef() {
+cbor_item_t *cbor_new_undef(void) {
   cbor_item_t *item = cbor_new_ctrl();
   _CBOR_NOTNULL(item);
   cbor_set_ctrl(item, CBOR_CTRL_UNDEF);

--- a/src/cbor/floats_ctrls.h
+++ b/src/cbor/floats_ctrls.h
@@ -84,7 +84,7 @@ CBOR_EXPORT bool cbor_get_bool(const cbor_item_t *item);
  *
  * @return **new** 1B ctrl or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_ctrl();
+CBOR_EXPORT cbor_item_t *cbor_new_ctrl(void);
 
 /** Constructs a new float item
  *
@@ -92,7 +92,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_ctrl();
  *
  * @return **new** 2B float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_float2();
+CBOR_EXPORT cbor_item_t *cbor_new_float2(void);
 
 /** Constructs a new float item
  *
@@ -100,7 +100,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_float2();
  *
  * @return **new** 4B float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_float4();
+CBOR_EXPORT cbor_item_t *cbor_new_float4(void);
 
 /** Constructs a new float item
  *
@@ -108,19 +108,19 @@ CBOR_EXPORT cbor_item_t *cbor_new_float4();
  *
  * @return **new** 8B float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_float8();
+CBOR_EXPORT cbor_item_t *cbor_new_float8(void);
 
 /** Constructs new null ctrl item
  *
  * @return **new** null ctrl item or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_null();
+CBOR_EXPORT cbor_item_t *cbor_new_null(void);
 
 /** Constructs new undef ctrl item
  *
  * @return **new** undef ctrl item or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_undef();
+CBOR_EXPORT cbor_item_t *cbor_new_undef(void);
 
 /** Constructs new boolean ctrl item
  *

--- a/src/cbor/internal/stack.c
+++ b/src/cbor/internal/stack.c
@@ -7,7 +7,7 @@
 
 #include "stack.h"
 
-struct _cbor_stack _cbor_stack_init() {
+struct _cbor_stack _cbor_stack_init(void) {
   return (struct _cbor_stack){.top = NULL, .size = 0};
 }
 

--- a/src/cbor/internal/stack.h
+++ b/src/cbor/internal/stack.h
@@ -27,7 +27,7 @@ struct _cbor_stack {
   size_t size;
 };
 
-struct _cbor_stack _cbor_stack_init();
+struct _cbor_stack _cbor_stack_init(void);
 
 void _cbor_stack_pop(struct _cbor_stack *);
 

--- a/src/cbor/ints.c
+++ b/src/cbor/ints.c
@@ -86,7 +86,7 @@ void cbor_mark_negint(cbor_item_t *item) {
   item->type = CBOR_TYPE_NEGINT;
 }
 
-cbor_item_t *cbor_new_int8() {
+cbor_item_t *cbor_new_int8(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t) + 1);
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),
@@ -96,7 +96,7 @@ cbor_item_t *cbor_new_int8() {
   return item;
 }
 
-cbor_item_t *cbor_new_int16() {
+cbor_item_t *cbor_new_int16(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t) + 2);
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),
@@ -106,7 +106,7 @@ cbor_item_t *cbor_new_int16() {
   return item;
 }
 
-cbor_item_t *cbor_new_int32() {
+cbor_item_t *cbor_new_int32(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t) + 4);
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),
@@ -116,7 +116,7 @@ cbor_item_t *cbor_new_int32() {
   return item;
 }
 
-cbor_item_t *cbor_new_int64() {
+cbor_item_t *cbor_new_int64(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t) + 8);
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),

--- a/src/cbor/ints.h
+++ b/src/cbor/ints.h
@@ -118,7 +118,7 @@ CBOR_EXPORT void cbor_mark_negint(cbor_item_t *item);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int8();
+CBOR_EXPORT cbor_item_t *cbor_new_int8(void);
 
 /** Allocates new integer with 2B width
  *
@@ -127,7 +127,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_int8();
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int16();
+CBOR_EXPORT cbor_item_t *cbor_new_int16(void);
 
 /** Allocates new integer with 4B width
  *
@@ -136,7 +136,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_int16();
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int32();
+CBOR_EXPORT cbor_item_t *cbor_new_int32(void);
 
 /** Allocates new integer with 8B width
  *
@@ -145,7 +145,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_int32();
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int64();
+CBOR_EXPORT cbor_item_t *cbor_new_int64(void);
 
 /** Constructs a new positive integer
  *

--- a/src/cbor/maps.c
+++ b/src/cbor/maps.c
@@ -34,7 +34,7 @@ cbor_item_t *cbor_new_definite_map(size_t size) {
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_map() {
+cbor_item_t *cbor_new_indefinite_map(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 

--- a/src/cbor/maps.h
+++ b/src/cbor/maps.h
@@ -46,7 +46,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_definite_map(size_t size);
  *
  * @return **new** indefinite map. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map();
+CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map(void);
 
 /** Add a pair to the map
  *

--- a/src/cbor/strings.c
+++ b/src/cbor/strings.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include "internal/memory_utils.h"
 
-cbor_item_t *cbor_new_definite_string() {
+cbor_item_t *cbor_new_definite_string(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){
@@ -19,7 +19,7 @@ cbor_item_t *cbor_new_definite_string() {
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_string() {
+cbor_item_t *cbor_new_indefinite_string(void) {
   cbor_item_t *item = _CBOR_MALLOC(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){

--- a/src/cbor/strings.h
+++ b/src/cbor/strings.h
@@ -118,7 +118,7 @@ CBOR_EXPORT bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk);
  *
  * @return **new** definite string. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_definite_string();
+CBOR_EXPORT cbor_item_t *cbor_new_definite_string(void);
 
 /** Creates a new indefinite string
  *
@@ -126,7 +126,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_definite_string();
  *
  * @return **new** indefinite string. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_indefinite_string();
+CBOR_EXPORT cbor_item_t *cbor_new_indefinite_string(void);
 
 /** Creates a new string and initializes it
  *

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -207,7 +207,7 @@ static void test_serialize_definite_map(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_serialize_indefinite_map(void **_CBOR_UNUSED(_state)) {
-  cbor_item_t *item = cbor_new_indefinite_map(2);
+  cbor_item_t *item = cbor_new_indefinite_map();
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);
 

--- a/test/copy_test.c
+++ b/test/copy_test.c
@@ -139,7 +139,7 @@ static void test_def_map(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_indef_map(void **_CBOR_UNUSED(_state)) {
-  item = cbor_new_indefinite_map(1);
+  item = cbor_new_indefinite_map();
   cbor_map_add(item, (struct cbor_pair){
                          .key = cbor_move(cbor_build_uint8(42)),
                          .value = cbor_move(cbor_build_uint8(43)),

--- a/test/float_ctrl_encoders_test.c
+++ b/test/float_ctrl_encoders_test.c
@@ -40,7 +40,7 @@ static void test_break(void **_CBOR_UNUSED(_state)) {
 
 /* Check that encode(decode(buffer)) = buffer for a valid half-float in the
  * buffer.*/
-static void assert_half_float_codec_identity() {
+static void assert_half_float_codec_identity(void) {
   unsigned char secondary_buffer[3];
   struct cbor_load_result res;
   // Load and check data in buffer

--- a/test/fuzz_test.c
+++ b/test/fuzz_test.c
@@ -40,7 +40,7 @@ void *mock_malloc(size_t size) {
 }
 #endif
 
-static void run_round() {
+static void run_round(void) {
   cbor_item_t *item;
   struct cbor_load_result res;
 

--- a/test/memory_allocation_test.c
+++ b/test/memory_allocation_test.c
@@ -46,7 +46,7 @@ void set_mock_malloc(int calls, ...) {
   va_end(args);
 }
 
-void finalize_mock_malloc() {
+void finalize_mock_malloc(void) {
   assert_int_equal(alloc_calls, alloc_calls_expected);
   free(expectations);
 }

--- a/test/stack_over_limit_test.c
+++ b/test/stack_over_limit_test.c
@@ -27,7 +27,7 @@ static void test_stack_over_limit(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(res.error.code, CBOR_ERR_MEMERROR);
 }
 
-int main() {
+int main(void) {
   const struct CMUnitTest tests[] = {cmocka_unit_test(test_stack_over_limit)};
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -17,7 +17,7 @@ int clear_stream_assertions(void **state) {
 }
 
 /* Callbacks */
-struct test_assertion current() {
+struct test_assertion current(void) {
   return assertions_queue[current_expectation];
 }
 
@@ -125,7 +125,7 @@ void byte_string_callback(void *_CBOR_UNUSED(_context), cbor_data address,
   current_expectation++;
 }
 
-void assert_bstring_indef_start() {
+void assert_bstring_indef_start(void) {
   assertions_queue[queue_size++] =
       (struct test_assertion){.expectation = BSTRING_INDEF_START};
 }
@@ -135,7 +135,7 @@ void byte_string_start_callback(void *_CBOR_UNUSED(_context)) {
   current_expectation++;
 }
 
-void assert_indef_break() {
+void assert_indef_break(void) {
   assertions_queue[queue_size++] =
       (struct test_assertion){.expectation = INDEF_BREAK};
 }
@@ -156,7 +156,7 @@ void array_start_callback(void *_CBOR_UNUSED(_context), uint64_t length) {
   current_expectation++;
 }
 
-void assert_indef_array_start() {
+void assert_indef_array_start(void) {
   assertions_queue[queue_size++] =
       (struct test_assertion){.expectation = ARRAY_INDEF_START};
 }
@@ -177,7 +177,7 @@ void map_start_callback(void *_CBOR_UNUSED(_context), uint64_t length) {
   current_expectation++;
 }
 
-void assert_indef_map_start() {
+void assert_indef_map_start(void) {
   assertions_queue[queue_size++] =
       (struct test_assertion){.expectation = MAP_INDEF_START};
 }
@@ -236,11 +236,11 @@ void assert_bool(bool value) {
       (struct test_assertion){BOOL_EQ, {.boolean = value}};
 }
 
-void assert_nil() {
+void assert_nil(void) {
   assertions_queue[queue_size++] = (struct test_assertion){.expectation = NIL};
 }
 
-void assert_undef() {
+void assert_undef(void) {
   assertions_queue[queue_size++] =
       (struct test_assertion){.expectation = UNDEF};
 }

--- a/test/stream_expectations.h
+++ b/test/stream_expectations.h
@@ -97,13 +97,13 @@ void assert_negint32_eq(uint32_t);
 void assert_negint64_eq(uint64_t);
 
 void assert_bstring_mem_eq(cbor_data, size_t);
-void assert_bstring_indef_start();
+void assert_bstring_indef_start(void);
 
 void assert_array_start(size_t);
-void assert_indef_array_start();
+void assert_indef_array_start(void);
 
 void assert_map_start(size_t);
-void assert_indef_map_start();
+void assert_indef_map_start(void);
 
 void assert_tag_eq(uint64_t);
 
@@ -112,10 +112,10 @@ void assert_float(float);
 void assert_double(double);
 
 void assert_bool(bool);
-void assert_nil(); /* assert_null already exists */
-void assert_undef();
+void assert_nil(void); /* assert_null already exists */
+void assert_undef(void);
 
-void assert_indef_break();
+void assert_indef_break(void);
 
 /* Assertions verifying callbacks */
 void uint8_callback(void *, uint8_t);


### PR DESCRIPTION
## Description

Clang 15 has become more strict about prototypes of functions without arguments in C, showing many warnings similar to:

    src/cbor/maps.h:49:49: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map();
                                                    ^
                                                     void

This is because in C, functions declared or defined with () are considered old-style functions with variadic arguments. (Although these will likely be finally removed in C23.)

Fix the warnings by using `(void)` for each of the declarations and definitions. This also fixes two incorrect invocations of `cbor_new_indefinite_map(void)` in the tests.

(Note: this has been submitted as a follow-up of https://bugs.freebsd.org/268417, for the FreeBSD port of libcbor. The libfido2 port that depends on libcbor is also fixed by adjusting the prototypes.)

## Checklist

- [y] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [n] I have added tests
	- [n] I have updated the documentation
	- [n] I have updated the CHANGELOG
- [n] Are there any breaking changes? If so, are they documented?
- [n] Does this PR introduce any platform specific code? If so, is this captured in the description?
- [n] Security: Does this PR potentially affect security? If so, is this captured in the description?
- [n] Performance: Does this PR potentially affect performance? If so, is this captured in the description?
