### PR TITLE
Update, simplify, and speed up Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ platform:
   - x64
   - x86
 
+# Do not build feature branch with open Pull Requests
+# The build is redundant and gets queued behind the other one.
+skip_branch_with_pr: true
 
 # Via https://github.com/apitrace/apitrace/blob/master/appveyor.yml
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,21 @@
-image: Visual Studio 2015
+image: 
+  - Visual Studio 2015
+  - Visual Studio 2022
 version: '{build}'
 
 branches:
   except:
     - gh-pages
 
-platform: x64
+platform: 
+  - x64
+  - x86
 
-
-environment:
-  matrix:
-  - CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
 
 # Via https://github.com/apitrace/apitrace/blob/master/appveyor.yml
 
 before_build:
-- cmake -H. -Bbuild -G "%CMAKE_GENERATOR%"
-- C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\CL.exe /?
+- cmake -H. -Bbuild
 
 build_script:
 - if "%APPVEYOR_REPO_TAG%"=="true" (set CONFIGURATION=RelWithDebInfo) else (set CONFIGURATION=Debug)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,45 @@
-image: 
-  - Visual Studio 2015
-  - Visual Studio 2022
-version: '{build}'
+# Fast single-config build for PRs
+-
+  branches:
+    except: [master]
+ 
+  image: Visual Studio 2022
+  version: '{build}'
 
-branches:
-  except:
-    - gh-pages
+  platform: x64
 
-platform: 
-  - x64
-  - x86
+  # Do not build feature branch with open Pull Requests
+  # The build is redundant and gets queued behind the other one.
+  skip_branch_with_pr: true
 
-# Do not build feature branch with open Pull Requests
-# The build is redundant and gets queued behind the other one.
-skip_branch_with_pr: true
+  before_build:
+  - cmake -H. -Bbuild
 
-# Via https://github.com/apitrace/apitrace/blob/master/appveyor.yml
+  build_script:
+  - if "%APPVEYOR_REPO_TAG%"=="true" (set CONFIGURATION=RelWithDebInfo) else (set CONFIGURATION=Debug)
+  - cmake --build build --config "%CONFIGURATION%"
 
-before_build:
-- cmake -H. -Bbuild
+- 
+  branches:
+    only: [master]
+ 
+  image: 
+    - Visual Studio 2015
+    - Visual Studio 2022
+  version: '{build}'
 
-build_script:
-- if "%APPVEYOR_REPO_TAG%"=="true" (set CONFIGURATION=RelWithDebInfo) else (set CONFIGURATION=Debug)
-- cmake --build build --config "%CONFIGURATION%"
+  platform: 
+    - x64
+    - x86
+
+  skip_branch_with_pr: true
+
+  before_build:
+  - cmake -H. -Bbuild
+
+  build_script:
+  - if "%APPVEYOR_REPO_TAG%"=="true" (set CONFIGURATION=RelWithDebInfo) else (set CONFIGURATION=Debug)
+  - cmake --build build --config "%CONFIGURATION%"
 
 # TODO enable CMocka tests, maybe package the binaries
 # TODO add MinGW
-# TODO add older MSVC


### PR DESCRIPTION
## Description

- Use 2022 VS
- Run a single build on PRs (Appveyor was often the blocking check)
- Run both x84 and x64 builds 
