### PR TITLE
Trim down Appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,45 +1,14 @@
-# Fast single-config build for PRs
--
-  branches:
-    except: [master]
- 
-  image: Visual Studio 2022
-  version: '{build}'
+image: Visual Studio 2022
+version: '{build}'
+platform: x64
 
-  platform: x64
+skip_branch_with_pr: true
 
-  # Do not build feature branch with open Pull Requests
-  # The build is redundant and gets queued behind the other one.
-  skip_branch_with_pr: true
+before_build:
+- cmake -H. -Bbuild
 
-  before_build:
-  - cmake -H. -Bbuild
-
-  build_script:
-  - if "%APPVEYOR_REPO_TAG%"=="true" (set CONFIGURATION=RelWithDebInfo) else (set CONFIGURATION=Debug)
-  - cmake --build build --config "%CONFIGURATION%"
-
-- 
-  branches:
-    only: [master]
- 
-  image: 
-    - Visual Studio 2015
-    - Visual Studio 2022
-  version: '{build}'
-
-  platform: 
-    - x64
-    - x86
-
-  skip_branch_with_pr: true
-
-  before_build:
-  - cmake -H. -Bbuild
-
-  build_script:
-  - if "%APPVEYOR_REPO_TAG%"=="true" (set CONFIGURATION=RelWithDebInfo) else (set CONFIGURATION=Debug)
-  - cmake --build build --config "%CONFIGURATION%"
+build_script:
+- if "%APPVEYOR_REPO_TAG%"=="true" (set CONFIGURATION=RelWithDebInfo) else (set CONFIGURATION=Debug)
+- cmake --build build --config "%CONFIGURATION%"
 
 # TODO enable CMocka tests, maybe package the binaries
-# TODO add MinGW


### PR DESCRIPTION
The branch-specific config was still triggering the big build on all PRs (https://ci.appveyor.com/project/PJK/libcbor/builds/45784768) because they go to "master" :(