### PR TITLE
Reenable memcheck on CI and improve string/bytestring streaming decoding test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
     steps:
       - checkout
       - linux-setup
+      - run: sudo apt-get install -y valgrind
       - build-test
       - run: ctest -T Coverage
       - codecov/upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,15 +57,11 @@ jobs:
       - build-test
       - run: ctest -T Coverage
       - codecov/upload
-        # TODO: Reenable, currently fails on libjson leak (package out of date)
-        # The issue actually seems to be in the instrumentation code, not
-        # libcbor (we don't use libjsoncpp)
-        # https://github.com/open-source-parsers/jsoncpp/issues/507
-      #      - run: >
-      #          ctest --output-on-failure -T memcheck | tee memcheck.out
-      #          if grep -q 'Memory Leak\|IPW\|Uninitialized Memory Conditional\|Uninitialized Memory Read' memcheck.out; then
-      #            exit 1
-      #          fi;
+      - run: ctest --output-on-failure -T memcheck | tee memcheck.out
+      - run: >
+          if grep -q 'Memory Leak\|IPW\|Uninitialized Memory Conditional\|Uninitialized Memory Read' memcheck.out; then
+            exit 1
+          fi;
 
   build-and-test-clang:
     machine:

--- a/test/assertions.c
+++ b/test/assertions.c
@@ -32,19 +32,19 @@ void assert_uint64(cbor_item_t* item, uint64_t num) {
   assert_true(cbor_get_uint64(item) == num);
 }
 
