### PR TITLE
Add code coverage tooling for clang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     - run: sudo apt-get update
     - run: sudo apt-get install -y cmake "${TOOLCHAIN_PACKAGE}"
     - run: sudo apt install libcmocka-dev
-  build-test:
+  build:
     steps:
     - run: >
         cmake -DWITH_TESTS=ON \
@@ -15,7 +15,9 @@ commands:
           -DSANITIZE=OFF \
           -DCOVERAGE="${CMAKE_COVERAGE:='OFF'}" \
           .
-    - run: make VERBOSE=1
+    - run: make -j 16 VERBOSE=1
+  test:
+    steps:
     - run: ctest -VV
 
 orbs:
@@ -55,7 +57,7 @@ jobs:
       - checkout
       - linux-setup
       - run: sudo apt-get install -y valgrind
-      - build-test
+      - build
       - run: ctest -T Coverage
       - codecov/upload
       - run: ctest --output-on-failure -T memcheck | tee memcheck.out
@@ -74,7 +76,24 @@ jobs:
     steps:
       - checkout
       - linux-setup
-      - build-test
+      - build
+      - test
+
+
+  llvm-coverage:
+    machine:
+      image: ubuntu-2204:2022.10.2
+    environment:
+      TOOLCHAIN_PACKAGE: clang
+      CC: clang
+      CXX: clang++
+      CMAKE_COVERAGE: ON
+    steps:
+      - checkout
+      - linux-setup
+      - build
+      - run: make llvm-coverage
+
 
   build-and-test-arm:
     machine:
@@ -85,7 +104,8 @@ jobs:
     steps:
       - checkout
       - linux-setup
-      - build-test
+      - build
+      - test
 
   build-bazel:
     machine:
@@ -113,7 +133,8 @@ jobs:
       - checkout
       - run: bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       - run: brew install cmocka cmake
-      - build-test
+      - build
+      - test
 
 workflows:
   build-and-test:
@@ -122,11 +143,12 @@ workflows:
       - build-and-test
       - build-and-test-clang
       - build-and-test-arm
+      - build-bazel
+      - llvm-coverage
+      # OSX builds are expensive, run only on master
       - build-and-test-osx:
           requires:
             - build-and-test
           filters:
             branches:
-              only:
-                - master
-      - build-bazel
+              only: [master]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,19 +99,36 @@ add_custom_target(coverage
                   COMMAND ctest
                   COMMAND lcov --capture --directory . --output-file coverage.info
                   COMMAND genhtml coverage.info --highlight --legend --output-directory coverage_html
-                  COMMAND echo "Coverage report ready: file://${CMAKE_CURRENT_BINARY_DIR}/coverage_html/index.html")
+                  COMMAND echo "Coverage report ready: ${CMAKE_CURRENT_BINARY_DIR}/coverage_html/index.html")
+
+add_custom_target(llvm-coverage
+                    COMMAND make -j 16
+                    COMMAND rm -rf coverage_profiles
+                    COMMAND mkdir coverage_profiles
+                    COMMAND bash -c [[ for TEST in $(ls test/*_test); do LLVM_PROFILE_FILE="coverage_profiles/$(basename -- ${TEST}).profraw" ./${TEST}; done ]]
+                    # VERBATIM makes escaping working, but breaks shell expansions, so we need to explicitly use bash
+                    COMMAND bash -c [[ llvm-profdata merge -sparse $(ls coverage_profiles/*.profraw) -o coverage_profiles/combined.profdata ]]
+                    COMMAND bash -c [[ llvm-cov show -instr-profile=coverage_profiles/combined.profdata test/*_test -format=html > coverage_profiles/report.html ]]
+                    COMMAND bash -c [[ llvm-cov report -instr-profile=coverage_profiles/combined.profdata test/*_test ]]
+                    COMMAND echo "Coverage report ready: ${CMAKE_CURRENT_BINARY_DIR}/coverage_profiles/report.html"
+                    VERBATIM)
+
 include_directories(src)
 
 
 option(c "Enable code coverage instrumentation" OFF)
 if (COVERAGE)
     message("Configuring code coverage instrumentation")
-    if(NOT CMAKE_C_COMPILER MATCHES "gcc")
-        message(WARNING "Gcov instrumentation only works with GCC")
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU")
+        # https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fprofile-arcs -ftest-coverage --coverage")
+        set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -g -fprofile-arcs -ftest-coverage --coverage")
+    elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+        set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fprofile-instr-generate")
+    else()
+        message(WARNING "Code coverage build not implemented for compiler ${CMAKE_C_COMPILER_ID}")
     endif()
-    # https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fprofile-arcs -ftest-coverage --coverage")
-    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -g -fprofile-arcs -ftest-coverage --coverage")
 endif (COVERAGE)
 
 


### PR DESCRIPTION
 - For now keeping coveralls on gcov
 - Handy for OSX development 