### PR TITLE
Add [[nodiscard]]-like macro and fix a few violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Next
 - Fix a potential memory leak when the allocator fails during array or map decoding [[#224]](https://github.com/PJK/libcbor/pull/224) (by [James-ZHANG](https://github.com/James-ZHANG))
 - [Fix a memory leak when the allocator fails when adding chunks to indefinite bytestrings.](https://github.com/PJK/libcbor/pull/242) ([discovered](https://github.com/PJK/libcbor/pull/228) by [James-ZHANG](https://github.com/James-ZHANG))
 - [Fix a memory leak when the allocator fails when adding chunks to indefinite strings](https://github.com/PJK/libcbor/pull/246)
+- Potentially BUILD BREAKING: [Add nodiscard attributes to most functions](https://github.com/PJK/libcbor/pull/248)
+  - **Warning**: This may cause new build warnings and (in rare cases, depending on your configuration) errors
 
 
 0.9.0 (2021-11-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Next
   - See https://repology.org/project/cmake/versions for support; the vast majority of users should not be affected.
 - Fix a potential memory leak when the allocator fails during array or map decoding [[#224]](https://github.com/PJK/libcbor/pull/224) (by [James-ZHANG](https://github.com/James-ZHANG))
 - [Fix a memory leak when the allocator fails when adding chunks to indefinite bytestrings.](https://github.com/PJK/libcbor/pull/242) ([discovered](https://github.com/PJK/libcbor/pull/228) by [James-ZHANG](https://github.com/James-ZHANG))
+- [Fix a memory leak when the allocator fails when adding chunks to indefinite strings](https://github.com/PJK/libcbor/pull/246)
+
 
 0.9.0 (2021-11-14)
 ---------------------

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -152,6 +152,9 @@ static cbor_item_t *_cbor_copy_float_ctrl(cbor_item_t *item) {
 }
 
 cbor_item_t *cbor_copy(cbor_item_t *item) {
+  // TODO: Handle memory allocation error -- currently the code will produce
+  // partial or invalid items on failure
+
   // cppcheck-suppress missingReturn
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -43,8 +43,8 @@ extern "C" {
  * @return **new** CBOR item or `NULL` on failure. In that case, \p result
  * contains location and description of the error.
  */
-CBOR_EXPORT cbor_item_t* cbor_load(cbor_data source, size_t source_size,
-                                   struct cbor_load_result* result);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_load(
+    cbor_data source, size_t source_size, struct cbor_load_result* result);
 
 /** Deep copy of an item
  *
@@ -53,7 +53,7 @@ CBOR_EXPORT cbor_item_t* cbor_load(cbor_data source, size_t source_size,
  * @param item[borrow] item to copy
  * @return **new** CBOR deep copy
  */
-CBOR_EXPORT cbor_item_t* cbor_copy(cbor_item_t* item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_copy(cbor_item_t* item);
 
 #if CBOR_PRETTY_PRINTER
 #include <stdio.h>

--- a/src/cbor/arrays.h
+++ b/src/cbor/arrays.h
@@ -20,6 +20,7 @@ extern "C" {
  * @param item[borrow] An array
  * @return The number of members
  */
+_CBOR_NODISCARD
 CBOR_EXPORT size_t cbor_array_size(const cbor_item_t* item);
 
 /** Get the size of the allocated storage
@@ -27,6 +28,7 @@ CBOR_EXPORT size_t cbor_array_size(const cbor_item_t* item);
  * @param item[borrow] An array
  * @return The size of the allocated storage (number of items)
  */
+_CBOR_NODISCARD
 CBOR_EXPORT size_t cbor_array_allocated(const cbor_item_t* item);
 
 /** Get item by index
@@ -35,6 +37,7 @@ CBOR_EXPORT size_t cbor_array_allocated(const cbor_item_t* item);
  * @param index The index
  * @return **incref** The item, or `NULL` in case of boundary violation
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t* cbor_array_get(const cbor_item_t* item, size_t index);
 
 /** Set item by index
@@ -47,6 +50,7 @@ CBOR_EXPORT cbor_item_t* cbor_array_get(const cbor_item_t* item, size_t index);
  * @param index The index, first item is 0.
  * @return true on success, false on allocation failure.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_array_set(cbor_item_t* item, size_t index,
                                 cbor_item_t* value);
 
@@ -59,6 +63,7 @@ CBOR_EXPORT bool cbor_array_set(cbor_item_t* item, size_t index,
  * @param index The index, first item is 0.
  * @return true on success, false on allocation failure.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_array_replace(cbor_item_t* item, size_t index,
                                     cbor_item_t* value);
 
@@ -67,6 +72,7 @@ CBOR_EXPORT bool cbor_array_replace(cbor_item_t* item, size_t index,
  * @param item[borrow] An array
  * @return Is the array definite?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_array_is_definite(const cbor_item_t* item);
 
 /** Is the array indefinite?
@@ -74,6 +80,7 @@ CBOR_EXPORT bool cbor_array_is_definite(const cbor_item_t* item);
  * @param item[borrow] An array
  * @return Is the array indefinite?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_array_is_indefinite(const cbor_item_t* item);
 
 /** Get the array contents
@@ -84,6 +91,7 @@ CBOR_EXPORT bool cbor_array_is_indefinite(const cbor_item_t* item);
  * @param item[borrow] An array
  * @return #cbor_array_size items
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t** cbor_array_handle(const cbor_item_t* item);
 
 /** Create new definite array
@@ -91,12 +99,14 @@ CBOR_EXPORT cbor_item_t** cbor_array_handle(const cbor_item_t* item);
  * @param size Number of slots to preallocate
  * @return **new** array or `NULL` upon malloc failure
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t* cbor_new_definite_array(size_t size);
 
 /** Create new indefinite array
  *
  * @return **new** array or `NULL` upon malloc failure
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t* cbor_new_indefinite_array(void);
 
 /** Append to the end
@@ -108,6 +118,7 @@ CBOR_EXPORT cbor_item_t* cbor_new_indefinite_array(void);
  * @param pushee[incref] The item to push
  * @return true on success, false on failure
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_array_push(cbor_item_t* array, cbor_item_t* pushee);
 
 #ifdef __cplusplus

--- a/src/cbor/bytestrings.h
+++ b/src/cbor/bytestrings.h
@@ -28,6 +28,7 @@ extern "C" {
  * @param item[borrow] a definite bytestring
  * @return length of the binary data. Zero if no chunk has been attached yet
  */
+_CBOR_NODISCARD
 CBOR_EXPORT size_t cbor_bytestring_length(const cbor_item_t *item);
 
 /** Is the byte string definite?
@@ -35,6 +36,7 @@ CBOR_EXPORT size_t cbor_bytestring_length(const cbor_item_t *item);
  * @param item[borrow] a byte string
  * @return Is the byte string definite?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_bytestring_is_definite(const cbor_item_t *item);
 
 /** Is the byte string indefinite?
@@ -42,6 +44,7 @@ CBOR_EXPORT bool cbor_bytestring_is_definite(const cbor_item_t *item);
  * @param item[borrow] a byte string
  * @return Is the byte string indefinite?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_bytestring_is_indefinite(const cbor_item_t *item);
 
 /** Get the handle to the binary data
@@ -53,6 +56,7 @@ CBOR_EXPORT bool cbor_bytestring_is_indefinite(const cbor_item_t *item);
  * @return The address of the binary data. `NULL` if no data have been assigned
  * yet.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_mutable_data cbor_bytestring_handle(const cbor_item_t *item);
 
 /** Set the handle to the binary data
@@ -74,6 +78,7 @@ CBOR_EXPORT void cbor_bytestring_set_handle(
  * @param item[borrow] A indefinite byte string
  * @return array of #cbor_bytestring_chunk_count definite bytestrings
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t **cbor_bytestring_chunks_handle(
     const cbor_item_t *item);
 
@@ -82,6 +87,7 @@ CBOR_EXPORT cbor_item_t **cbor_bytestring_chunks_handle(
  * @param item[borrow] A indefinite bytestring
  * @return The chunk count. 0 for freshly created items.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT size_t cbor_bytestring_chunk_count(const cbor_item_t *item);
 
 /** Appends a chunk to the bytestring
@@ -95,6 +101,7 @@ CBOR_EXPORT size_t cbor_bytestring_chunk_count(const cbor_item_t *item);
  * @return true on success, false on realloc failure. In that case, the refcount
  * of `chunk` is not increased and the `item` is left intact.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_bytestring_add_chunk(cbor_item_t *item,
                                            cbor_item_t *chunk);
 
@@ -104,6 +111,7 @@ CBOR_EXPORT bool cbor_bytestring_add_chunk(cbor_item_t *item,
  *
  * @return **new** definite bytestring. `NULL` on malloc failure.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t *cbor_new_definite_bytestring(void);
 
 /** Creates a new indefinite byte string
@@ -112,6 +120,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_definite_bytestring(void);
  *
  * @return **new** indefinite bytestring. `NULL` on malloc failure.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t *cbor_new_indefinite_bytestring(void);
 
 /** Creates a new byte string and initializes it
@@ -123,6 +132,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_indefinite_bytestring(void);
  * @return A **new** byte string with content `handle`. `NULL` on malloc
  * failure.
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t *cbor_build_bytestring(cbor_data handle, size_t length);
 
 #ifdef __cplusplus

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -67,10 +67,15 @@ static const uint8_t cbor_patch_version = CBOR_PATCH_VERSION;
 
 #ifdef __GNUC__
 #define _CBOR_UNUSED(x) __attribute__((__unused__)) x
+// TODO(https://github.com/PJK/libcbor/issues/247): Prefer [[nodiscard]] if
+// available
+#define _CBOR_NODISCARD __attribute__((warn_unused_result))
 #elif defined(_MSC_VER)
 #define _CBOR_UNUSED(x) __pragma(warning(suppress : 4100 4101)) x
+#define _CBOR_NODISCARD
 #else
 #define _CBOR_UNUSED(x) x
+#define _CBOR_NODISCARD
 #endif
 
 // Macro to short-circuit builder functions when memory allocation fails
@@ -146,6 +151,7 @@ CBOR_EXPORT void cbor_set_allocs(_cbor_malloc_t custom_malloc,
  * @param item[borrow]
  * @return The type
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_type cbor_typeof(
     const cbor_item_t *item); /* Will be inlined iff link-time opt is enabled */
 
@@ -155,48 +161,56 @@ CBOR_EXPORT cbor_type cbor_typeof(
  * @param item[borrow] the item
  * @return Is the item an #CBOR_TYPE_UINT?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_uint(const cbor_item_t *item);
 
 /** Does the item have the appropriate major type?
  * @param item[borrow] the item
  * @return Is the item a #CBOR_TYPE_NEGINT?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_negint(const cbor_item_t *item);
 
 /** Does the item have the appropriate major type?
  * @param item[borrow] the item
  * @return Is the item a #CBOR_TYPE_BYTESTRING?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_bytestring(const cbor_item_t *item);
 
 /** Does the item have the appropriate major type?
  * @param item[borrow] the item
  * @return Is the item a #CBOR_TYPE_STRING?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_string(const cbor_item_t *item);
 
 /** Does the item have the appropriate major type?
  * @param item[borrow] the item
  * @return Is the item an #CBOR_TYPE_ARRAY?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_array(const cbor_item_t *item);
 
 /** Does the item have the appropriate major type?
  * @param item[borrow] the item
  * @return Is the item a #CBOR_TYPE_MAP?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_map(const cbor_item_t *item);
 
 /** Does the item have the appropriate major type?
  * @param item[borrow] the item
  * @return Is the item a #CBOR_TYPE_TAG?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_tag(const cbor_item_t *item);
 
 /** Does the item have the appropriate major type?
  * @param item[borrow] the item
  * @return Is the item a #CBOR_TYPE_FLOAT_CTRL?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_isa_float_ctrl(const cbor_item_t *item);
 
 /* Practical types with respect to their semantics (but not tag values) */
@@ -205,18 +219,21 @@ CBOR_EXPORT bool cbor_isa_float_ctrl(const cbor_item_t *item);
  * @param item[borrow] the item
  * @return  Is the item an integer, either positive or negative?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_is_int(const cbor_item_t *item);
 
 /** Is the item an a floating point number?
  * @param item[borrow] the item
  * @return  Is the item a floating point number?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_is_float(const cbor_item_t *item);
 
 /** Is the item an a boolean?
  * @param item[borrow] the item
  * @return  Is the item a boolean?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_is_bool(const cbor_item_t *item);
 
 /** Does this item represent `null`
@@ -229,6 +246,7 @@ CBOR_EXPORT bool cbor_is_bool(const cbor_item_t *item);
  * @param item[borrow] the item
  * @return  Is the item (CBOR logical) null?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_is_null(const cbor_item_t *item);
 
 /** Does this item represent `undefined`
@@ -241,6 +259,7 @@ CBOR_EXPORT bool cbor_is_null(const cbor_item_t *item);
  * @param item[borrow] the item
  * @return Is the item (CBOR logical) undefined?
  */
+_CBOR_NODISCARD
 CBOR_EXPORT bool cbor_is_undef(const cbor_item_t *item);
 
 /*
@@ -285,6 +304,7 @@ CBOR_EXPORT void cbor_intermediate_decref(cbor_item_t *item);
  * @param item[borrow] the item
  * @return the reference count
  */
+_CBOR_NODISCARD
 CBOR_EXPORT size_t cbor_refcount(const cbor_item_t *item);
 
 /** Provides CPP-like move construct
@@ -302,6 +322,7 @@ CBOR_EXPORT size_t cbor_refcount(const cbor_item_t *item);
  * @param item[take] the item
  * @return the item with reference count decreased by one
  */
+_CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t *cbor_move(cbor_item_t *item);
 
 #ifdef __cplusplus

--- a/src/cbor/encoding.h
+++ b/src/cbor/encoding.h
@@ -27,50 +27,76 @@ extern "C" {
  * case it is not modified).
  */
 
-CBOR_EXPORT size_t cbor_encode_uint8(uint8_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint8(uint8_t, unsigned char *,
+                                                     size_t);
 
-CBOR_EXPORT size_t cbor_encode_uint16(uint16_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint16(uint16_t, unsigned char *,
+                                                      size_t);
 
-CBOR_EXPORT size_t cbor_encode_uint32(uint32_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint32(uint32_t, unsigned char *,
+                                                      size_t);
 
-CBOR_EXPORT size_t cbor_encode_uint64(uint64_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint64(uint64_t, unsigned char *,
+                                                      size_t);
 
-CBOR_EXPORT size_t cbor_encode_uint(uint64_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint(uint64_t, unsigned char *,
+                                                    size_t);
 
-CBOR_EXPORT size_t cbor_encode_negint8(uint8_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint8(uint8_t, unsigned char *,
+                                                       size_t);
 
-CBOR_EXPORT size_t cbor_encode_negint16(uint16_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint16(uint16_t,
+                                                        unsigned char *,
+                                                        size_t);
 
-CBOR_EXPORT size_t cbor_encode_negint32(uint32_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint32(uint32_t,
+                                                        unsigned char *,
+                                                        size_t);
 
-CBOR_EXPORT size_t cbor_encode_negint64(uint64_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint64(uint64_t,
+                                                        unsigned char *,
+                                                        size_t);
 
-CBOR_EXPORT size_t cbor_encode_negint(uint64_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint(uint64_t, unsigned char *,
+                                                      size_t);
 
-CBOR_EXPORT size_t cbor_encode_bytestring_start(size_t, unsigned char *,
-                                                size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_bytestring_start(size_t,
+                                                                unsigned char *,
+                                                                size_t);
 
-CBOR_EXPORT size_t cbor_encode_indef_bytestring_start(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_encode_indef_bytestring_start(unsigned char *, size_t);
 
-CBOR_EXPORT size_t cbor_encode_string_start(size_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_string_start(size_t,
+                                                            unsigned char *,
+                                                            size_t);
 
-CBOR_EXPORT size_t cbor_encode_indef_string_start(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_encode_indef_string_start(unsigned char *, size_t);
 
-CBOR_EXPORT size_t cbor_encode_array_start(size_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_array_start(size_t,
+                                                           unsigned char *,
+                                                           size_t);
 
-CBOR_EXPORT size_t cbor_encode_indef_array_start(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_encode_indef_array_start(unsigned char *, size_t);
 
-CBOR_EXPORT size_t cbor_encode_map_start(size_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_map_start(size_t,
+                                                         unsigned char *,
+                                                         size_t);
 
-CBOR_EXPORT size_t cbor_encode_indef_map_start(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_indef_map_start(unsigned char *,
+                                                               size_t);
 
-CBOR_EXPORT size_t cbor_encode_tag(uint64_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_tag(uint64_t, unsigned char *,
+                                                   size_t);
 
-CBOR_EXPORT size_t cbor_encode_bool(bool, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_bool(bool, unsigned char *,
+                                                    size_t);
 
-CBOR_EXPORT size_t cbor_encode_null(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_null(unsigned char *, size_t);
 
-CBOR_EXPORT size_t cbor_encode_undef(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_undef(unsigned char *, size_t);
 
 /** Encodes a half-precision float
  *
@@ -93,15 +119,19 @@ CBOR_EXPORT size_t cbor_encode_undef(unsigned char *, size_t);
  *   - In all other cases, the sign bit, the exponent, and 10 most significant
  * bits of the significand are kept
  */
-CBOR_EXPORT size_t cbor_encode_half(float, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_half(float, unsigned char *,
+                                                    size_t);
 
-CBOR_EXPORT size_t cbor_encode_single(float, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_single(float, unsigned char *,
+                                                      size_t);
 
-CBOR_EXPORT size_t cbor_encode_double(double, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_double(double, unsigned char *,
+                                                      size_t);
 
-CBOR_EXPORT size_t cbor_encode_break(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_break(unsigned char *, size_t);
 
-CBOR_EXPORT size_t cbor_encode_ctrl(uint8_t, unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_ctrl(uint8_t, unsigned char *,
+                                                    size_t);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/floats_ctrls.h
+++ b/src/cbor/floats_ctrls.h
@@ -26,14 +26,16 @@ extern "C" {
  * @param item[borrow] A float or ctrl item
  * @return Is this a ctrl value?
  */
-CBOR_EXPORT bool cbor_float_ctrl_is_ctrl(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_float_ctrl_is_ctrl(
+    const cbor_item_t *item);
 
 /** Get the float width
  *
  * @param item[borrow] A float or ctrl item
  * @return The width.
  */
-CBOR_EXPORT cbor_float_width cbor_float_get_width(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_float_width
+cbor_float_get_width(const cbor_item_t *item);
 
 /** Get a half precision float
  *
@@ -42,7 +44,8 @@ CBOR_EXPORT cbor_float_width cbor_float_get_width(const cbor_item_t *item);
  * @param[borrow] A half precision float
  * @return half precision value
  */
-CBOR_EXPORT float cbor_float_get_float2(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT float cbor_float_get_float2(
+    const cbor_item_t *item);
 
 /** Get a single precision float
  *
@@ -51,7 +54,8 @@ CBOR_EXPORT float cbor_float_get_float2(const cbor_item_t *item);
  * @param[borrow] A single precision float
  * @return single precision value
  */
-CBOR_EXPORT float cbor_float_get_float4(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT float cbor_float_get_float4(
+    const cbor_item_t *item);
 
 /** Get a double precision float
  *
@@ -60,7 +64,8 @@ CBOR_EXPORT float cbor_float_get_float4(const cbor_item_t *item);
  * @param[borrow] A double precision float
  * @return double precision value
  */
-CBOR_EXPORT double cbor_float_get_float8(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT double cbor_float_get_float8(
+    const cbor_item_t *item);
 
 /** Get the float value represented as double
  *
@@ -69,14 +74,15 @@ CBOR_EXPORT double cbor_float_get_float8(const cbor_item_t *item);
  * @param[borrow] Any float
  * @return double precision value
  */
-CBOR_EXPORT double cbor_float_get_float(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT double cbor_float_get_float(
+    const cbor_item_t *item);
 
 /** Get value from a boolean ctrl item
  *
  * @param item[borrow] A ctrl item
  * @return boolean value
  */
-CBOR_EXPORT bool cbor_get_bool(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_get_bool(const cbor_item_t *item);
 
 /** Constructs a new ctrl item
  *
@@ -84,7 +90,7 @@ CBOR_EXPORT bool cbor_get_bool(const cbor_item_t *item);
  *
  * @return **new** 1B ctrl or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_ctrl(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_ctrl(void);
 
 /** Constructs a new float item
  *
@@ -92,7 +98,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_ctrl(void);
  *
  * @return **new** 2B float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_float2(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float2(void);
 
 /** Constructs a new float item
  *
@@ -100,7 +106,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_float2(void);
  *
  * @return **new** 4B float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_float4(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float4(void);
 
 /** Constructs a new float item
  *
@@ -108,26 +114,26 @@ CBOR_EXPORT cbor_item_t *cbor_new_float4(void);
  *
  * @return **new** 8B float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_float8(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float8(void);
 
 /** Constructs new null ctrl item
  *
  * @return **new** null ctrl item or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_null(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_null(void);
 
 /** Constructs new undef ctrl item
  *
  * @return **new** undef ctrl item or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_undef(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_undef(void);
 
 /** Constructs new boolean ctrl item
  *
  * @param value The value to use
  * @return **new** boolean ctrl item or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_bool(bool value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_bool(bool value);
 
 /** Assign a control value
  *
@@ -175,35 +181,35 @@ CBOR_EXPORT void cbor_set_float8(cbor_item_t *item, double value);
  * @param item[borrow] A ctrl item
  * @return the simple value
  */
-CBOR_EXPORT uint8_t cbor_ctrl_value(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint8_t cbor_ctrl_value(const cbor_item_t *item);
 
 /** Constructs a new float
  *
  * @param value the value to use
  * @return **new** float
  */
-CBOR_EXPORT cbor_item_t *cbor_build_float2(float value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float2(float value);
 
 /** Constructs a new float
  *
  * @param value the value to use
  * @return **new** float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_float4(float value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float4(float value);
 
 /** Constructs a new float
  *
  * @param value the value to use
  * @return **new** float or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_float8(double value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float8(double value);
 
 /** Constructs a ctrl item
  *
  * @param value the value to use
  * @return **new** ctrl item or `NULL` upon memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_ctrl(uint8_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_ctrl(uint8_t value);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/internal/encoders.h
+++ b/src/cbor/internal/encoders.h
@@ -14,18 +14,23 @@
 extern "C" {
 #endif
 
+_CBOR_NODISCARD
 size_t _cbor_encode_uint8(uint8_t value, unsigned char *buffer,
                           size_t buffer_size, uint8_t offset);
 
+_CBOR_NODISCARD
 size_t _cbor_encode_uint16(uint16_t value, unsigned char *buffer,
                            size_t buffer_size, uint8_t offset);
 
+_CBOR_NODISCARD
 size_t _cbor_encode_uint32(uint32_t value, unsigned char *buffer,
                            size_t buffer_size, uint8_t offset);
 
+_CBOR_NODISCARD
 size_t _cbor_encode_uint64(uint64_t value, unsigned char *buffer,
                            size_t buffer_size, uint8_t offset);
 
+_CBOR_NODISCARD
 size_t _cbor_encode_uint(uint64_t value, unsigned char *buffer,
                          size_t buffer_size, uint8_t offset);
 

--- a/src/cbor/internal/loaders.h
+++ b/src/cbor/internal/loaders.h
@@ -15,18 +15,25 @@ extern "C" {
 #endif
 
 /* Read the given uint from the given location, no questions asked */
+_CBOR_NODISCARD
 uint8_t _cbor_load_uint8(const unsigned char *source);
 
+_CBOR_NODISCARD
 uint16_t _cbor_load_uint16(const unsigned char *source);
 
+_CBOR_NODISCARD
 uint32_t _cbor_load_uint32(const unsigned char *source);
 
+_CBOR_NODISCARD
 uint64_t _cbor_load_uint64(const unsigned char *source);
 
+_CBOR_NODISCARD
 float _cbor_load_half(cbor_data source);
 
+_CBOR_NODISCARD
 float _cbor_load_float(cbor_data source);
 
+_CBOR_NODISCARD
 double _cbor_load_double(cbor_data source);
 
 #ifdef __cplusplus

--- a/src/cbor/internal/memory_utils.h
+++ b/src/cbor/internal/memory_utils.h
@@ -11,7 +11,10 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "cbor/common.h"
+
 /** Can a and b be multiplied without overflowing size_t? */
+_CBOR_NODISCARD
 bool _cbor_safe_to_multiply(size_t a, size_t b);
 
 /** Overflow-proof contiguous array allocation

--- a/src/cbor/internal/stack.h
+++ b/src/cbor/internal/stack.h
@@ -37,10 +37,12 @@ struct _cbor_stack {
   size_t size;
 };
 
+_CBOR_NODISCARD
 struct _cbor_stack _cbor_stack_init(void);
 
 void _cbor_stack_pop(struct _cbor_stack *);
 
+_CBOR_NODISCARD
 struct _cbor_stack_record *_cbor_stack_push(struct _cbor_stack *, cbor_item_t *,
                                             size_t);
 

--- a/src/cbor/internal/unicode.h
+++ b/src/cbor/internal/unicode.h
@@ -22,6 +22,7 @@ struct _cbor_unicode_status {
   uint64_t location;
 };
 
+_CBOR_NODISCARD
 uint64_t _cbor_unicode_codepoint_count(cbor_data source, uint64_t source_length,
                                        struct _cbor_unicode_status* status);
 

--- a/src/cbor/ints.h
+++ b/src/cbor/ints.h
@@ -26,35 +26,35 @@ extern "C" {
  * @param item[borrow] positive or negative integer
  * @return the value
  */
-CBOR_EXPORT uint8_t cbor_get_uint8(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint8_t cbor_get_uint8(const cbor_item_t *item);
 
 /** Extracts the integer value
  *
  * @param item[borrow] positive or negative integer
  * @return the value
  */
-CBOR_EXPORT uint16_t cbor_get_uint16(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint16_t cbor_get_uint16(const cbor_item_t *item);
 
 /** Extracts the integer value
  *
  * @param item[borrow] positive or negative integer
  * @return the value
  */
-CBOR_EXPORT uint32_t cbor_get_uint32(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint32_t cbor_get_uint32(const cbor_item_t *item);
 
 /** Extracts the integer value
  *
  * @param item[borrow] positive or negative integer
  * @return the value
  */
-CBOR_EXPORT uint64_t cbor_get_uint64(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_get_uint64(const cbor_item_t *item);
 
 /** Extracts the integer value
  *
  * @param item[borrow] positive or negative integer
  * @return the value, extended to `uint64_t`
  */
-CBOR_EXPORT uint64_t cbor_get_int(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_get_int(const cbor_item_t *item);
 
 /** Assigns the integer value
  *
@@ -93,7 +93,8 @@ CBOR_EXPORT void cbor_set_uint64(cbor_item_t *item, uint64_t value);
  *  @param item[borrow] positive or negative integer item
  *  @return the width
  */
-CBOR_EXPORT cbor_int_width cbor_int_get_width(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_int_width
+cbor_int_get_width(const cbor_item_t *item);
 
 /** Marks the integer item as a positive integer
  *
@@ -118,7 +119,7 @@ CBOR_EXPORT void cbor_mark_negint(cbor_item_t *item);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int8(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int8(void);
 
 /** Allocates new integer with 2B width
  *
@@ -127,7 +128,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_int8(void);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int16(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int16(void);
 
 /** Allocates new integer with 4B width
  *
@@ -136,7 +137,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_int16(void);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int32(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int32(void);
 
 /** Allocates new integer with 8B width
  *
@@ -145,63 +146,63 @@ CBOR_EXPORT cbor_item_t *cbor_new_int32(void);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-CBOR_EXPORT cbor_item_t *cbor_new_int64(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int64(void);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_uint8(uint8_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint8(uint8_t value);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_uint16(uint16_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint16(uint16_t value);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_uint32(uint32_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint32(uint32_t value);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_uint64(uint64_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint64(uint64_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_negint8(uint8_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint8(uint8_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_negint16(uint16_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint16(uint16_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_negint32(uint32_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint32(uint32_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_build_negint64(uint64_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint64(uint64_t value);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/maps.h
+++ b/src/cbor/maps.h
@@ -26,27 +26,27 @@ extern "C" {
  * @param item[borrow] A map
  * @return The number of pairs
  */
-CBOR_EXPORT size_t cbor_map_size(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_map_size(const cbor_item_t *item);
 
 /** Get the size of the allocated storage
  *
  * @param item[borrow] A map
  * @return Allocated storage size (as the number of #cbor_pair items)
  */
-CBOR_EXPORT size_t cbor_map_allocated(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_map_allocated(const cbor_item_t *item);
 
 /** Create a new definite map
  *
  * @param size The number of slots to preallocate
  * @return **new** definite map. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_definite_map(size_t size);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_definite_map(size_t size);
 
 /** Create a new indefinite map
  *
  * @return **new** indefinite map. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map(void);
 
 /** Add a pair to the map
  *
@@ -58,7 +58,8 @@ CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map(void);
  * @return `true` on success, `false` if either reallocation failed or the
  * preallocated storage is full
  */
-CBOR_EXPORT bool cbor_map_add(cbor_item_t *item, struct cbor_pair pair);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_map_add(cbor_item_t *item,
+                                              struct cbor_pair pair);
 
 /** Add a key to the map
  *
@@ -69,7 +70,8 @@ CBOR_EXPORT bool cbor_map_add(cbor_item_t *item, struct cbor_pair pair);
  * @return `true` on success, `false` if either reallocation failed or the
  * preallocated storage is full
  */
-CBOR_EXPORT bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key);
+_CBOR_NODISCARD CBOR_EXPORT bool _cbor_map_add_key(cbor_item_t *item,
+                                                   cbor_item_t *key);
 
 /** Add a value to the map
  *
@@ -80,21 +82,23 @@ CBOR_EXPORT bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key);
  * @return `true` on success, `false` if either reallocation failed or the
  * preallocated storage is full
  */
-CBOR_EXPORT bool _cbor_map_add_value(cbor_item_t *item, cbor_item_t *value);
+_CBOR_NODISCARD CBOR_EXPORT bool _cbor_map_add_value(cbor_item_t *item,
+                                                     cbor_item_t *value);
 
 /** Is this map definite?
  *
  * @param item[borrow] A map
  * @return Is this map definite?
  */
-CBOR_EXPORT bool cbor_map_is_definite(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_definite(const cbor_item_t *item);
 
 /** Is this map indefinite?
  *
  * @param item[borrow] A map
  * @return Is this map indefinite?
  */
-CBOR_EXPORT bool cbor_map_is_indefinite(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_indefinite(
+    const cbor_item_t *item);
 
 /** Get the pairs storage
  *
@@ -102,7 +106,8 @@ CBOR_EXPORT bool cbor_map_is_indefinite(const cbor_item_t *item);
  * @return Array of #cbor_map_size pairs. Manipulation is possible as long as
  * references remain valid.
  */
-CBOR_EXPORT struct cbor_pair *cbor_map_handle(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT struct cbor_pair *cbor_map_handle(
+    const cbor_item_t *item);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/serialization.h
+++ b/src/cbor/serialization.h
@@ -28,8 +28,9 @@ extern "C" {
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize(const cbor_item_t *item,
-                                  cbor_mutable_data buffer, size_t buffer_size);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize(const cbor_item_t *item,
+                                                  cbor_mutable_data buffer,
+                                                  size_t buffer_size);
 
 /** Serialize the given item, allocating buffers as needed
  *
@@ -44,9 +45,8 @@ CBOR_EXPORT size_t cbor_serialize(const cbor_item_t *item,
  * @return Length of the result. 0 on failure, in which case \p buffer is
  * ``NULL``.
  */
-CBOR_EXPORT size_t cbor_serialize_alloc(const cbor_item_t *item,
-                                        cbor_mutable_data *buffer,
-                                        size_t *buffer_size);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_alloc(
+    const cbor_item_t *item, cbor_mutable_data *buffer, size_t *buffer_size);
 
 /** Serialize an uint
  *
@@ -55,8 +55,9 @@ CBOR_EXPORT size_t cbor_serialize_alloc(const cbor_item_t *item,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_uint(const cbor_item_t *, cbor_mutable_data,
-                                       size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_uint(const cbor_item_t *,
+                                                       cbor_mutable_data,
+                                                       size_t);
 
 /** Serialize a negint
  *
@@ -65,8 +66,9 @@ CBOR_EXPORT size_t cbor_serialize_uint(const cbor_item_t *, cbor_mutable_data,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_negint(const cbor_item_t *, cbor_mutable_data,
-                                         size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_negint(const cbor_item_t *,
+                                                         cbor_mutable_data,
+                                                         size_t);
 
 /** Serialize a bytestring
  *
@@ -75,8 +77,8 @@ CBOR_EXPORT size_t cbor_serialize_negint(const cbor_item_t *, cbor_mutable_data,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_bytestring(const cbor_item_t *,
-                                             cbor_mutable_data, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_serialize_bytestring(const cbor_item_t *, cbor_mutable_data, size_t);
 
 /** Serialize a string
  *
@@ -85,8 +87,9 @@ CBOR_EXPORT size_t cbor_serialize_bytestring(const cbor_item_t *,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_string(const cbor_item_t *, cbor_mutable_data,
-                                         size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_string(const cbor_item_t *,
+                                                         cbor_mutable_data,
+                                                         size_t);
 
 /** Serialize an array
  *
@@ -95,8 +98,9 @@ CBOR_EXPORT size_t cbor_serialize_string(const cbor_item_t *, cbor_mutable_data,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_array(const cbor_item_t *, cbor_mutable_data,
-                                        size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_array(const cbor_item_t *,
+                                                        cbor_mutable_data,
+                                                        size_t);
 
 /** Serialize a map
  *
@@ -105,8 +109,9 @@ CBOR_EXPORT size_t cbor_serialize_array(const cbor_item_t *, cbor_mutable_data,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_map(const cbor_item_t *, cbor_mutable_data,
-                                      size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_map(const cbor_item_t *,
+                                                      cbor_mutable_data,
+                                                      size_t);
 
 /** Serialize a tag
  *
@@ -115,8 +120,9 @@ CBOR_EXPORT size_t cbor_serialize_map(const cbor_item_t *, cbor_mutable_data,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_tag(const cbor_item_t *, cbor_mutable_data,
-                                      size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_tag(const cbor_item_t *,
+                                                      cbor_mutable_data,
+                                                      size_t);
 
 /** Serialize a
  *
@@ -125,8 +131,8 @@ CBOR_EXPORT size_t cbor_serialize_tag(const cbor_item_t *, cbor_mutable_data,
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-CBOR_EXPORT size_t cbor_serialize_float_ctrl(const cbor_item_t *,
-                                             cbor_mutable_data, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_serialize_float_ctrl(const cbor_item_t *, cbor_mutable_data, size_t);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/streaming.h
+++ b/src/cbor/streaming.h
@@ -26,7 +26,7 @@ extern "C" {
  * @param callbacks The callback bundle
  * @param context An arbitrary pointer to allow for maintaining context.
  */
-CBOR_EXPORT struct cbor_decoder_result cbor_stream_decode(
+_CBOR_NODISCARD CBOR_EXPORT struct cbor_decoder_result cbor_stream_decode(
     cbor_data source, size_t source_size,
     const struct cbor_callbacks* callbacks, void* context);
 

--- a/src/cbor/strings.h
+++ b/src/cbor/strings.h
@@ -28,7 +28,7 @@ extern "C" {
  * @param item[borrow] a definite string
  * @return length of the string. Zero if no chunk has been attached yet
  */
-CBOR_EXPORT size_t cbor_string_length(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_string_length(const cbor_item_t *item);
 
 /** The number of codepoints in this string
  *
@@ -37,21 +37,24 @@ CBOR_EXPORT size_t cbor_string_length(const cbor_item_t *item);
  * @param item[borrow] A string
  * @return The number of codepoints in this string
  */
-CBOR_EXPORT size_t cbor_string_codepoint_count(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_string_codepoint_count(const cbor_item_t *item);
 
 /** Is the string definite?
  *
  * @param item[borrow] a string
  * @return Is the string definite?
  */
-CBOR_EXPORT bool cbor_string_is_definite(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_string_is_definite(
+    const cbor_item_t *item);
 
 /** Is the string indefinite?
  *
  * @param item[borrow] a string
  * @return Is the string indefinite?
  */
-CBOR_EXPORT bool cbor_string_is_indefinite(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_string_is_indefinite(
+    const cbor_item_t *item);
 
 /** Get the handle to the underlying string
  *
@@ -62,7 +65,8 @@ CBOR_EXPORT bool cbor_string_is_indefinite(const cbor_item_t *item);
  * @return The address of the underlying string. `NULL` if no data have been
  * assigned yet.
  */
-CBOR_EXPORT cbor_mutable_data cbor_string_handle(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_mutable_data
+cbor_string_handle(const cbor_item_t *item);
 
 /** Set the handle to the underlying string
  *
@@ -90,14 +94,16 @@ CBOR_EXPORT void cbor_string_set_handle(
  * @param item[borrow] A indefinite string
  * @return array of #cbor_string_chunk_count definite strings
  */
-CBOR_EXPORT cbor_item_t **cbor_string_chunks_handle(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t **cbor_string_chunks_handle(
+    const cbor_item_t *item);
 
 /** Get the number of chunks this string consist of
  *
  * @param item[borrow] A indefinite string
  * @return The chunk count. 0 for freshly created items.
  */
-CBOR_EXPORT size_t cbor_string_chunk_count(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_string_chunk_count(const cbor_item_t *item);
 
 /** Appends a chunk to the string
  *
@@ -110,7 +116,8 @@ CBOR_EXPORT size_t cbor_string_chunk_count(const cbor_item_t *item);
  * @return true on success. false on realloc failure. In that case, the refcount
  * of `chunk` is not increased and the `item` is left intact.
  */
-CBOR_EXPORT bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_string_add_chunk(cbor_item_t *item,
+                                                       cbor_item_t *chunk);
 
 /** Creates a new definite string
  *
@@ -118,7 +125,7 @@ CBOR_EXPORT bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk);
  *
  * @return **new** definite string. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_definite_string(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_definite_string(void);
 
 /** Creates a new indefinite string
  *
@@ -126,7 +133,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_definite_string(void);
  *
  * @return **new** indefinite string. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_new_indefinite_string(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_indefinite_string(void);
 
 /** Creates a new string and initializes it
  *
@@ -135,7 +142,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_indefinite_string(void);
  * @param val A null-terminated UTF-8 string
  * @return A **new** string with content `handle`. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_build_string(const char *val);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_string(const char *val);
 
 /** Creates a new string and initializes it
  *
@@ -144,7 +151,8 @@ CBOR_EXPORT cbor_item_t *cbor_build_string(const char *val);
  * @param val A UTF-8 string, at least \p length long (excluding the null byte)
  * @return A **new** string with content `handle`. `NULL` on malloc failure.
  */
-CBOR_EXPORT cbor_item_t *cbor_build_stringn(const char *val, size_t length);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_stringn(const char *val,
+                                                            size_t length);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/tags.h
+++ b/src/cbor/tags.h
@@ -27,21 +27,21 @@ extern "C" {
  * @return **new** tag. Item reference is `NULL`. Returns `NULL` upon
  * 	memory allocation failure
  */
-CBOR_EXPORT cbor_item_t *cbor_new_tag(uint64_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_tag(uint64_t value);
 
 /** Get the tagged item
  *
  * @param item[borrow] A tag
  * @return **incref** the tagged item
  */
-CBOR_EXPORT cbor_item_t *cbor_tag_item(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_tag_item(const cbor_item_t *item);
 
 /** Get tag value
  *
  * @param item[borrow] A tag
  * @return The tag value. Please consult the tag repository
  */
-CBOR_EXPORT uint64_t cbor_tag_value(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_tag_value(const cbor_item_t *item);
 
 /** Set the tagged item
  *
@@ -56,7 +56,8 @@ CBOR_EXPORT void cbor_tag_set_item(cbor_item_t *item, cbor_item_t *tagged_item);
  * @param value Tag value
  * @return **new** tag item
  */
-CBOR_EXPORT cbor_item_t *cbor_build_tag(uint64_t value, cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_tag(uint64_t value,
+                                                        cbor_item_t *item);
 
 #ifdef __cplusplus
 }

--- a/test/callbacks_test.c
+++ b/test/callbacks_test.c
@@ -38,7 +38,8 @@ unsigned char bytestring_data[] = {0x01, 0x02, 0x03};
 static void test_builder_byte_string_callback_append(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0);
+  assert_non_null(
+      _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,
@@ -77,7 +78,8 @@ static void test_builder_byte_string_callback_append(
 static void test_builder_byte_string_callback_append_alloc_failure(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0);
+  assert_non_null(
+      _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,
@@ -108,7 +110,8 @@ static void test_builder_byte_string_callback_append_alloc_failure(
 static void test_builder_byte_string_callback_append_item_alloc_failure(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0);
+  assert_non_null(
+      _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,
@@ -141,7 +144,8 @@ static void test_builder_byte_string_callback_append_item_alloc_failure(
 static void test_builder_byte_string_callback_append_parent_alloc_failure(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0);
+  assert_non_null(
+      _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,
@@ -174,7 +178,7 @@ static void test_builder_byte_string_callback_append_parent_alloc_failure(
 unsigned char string_data[] = {0x61, 0x62, 0x63};
 static void test_builder_string_callback_append(void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_string(), 0);
+  assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,
@@ -211,7 +215,7 @@ static void test_builder_string_callback_append(void** _CBOR_UNUSED(_state)) {
 static void test_builder_string_callback_append_alloc_failure(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_string(), 0);
+  assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,
@@ -242,7 +246,7 @@ static void test_builder_string_callback_append_alloc_failure(
 static void test_builder_string_callback_append_item_alloc_failure(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_string(), 0);
+  assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,
@@ -274,7 +278,7 @@ static void test_builder_string_callback_append_item_alloc_failure(
 static void test_builder_string_callback_append_parent_alloc_failure(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-  _cbor_stack_push(&stack, cbor_new_indefinite_string(), 0);
+  assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,

--- a/test/callbacks_test.c
+++ b/test/callbacks_test.c
@@ -278,11 +278,7 @@ static void test_builder_string_callback_append_item_alloc_failure(
 static void test_builder_string_callback_append_parent_alloc_failure(
     void** _CBOR_UNUSED(_state)) {
   struct _cbor_stack stack = _cbor_stack_init();
-<<<<<<< HEAD
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
-=======
-  _cbor_stack_push(&stack, cbor_new_indefinite_string(), 0);
->>>>>>> master
   struct _cbor_decoder_context context = {
       .creation_failed = false,
       .syntax_error = false,


### PR DESCRIPTION
## Description

First step towards https://github.com/PJK/libcbor/issues/247

Marking all functions where ignoring the return value 
- is dangerous, or
- doesn't make sense since the function has no other effect (indicates incorrect usage)

## Checklist

- [ ] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [x] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [x] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