-void assert_decoder_result(size_t expected_read,
+void assert_decoder_result(size_t expected_bytes_read,
                            enum cbor_decoder_status expected_status,
                            struct cbor_decoder_result actual_result) {
-  assert_true(actual_result.read == expected_read);
+  assert_true(actual_result.read == expected_bytes_read);
   assert_true(actual_result.status == expected_status);
   assert_true(actual_result.required == 0);
 }
 
-void assert_decoder_result_nedata(size_t expected_required,
+void assert_decoder_result_nedata(size_t expected_bytes_required,
                                   struct cbor_decoder_result actual_result) {
   assert_true(actual_result.read == 0);
   assert_true(actual_result.status == CBOR_DECODER_NEDATA);
-  assert_true(actual_result.required == expected_required);
+  assert_true(actual_result.required == expected_bytes_required);
 }
 
 void assert_minimum_input_size(size_t expected, cbor_data data) {

--- a/test/assertions.c
+++ b/test/assertions.c
@@ -32,18 +32,19 @@ void assert_uint64(cbor_item_t* item, uint64_t num) {
   assert_true(cbor_get_uint64(item) == num);
 }
 
-void assert_decoder_result(size_t read, enum cbor_decoder_status status,
-                           struct cbor_decoder_result result) {
-  assert_true(read == result.read);
-  assert_true(status == result.status);
-  assert_true(0 == result.required);
+void assert_decoder_result(size_t expected_read,
+                           enum cbor_decoder_status expected_status,
+                           struct cbor_decoder_result actual_result) {
+  assert_true(actual_result.read == expected_read);
+  assert_true(actual_result.status == expected_status);
+  assert_true(actual_result.required == 0);
 }
 
-void assert_decoder_result_nedata(size_t required,
-                                  struct cbor_decoder_result result) {
-  assert_true(0 == result.read);
-  assert_true(CBOR_DECODER_NEDATA == result.status);
-  assert_int_equal((int)required, (int)result.required);
+void assert_decoder_result_nedata(size_t expected_required,
+                                  struct cbor_decoder_result actual_result) {
+  assert_true(actual_result.read == 0);
+  assert_true(actual_result.status == CBOR_DECODER_NEDATA);
+  assert_true(actual_result.required == expected_required);
 }
 
 void assert_minimum_input_size(size_t expected, cbor_data data) {

--- a/test/assertions.h
+++ b/test/assertions.h
@@ -14,16 +14,17 @@ void assert_uint16(cbor_item_t* item, uint16_t num);
 void assert_uint32(cbor_item_t* item, uint32_t num);
 void assert_uint64(cbor_item_t* item, uint64_t num);
 
-/** Assert that result `status` and `read` are equal. */
-void assert_decoder_result(size_t read, enum cbor_decoder_status status,
-                           struct cbor_decoder_result result);
+/** Verify the `actual_result.status` and `actual_result.status`. */
+void assert_decoder_result(size_t expected_read,
+                           enum cbor_decoder_status expected_status,
+                           struct cbor_decoder_result actual_result);
 
 /**
  * Assert that the result is set to CBOR_DECODER_NEDATA with the given
  * `cbor_decoder_result.required` value.
  */
-void assert_decoder_result_nedata(size_t required,
-                                  struct cbor_decoder_result result);
+void assert_decoder_result_nedata(size_t expected_required,
+                                  struct cbor_decoder_result actual_result);
 
 /**
  * Check that the streaming decoder returns a correct CBOR_DECODER_NEDATA

--- a/test/assertions.h
+++ b/test/assertions.h
@@ -15,7 +15,7 @@ void assert_uint32(cbor_item_t* item, uint32_t num);
 void assert_uint64(cbor_item_t* item, uint64_t num);
 
 /** Verify the `actual_result.status` and `actual_result.status`. */
-void assert_decoder_result(size_t expected_read,
+void assert_decoder_result(size_t expected_bytes_read,
                            enum cbor_decoder_status expected_status,
                            struct cbor_decoder_result actual_result);
 
@@ -23,7 +23,7 @@ void assert_decoder_result(size_t expected_read,
  * Assert that the result is set to CBOR_DECODER_NEDATA with the given
  * `cbor_decoder_result.required` value.
  */
-void assert_decoder_result_nedata(size_t expected_required,
+void assert_decoder_result_nedata(size_t expected_bytes_required,
                                   struct cbor_decoder_result actual_result);
 
 /**

--- a/test/cbor_stream_decode_test.c
+++ b/test/cbor_stream_decode_test.c
@@ -538,7 +538,6 @@ static void test_undef_decoding(void **_CBOR_UNUSED(_state)) {
 #define stream_test(f) cmocka_unit_test_teardown(f, clear_stream_assertions)
 
 int main(void) {
-  set_decoder(&cbor_stream_decode);
   const struct CMUnitTest tests[] = {
       stream_test(test_no_data),
 

--- a/test/cbor_stream_decode_test.c
+++ b/test/cbor_stream_decode_test.c
@@ -227,9 +227,9 @@ static void test_bstring_indef_decoding_2(void **_CBOR_UNUSED(_state)) {
 
 unsigned char bstring_indef_3_data[] = {0x5F,
                                         // Empty byte string
-                                        0x40, 0x58,
+                                        0x40,
                                         // 1B, 1 character byte string
-                                        0x01, 0xFF,
+                                        0x58, 0x01, 0x00,
                                         // Break
                                         0xFF};
 static void test_bstring_indef_decoding_3(void **_CBOR_UNUSED(_state)) {
@@ -248,6 +248,126 @@ static void test_bstring_indef_decoding_3(void **_CBOR_UNUSED(_state)) {
   assert_indef_break();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(bstring_indef_3_data + 5, 1));
+}
+
+unsigned char string_embedded_int8_data[] = {0x61, 0xFF};
+static void test_string_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
+  assert_string_mem_eq(string_embedded_int8_data + 1, 1);
+  assert_decoder_result(2, CBOR_DECODER_FINISHED,
+                        decode(string_embedded_int8_data, 2));
+
+  assert_minimum_input_size(2, string_embedded_int8_data);
+}
+
+// The callback returns a *pointer* to the the start of the data segment (after
+// the second byte of input); the data is never read, so we never run into
+// memory issues despite not allocating and initializing all the data.
+unsigned char string_int8_data[] = {0x78, 0x02 /*, [2 bytes] */};
+static void test_string_int8_decoding(void **_CBOR_UNUSED(_state)) {
+  assert_string_mem_eq(string_int8_data + 2, 2);
+  assert_decoder_result(4, CBOR_DECODER_FINISHED, decode(string_int8_data, 4));
+
+  assert_minimum_input_size(2, string_int8_data);
+  assert_decoder_result_nedata(/* expected_bytes_required= */ 2 + 2,
+                               decode(string_int8_data, 2));
+}
+
+unsigned char string_int8_empty_data[] = {0x78, 0x00};
+static void test_string_int8_empty_decoding(void **_CBOR_UNUSED(_state)) {
+  assert_string_mem_eq(string_int8_empty_data + 2, 0);
+  assert_decoder_result(2, CBOR_DECODER_FINISHED,
+                        decode(string_int8_empty_data, 2));
+
+  assert_minimum_input_size(2, string_int8_empty_data);
+}
+
+unsigned char string_int16_data[] = {0x79, 0x01, 0x5C /*, [348 bytes] */};
+static void test_string_int16_decoding(void **_CBOR_UNUSED(_state)) {
+  assert_string_mem_eq(string_int16_data + 3, 348);
+  assert_decoder_result(3 + 348, CBOR_DECODER_FINISHED,
+                        decode(string_int16_data, 3 + 348));
+
+  assert_minimum_input_size(3, string_int16_data);
+  assert_decoder_result_nedata(/* expected_bytes_required= */ 3 + 348,
+                               decode(string_int16_data, 3));
+}
+
+unsigned char string_int32_data[] = {0x7A, 0x00, 0x10, 0x10,
+                                     0x10 /*, [1052688 bytes] */};
+static void test_string_int32_decoding(void **_CBOR_UNUSED(_state)) {
+  assert_string_mem_eq(string_int32_data + 5, 1052688);
+  assert_decoder_result(5 + 1052688, CBOR_DECODER_FINISHED,
+                        decode(string_int32_data, 5 + 1052688));
+
+  assert_minimum_input_size(5, string_int32_data);
+  assert_decoder_result_nedata(/* expected_bytes_required= */ 5 + 1052688,
+                               decode(string_int32_data, 5));
+}
+
+#ifdef EIGHT_BYTE_SIZE_T
+unsigned char string_int64_data[] = {
+    0x7B, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00 /*, [4294967296 bytes] */};
+static void test_string_int64_decoding(void **_CBOR_UNUSED(_state)) {
+  assert_string_mem_eq(string_int64_data + 9, 4294967296);
+  assert_decoder_result(9 + 4294967296, CBOR_DECODER_FINISHED,
+                        decode(string_int64_data, 9 + 4294967296));
+
+  assert_minimum_input_size(9, string_int64_data);
+  assert_decoder_result_nedata(/* expected_bytes_required= */ 9 + 4294967296,
+                               decode(string_int64_data, 9));
+}
+#endif
+
+unsigned char string_indef_1_data[] = {0x7F, 0x60 /* Empty string */, 0xFF};
+static void test_string_indef_decoding_1(void **_CBOR_UNUSED(_state)) {
+  assert_string_indef_start();
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_1_data, 3));
+
+  assert_string_mem_eq(string_indef_1_data + 2, 0);
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_1_data + 1, 2));
+
+  assert_indef_break();
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_1_data + 2, 1));
+}
+
+unsigned char string_indef_2_data[] = {0x7F, 0xFF};
+static void test_string_indef_decoding_2(void **_CBOR_UNUSED(_state)) {
+  assert_string_indef_start();
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_2_data, 2));
+
+  assert_indef_break();
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_2_data + 1, 1));
+}
+
+unsigned char string_indef_3_data[] = {0x7F,
+                                       // Empty string
+                                       0x60,
+                                       // 1B, 1 character byte string
+                                       0x78, 0x01, 0x00,
+                                       // Break
+                                       0xFF};
+static void test_string_indef_decoding_3(void **_CBOR_UNUSED(_state)) {
+  assert_string_indef_start();
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_3_data, 6));
+
+  assert_string_mem_eq(string_indef_3_data + 2, 0);
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_3_data + 1, 5));
+
+  assert_string_mem_eq(string_indef_3_data + 4, 1);
+  assert_decoder_result(3, CBOR_DECODER_FINISHED,
+                        decode(string_indef_3_data + 2, 4));
+
+  assert_indef_break();
+  assert_decoder_result(1, CBOR_DECODER_FINISHED,
+                        decode(string_indef_3_data + 5, 1));
 }
 
 unsigned char array_embedded_int8_data[] = {0x80};
