### PR TITLE
Fix CI code coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
       - linux-setup
       - run: sudo apt-get install -y valgrind
       - build
+      - test
       - run: ctest -T Coverage
       - codecov/upload
       - run: ctest --output-on-failure -T memcheck | tee memcheck.out


### PR DESCRIPTION
Broken in https://github.com/PJK/libcbor/pull/238/files because `ctest -T coverage` doesn't automatically run the testsuite