@@ -582,6 +702,18 @@ int main(void) {
       stream_test(test_bstring_indef_decoding_1),
       stream_test(test_bstring_indef_decoding_2),
       stream_test(test_bstring_indef_decoding_3),
+
+      stream_test(test_string_embedded_int8_decoding),
+      stream_test(test_string_int8_decoding),
+      stream_test(test_string_int8_empty_decoding),
+      stream_test(test_string_int16_decoding),
+      stream_test(test_string_int32_decoding),
+#ifdef EIGHT_BYTE_SIZE_T
+      stream_test(test_string_int64_decoding),
+#endif
+      stream_test(test_string_indef_decoding_1),
+      stream_test(test_string_indef_decoding_2),
+      stream_test(test_string_indef_decoding_3),
 
       stream_test(test_array_embedded_int8_decoding),
       stream_test(test_array_int8_decoding),

--- a/test/cbor_stream_decode_test.c
+++ b/test/cbor_stream_decode_test.c
@@ -535,7 +535,7 @@ static void test_undef_decoding(void **_CBOR_UNUSED(_state)) {
   assert_decoder_result(1, CBOR_DECODER_FINISHED, decode(undef_data, 1));
 }
 
-#define stream_test(f) cmocka_unit_test_teardown(f, clear_stream_assertions)
+#define stream_test(f) cmocka_unit_test_teardown(f, clean_up_stream_assertions)
 
 int main(void) {
   const struct CMUnitTest tests[] = {

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -134,13 +134,13 @@ void byte_string_start_callback(void *_CBOR_UNUSED(_context)) {
 
 void assert_string_mem_eq(cbor_data address, size_t length) {
   assertions_queue[queue_size++] = (struct test_assertion){
-      BSTRING_MEM_EQ,
+      STRING_MEM_EQ,
       (union test_expectation_data){.string = {address, length}}};
 }
 
 void string_callback(void *_CBOR_UNUSED(_context), cbor_data address,
                      uint64_t length) {
-  assert_true(current().expectation == BSTRING_MEM_EQ);
+  assert_true(current().expectation == STRING_MEM_EQ);
   assert_true(current().data.string.address == address);
   assert_true(current().data.string.length == length);
   current_expectation++;
@@ -148,11 +148,11 @@ void string_callback(void *_CBOR_UNUSED(_context), cbor_data address,
 
 void assert_string_indef_start(void) {
   assertions_queue[queue_size++] =
-      (struct test_assertion){.expectation = BSTRING_INDEF_START};
+      (struct test_assertion){.expectation = STRING_INDEF_START};
 }
 
 void string_start_callback(void *_CBOR_UNUSED(_context)) {
-  assert_true(current().expectation == BSTRING_INDEF_START);
+  assert_true(current().expectation == STRING_INDEF_START);
   current_expectation++;
 }
 
@@ -295,6 +295,9 @@ const struct cbor_callbacks asserting_callbacks = {
 
     .byte_string = &byte_string_callback,
     .byte_string_start = &byte_string_start_callback,
+
+    .string = &string_callback,
+    .string_start = &string_start_callback,
 
     .array_start = &array_start_callback,
     .indef_array_start = &indef_array_start_callback,

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -132,6 +132,30 @@ void byte_string_start_callback(void *_CBOR_UNUSED(_context)) {
   current_expectation++;
 }
 
+void assert_string_mem_eq(cbor_data address, size_t length) {
+  assertions_queue[queue_size++] = (struct test_assertion){
+      BSTRING_MEM_EQ,
+      (union test_expectation_data){.string = {address, length}}};
+}
+
+void string_callback(void *_CBOR_UNUSED(_context), cbor_data address,
+                     uint64_t length) {
+  assert_true(current().expectation == BSTRING_MEM_EQ);
+  assert_true(current().data.string.address == address);
+  assert_true(current().data.string.length == length);
+  current_expectation++;
+}
+
+void assert_string_indef_start(void) {
+  assertions_queue[queue_size++] =
+      (struct test_assertion){.expectation = BSTRING_INDEF_START};
+}
+
+void string_start_callback(void *_CBOR_UNUSED(_context)) {
+  assert_true(current().expectation == BSTRING_INDEF_START);
+  current_expectation++;
+}
+
 void assert_indef_break(void) {
   assertions_queue[queue_size++] =
       (struct test_assertion){.expectation = INDEF_BREAK};

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -3,9 +3,6 @@
 struct test_assertion assertions_queue[MAX_QUEUE_ITEMS];
 int queue_size = 0;
 int current_expectation = 0;
-decoder_t *decoder;
-
-void set_decoder(decoder_t *dec) { decoder = dec; }
 
 int clear_stream_assertions(void **state) {
   if (queue_size != current_expectation) {
@@ -295,7 +292,7 @@ const struct cbor_callbacks asserting_callbacks = {
 struct cbor_decoder_result decode(cbor_data source, size_t source_size) {
   int last_expectation = current_expectation;
   struct cbor_decoder_result result =
-      decoder(source, source_size, &asserting_callbacks, NULL);
+      cbor_stream_decode(source, source_size, &asserting_callbacks, NULL);
   if (result.status == CBOR_DECODER_FINISHED) {
     // Check that we have matched an expectation from the queue
     assert_true(last_expectation + 1 == current_expectation);

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -4,7 +4,7 @@ struct test_assertion assertions_queue[MAX_QUEUE_ITEMS];
 int queue_size = 0;
 int current_expectation = 0;
 
-int clear_stream_assertions(void **state) {
+int clean_up_stream_assertions(void **state) {
   if (queue_size != current_expectation) {
     return 1;  // We have not matched all expectations correctly
   }

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -1,5 +1,5 @@
 #include "stream_expectations.h"
-/* Ordered from 0 to queue_size - 1 */
+
 struct test_assertion assertions_queue[MAX_QUEUE_ITEMS];
 int queue_size = 0;
 int current_expectation = 0;

--- a/test/stream_expectations.h
+++ b/test/stream_expectations.h
@@ -74,12 +74,7 @@ struct test_assertion {
   union test_expectation_data data;
 };
 
-/* Tested function */
-// TODO: This looks overengineered, we only ever use one (?) in the testsuite
-typedef struct cbor_decoder_result decoder_t(cbor_data, size_t,
-                                             const struct cbor_callbacks *,
-                                             void *);
-void set_decoder(decoder_t *);
+/* Test harness -- calls `cbor_stream_decode` and checks assertions */
 struct cbor_decoder_result decode(cbor_data, size_t);
 
 /* Test setup */

--- a/test/stream_expectations.h
+++ b/test/stream_expectations.h
@@ -1,25 +1,28 @@
-/*
- * This file provides testing tools for the streaming decoder. The intended
- * usage is as follows: 1) SE API wrapper is initialized 2) Client builds
- * (ordered) series of expectations 3) The decoder is executed 4) SE checks all
- * assertions 5) Go to 2) if desired
- */
-
 #ifndef STREAM_EXPECTATIONS_H_
 #define STREAM_EXPECTATIONS_H_
 
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include <cmocka.h>
 
-#include <stdint.h>
 #include "cbor.h"
 
 #define MAX_QUEUE_ITEMS 30
 
-// How this
+// Utilities to test `cbor_stream_decode`.  See `cbor_stream_decode_test.cc`.
+//
+// Usage:
+// - The `assert_` helpers build a queue of `test_assertion`s
+//   (`assertions_queue` in the implementation file), specifying
+//  - Which callback is expected (`test_expectation`)
+//  - And what is the expected argument value (if applicable,
+//    `test_expectation_data`)
+// - `decode` will invoke `cbor_stream_decode` (test subject)
+// - `cbor_stream_decode` will invoke one of the `_callback` functions, which
+//   will check the passed data against the `assertions_queue`
 
 enum test_expectation {
   UINT8_EQ,
@@ -77,8 +80,8 @@ struct test_assertion {
 /* Test harness -- calls `cbor_stream_decode` and checks assertions */
 struct cbor_decoder_result decode(cbor_data, size_t);
 
-/* Test setup */
-int clear_stream_assertions(void **);
+/* Verify all assertions were applied and clean up */
+int clean_up_stream_assertions(void **);
 
 /* Assertions builders */
 void assert_uint8_eq(uint8_t);

--- a/test/stream_expectations.h
+++ b/test/stream_expectations.h
@@ -17,9 +17,9 @@
 #include <stdint.h>
 #include "cbor.h"
 
-// TODO: This setup is overengineered, we currently use one assertion at a time
-// TOOD: We never ensure that the queue is empty
 #define MAX_QUEUE_ITEMS 30
+
+// How this
 
 enum test_expectation {
   UINT8_EQ,

--- a/test/stream_expectations.h
+++ b/test/stream_expectations.h
@@ -35,9 +35,12 @@ enum test_expectation {
   NEGINT32_EQ,
   NEGINT64_EQ,
 
-  BSTRING_MEM_EQ, /* Matches length and memory address for definite byte strings
-                   */
+  // Matches length and memory address for definite strings
+  BSTRING_MEM_EQ,
   BSTRING_INDEF_START,
+
+  STRING_MEM_EQ,
+  STRING_INDEF_START,
 
   ARRAY_START, /* Definite arrays only */
   ARRAY_INDEF_START,
@@ -97,6 +100,9 @@ void assert_negint64_eq(uint64_t);
 void assert_bstring_mem_eq(cbor_data, size_t);
 void assert_bstring_indef_start(void);
 
+void assert_string_mem_eq(cbor_data, size_t);
+void assert_string_indef_start(void);
+
 void assert_array_start(size_t);
 void assert_indef_array_start(void);
 
@@ -128,6 +134,9 @@ void negint64_callback(void *, uint64_t);
 
 void byte_string_callback(void *, cbor_data, uint64_t);
 void byte_string_start_callback(void *);
+
+void string_callback(void *, cbor_data, uint64_t);
+void string_start_callback(void *);
 
 void array_start_callback(void *, uint64_t);
 void indef_array_start_callback(void *);


### PR DESCRIPTION
Prerequisite/preparation for https://github.com/PJK/libcbor/issues/231