### PR TITLE
Add cbor_serialized_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Next
 - BREAKING: [Fix `cbor_copy` leaking memory and creating invalid items when the allocator fails](https://github.com/PJK/libcbor/pull/249).
   - Previously, the failures were not handled in the interface. Now, `cbor_copy` may return `NULL` upon failure; clients should check the return value
 - [Fix `cbor_build_tag` illegal memory behavior when the allocator fails](https://github.com/PJK/libcbor/pull/249)
+- [Add a new `cbor_serialized_size` API](https://github.com/PJK/libcbor/pull/250)
 
 
 0.9.0 (2021-11-14)

--- a/doc/source/api/encoding.rst
+++ b/doc/source/api/encoding.rst
@@ -6,6 +6,10 @@ The easiest way to encode data items is using the :func:`cbor_serialize` or :fun
 .. doxygenfunction:: cbor_serialize
 .. doxygenfunction:: cbor_serialize_alloc
 
+To determine the number of bytes needed to serialize an item, use :func:`cbor_serialized_size`:
+
+.. doxygenfunction:: cbor_serialized_size
+
 Type-specific serializers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In case you know the type of the item you want to serialize beforehand, you can use one

--- a/src/cbor/internal/memory_utils.c
+++ b/src/cbor/internal/memory_utils.c
@@ -23,7 +23,14 @@ size_t _cbor_highest_bit(size_t number) {
 }
 
 bool _cbor_safe_to_multiply(size_t a, size_t b) {
+  if (a <= 1 || b <= 1) return true;
   return _cbor_highest_bit(a) + _cbor_highest_bit(b) <= sizeof(size_t) * 8;
+}
+
+bool _cbor_safe_to_add(size_t a, size_t b) {
+  // Unsigned integer overflow doesn't constitute UB
+  size_t sum = a + b;
+  return sum >= a && sum >= b;
 }
 
 void* _cbor_alloc_multiple(size_t item_size, size_t item_count) {

--- a/src/cbor/internal/memory_utils.c
+++ b/src/cbor/internal/memory_utils.c
@@ -33,6 +33,12 @@ bool _cbor_safe_to_add(size_t a, size_t b) {
   return sum >= a && sum >= b;
 }
 
+size_t _cbor_safe_signaling_add(size_t a, size_t b) {
+  if (a == 0 || b == 0) return 0;
+  if (_cbor_safe_to_add(a, b)) return a + b;
+  return 0;
+}
+
 void* _cbor_alloc_multiple(size_t item_size, size_t item_count) {
   if (_cbor_safe_to_multiply(item_size, item_count)) {
     return _CBOR_MALLOC(item_size * item_count);

--- a/src/cbor/internal/memory_utils.h
+++ b/src/cbor/internal/memory_utils.h
@@ -13,9 +13,13 @@
 
 #include "cbor/common.h"
 
-/** Can a and b be multiplied without overflowing size_t? */
+/** Can `a` and `b` be multiplied without overflowing size_t? */
 _CBOR_NODISCARD
 bool _cbor_safe_to_multiply(size_t a, size_t b);
+
+/** Can `a` and `b` be added without overflowing size_t? */
+_CBOR_NODISCARD
+bool _cbor_safe_to_add(size_t a, size_t b);
 
 /** Overflow-proof contiguous array allocation
  *

--- a/src/cbor/internal/memory_utils.h
+++ b/src/cbor/internal/memory_utils.h
@@ -21,6 +21,10 @@ bool _cbor_safe_to_multiply(size_t a, size_t b);
 _CBOR_NODISCARD
 bool _cbor_safe_to_add(size_t a, size_t b);
 
+/** Adds `a` and `b`, propagating zeros and returing 0 on overflow. */
+_CBOR_NODISCARD
+size_t _cbor_safe_signaling_add(size_t a, size_t b);
+
 /** Overflow-proof contiguous array allocation
  *
  * @param item_size

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -19,6 +19,7 @@
 
 size_t cbor_serialize(const cbor_item_t *item, unsigned char *buffer,
                       size_t buffer_size) {
+  // cppcheck-suppress missingReturn
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
       return cbor_serialize_uint(item, buffer, buffer_size);
@@ -36,8 +37,6 @@ size_t cbor_serialize(const cbor_item_t *item, unsigned char *buffer,
       return cbor_serialize_tag(item, buffer, buffer_size);
     case CBOR_TYPE_FLOAT_CTRL:
       return cbor_serialize_float_ctrl(item, buffer, buffer_size);
-    default:
-      return 0;
   }
 }
 
@@ -74,6 +73,7 @@ size_t cbor_serialize_alloc(const cbor_item_t *item, unsigned char **buffer,
 size_t cbor_serialize_uint(const cbor_item_t *item, unsigned char *buffer,
                            size_t buffer_size) {
   assert(cbor_isa_uint(item));
+  // cppcheck-suppress missingReturn
   switch (cbor_int_get_width(item)) {
     case CBOR_INT_8:
       return cbor_encode_uint8(cbor_get_uint8(item), buffer, buffer_size);
@@ -83,14 +83,13 @@ size_t cbor_serialize_uint(const cbor_item_t *item, unsigned char *buffer,
       return cbor_encode_uint32(cbor_get_uint32(item), buffer, buffer_size);
     case CBOR_INT_64:
       return cbor_encode_uint64(cbor_get_uint64(item), buffer, buffer_size);
-    default:
-      return 0;
   }
 }
 
 size_t cbor_serialize_negint(const cbor_item_t *item, unsigned char *buffer,
                              size_t buffer_size) {
   assert(cbor_isa_negint(item));
+  // cppcheck-suppress missingReturn
   switch (cbor_int_get_width(item)) {
     case CBOR_INT_8:
       return cbor_encode_negint8(cbor_get_uint8(item), buffer, buffer_size);
@@ -100,8 +99,6 @@ size_t cbor_serialize_negint(const cbor_item_t *item, unsigned char *buffer,
       return cbor_encode_negint32(cbor_get_uint32(item), buffer, buffer_size);
     case CBOR_INT_64:
       return cbor_encode_negint64(cbor_get_uint64(item), buffer, buffer_size);
-    default:
-      return 0;
   }
 }
 
@@ -267,6 +264,7 @@ size_t cbor_serialize_tag(const cbor_item_t *item, unsigned char *buffer,
 size_t cbor_serialize_float_ctrl(const cbor_item_t *item, unsigned char *buffer,
                                  size_t buffer_size) {
   assert(cbor_isa_float_ctrl(item));
+  // cppcheck-suppress missingReturn
   switch (cbor_float_get_width(item)) {
     case CBOR_FLOAT_0:
       /* CTRL - special treatment */
@@ -280,7 +278,4 @@ size_t cbor_serialize_float_ctrl(const cbor_item_t *item, unsigned char *buffer,
       return cbor_encode_double(cbor_float_get_float8(item), buffer,
                                 buffer_size);
   }
-
-  /* Should never happen - make the compiler happy */
-  return 0;
 }

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -59,6 +59,7 @@ size_t _cbor_encoded_header_size(uint64_t size) {
 }
 
 size_t cbor_serialized_size(const cbor_item_t *item) {
+  // cppcheck-suppress missingReturn
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
     case CBOR_TYPE_NEGINT:

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -40,6 +40,42 @@ size_t cbor_serialize(const cbor_item_t *item, unsigned char *buffer,
   }
 }
 
+size_t cbor_serialized_size(const cbor_item_t *item) {
+  switch (cbor_typeof(item)) {
+    case CBOR_TYPE_UINT:
+    case CBOR_TYPE_NEGINT:
+      switch (cbor_int_get_width(item)) {
+        case CBOR_INT_8:
+          if (cbor_get_uint8(item) <= 23) return 1;
+          return 2;
+        case CBOR_INT_16:
+          return 3;
+        case CBOR_INT_32:
+          return 5;
+        case CBOR_INT_64:
+          return 9;
+      }
+    case CBOR_TYPE_BYTESTRING:
+      // TODO
+      return 0;
+    case CBOR_TYPE_STRING:
+      // TODO
+      return 0;
+    case CBOR_TYPE_ARRAY:
+      // TODO
+      return 0;
+    case CBOR_TYPE_MAP:
+      // TODO
+      return 0;
+    case CBOR_TYPE_TAG:
+      // TODO
+      return 0;
+    case CBOR_TYPE_FLOAT_CTRL:
+      // TODO
+      return 0;
+  }
+}
+
 size_t cbor_serialize_alloc(const cbor_item_t *item, unsigned char **buffer,
                             size_t *buffer_size) {
   size_t bfr_size = 32;

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -103,9 +103,17 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
       }
       return indef_string_size;
     }
-    case CBOR_TYPE_ARRAY:
-      // TODO
-      return 0;
+    case CBOR_TYPE_ARRAY: {
+      size_t array_size = cbor_array_is_definite(item)
+                              ? _cbor_encoded_header_size(cbor_array_size(item))
+                              : 2;  // Leading byte + break
+      cbor_item_t **items = cbor_array_handle(item);
+      for (size_t i = 0; i < cbor_array_size(item); i++) {
+        array_size = _cbor_safe_signaling_add(array_size,
+                                              cbor_serialized_size(items[i]));
+      }
+      return array_size;
+    }
     case CBOR_TYPE_MAP:
       // TODO
       return 0;

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -114,9 +114,19 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
       }
       return array_size;
     }
-    case CBOR_TYPE_MAP:
-      // TODO
-      return 0;
+    case CBOR_TYPE_MAP: {
+      size_t map_size = cbor_map_is_definite(item)
+                            ? _cbor_encoded_header_size(cbor_map_size(item))
+                            : 2;  // Leading byte + break
+      struct cbor_pair *items = cbor_map_handle(item);
+      for (size_t i = 0; i < cbor_map_size(item); i++) {
+        map_size = _cbor_safe_signaling_add(
+            map_size,
+            _cbor_safe_signaling_add(cbor_serialized_size(items[i].key),
+                                     cbor_serialized_size(items[i].value)));
+      }
+      return map_size;
+    }
     case CBOR_TYPE_TAG:
       // TODO
       return 0;

--- a/src/cbor/serialization.h
+++ b/src/cbor/serialization.h
@@ -32,6 +32,18 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize(const cbor_item_t *item,
                                                   cbor_mutable_data buffer,
                                                   size_t buffer_size);
 
+/** Compute the length (in bytes) of the item when serialized using
+ * `cbor_serialize`.
+ *
+ * Time complexity is proportional to the number of nested items.
+ *
+ * @param item[borrow] A data item
+ * @return Length (>= 1) of the item when serialized. 0 if the length overflows
+ * `size_t`.
+ */
+_CBOR_NODISCARD CBOR_EXPORT size_t
+cbor_serialized_size(const cbor_item_t *item);
+
 /** Serialize the given item, allocating buffers as needed
  *
  * \rst

--- a/src/cbor/strings.h
+++ b/src/cbor/strings.h
@@ -21,9 +21,10 @@ extern "C" {
  * ============================================================================
  */
 
-/** Returns the length of the underlying string
+/** Returns the length of the underlying string in bytes
  *
- * For definite strings only
+ * There can be fewer unicode character than bytes (see
+ * `cbor_string_codepoint_count`). For definite strings only.
  *
  * @param item[borrow] a definite string
  * @return length of the string. Zero if no chunk has been attached yet

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -201,6 +201,7 @@ static void test_serialize_definite_array(void **_CBOR_UNUSED(_state)) {
 
   assert_int_equal(3, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x82, 0x01, 0x02}), 3);
+  assert_int_equal(cbor_serialized_size(item), 3);
   cbor_decref(&item);
   cbor_decref(&one);
   cbor_decref(&two);
@@ -216,6 +217,7 @@ static void test_serialize_indefinite_array(void **_CBOR_UNUSED(_state)) {
 
   assert_int_equal(4, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x9F, 0x01, 0x02, 0xFF}), 4);
+  assert_int_equal(cbor_serialized_size(item), 4);
   cbor_decref(&item);
   cbor_decref(&one);
   cbor_decref(&two);

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -165,6 +165,7 @@ static void test_serialize_definite_string(void **_CBOR_UNUSED(_state)) {
       ((unsigned char[]){0x6C, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x77, 0x6F,
                          0x72, 0x6C, 0x64, 0x21}),
       13);
+  assert_int_equal(cbor_serialized_size(item), 13);
   cbor_decref(&item);
 }
 
@@ -185,6 +186,7 @@ static void test_serialize_indefinite_string(void **_CBOR_UNUSED(_state)) {
       ((unsigned char[]){0x7F, 0x6C, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x77,
                          0x6F, 0x72, 0x6C, 0x64, 0x21, 0xFF}),
       15);
+  assert_int_equal(cbor_serialized_size(item), 15);
   cbor_decref(&item);
 }
 

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -234,6 +234,7 @@ static void test_serialize_definite_map(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(5, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xA2, 0x01, 0x02, 0x02, 0x01}),
                       5);
+  assert_int_equal(cbor_serialized_size(item), 5);
   cbor_decref(&item);
   cbor_decref(&one);
   cbor_decref(&two);
@@ -250,6 +251,7 @@ static void test_serialize_indefinite_map(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(6, cbor_serialize(item, buffer, 512));
   assert_memory_equal(
       buffer, ((unsigned char[]){0xBF, 0x01, 0x02, 0x02, 0x01, 0xFF}), 6);
+  assert_int_equal(cbor_serialized_size(item), 6);
   cbor_decref(&item);
   cbor_decref(&one);
   cbor_decref(&two);

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -20,11 +20,21 @@
 
 unsigned char buffer[512];
 
-static void test_serialize_uint8(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_uint8_embed(void **_CBOR_UNUSED(_state)) {
   cbor_item_t *item = cbor_new_int8();
   cbor_set_uint8(item, 0);
   assert_int_equal(1, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, (unsigned char[]){0x00}, 1);
+  assert_int_equal(cbor_serialized_size(item), 1);
+  cbor_decref(&item);
+}
+
+static void test_serialize_uint8(void **_CBOR_UNUSED(_state)) {
+  cbor_item_t *item = cbor_new_int8();
+  cbor_set_uint8(item, 42);
+  assert_int_equal(2, cbor_serialize(item, buffer, 512));
+  assert_memory_equal(buffer, ((unsigned char[]){0x18, 0x2a}), 2);
+  assert_int_equal(cbor_serialized_size(item), 2);
   cbor_decref(&item);
 }
 
@@ -33,6 +43,7 @@ static void test_serialize_uint16(void **_CBOR_UNUSED(_state)) {
   cbor_set_uint16(item, 1000);
   assert_int_equal(3, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x19, 0x03, 0xE8}), 3);
+  assert_int_equal(cbor_serialized_size(item), 3);
   cbor_decref(&item);
 }
 
@@ -42,6 +53,7 @@ static void test_serialize_uint32(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(5, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x1A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
+  assert_int_equal(cbor_serialized_size(item), 5);
   cbor_decref(&item);
 }
 
@@ -53,15 +65,27 @@ static void test_serialize_uint64(void **_CBOR_UNUSED(_state)) {
       buffer,
       ((unsigned char[]){0x1B, 0x00, 0x00, 0x00, 0xE8, 0xD4, 0xA5, 0x10, 0x00}),
       9);
+  assert_int_equal(cbor_serialized_size(item), 9);
   cbor_decref(&item);
 }
 
-static void test_serialize_negint8(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_negint8_embed(void **_CBOR_UNUSED(_state)) {
   cbor_item_t *item = cbor_new_int8();
   cbor_set_uint8(item, 0);
   cbor_mark_negint(item);
   assert_int_equal(1, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, (unsigned char[]){0x20}, 1);
+  assert_int_equal(cbor_serialized_size(item), 1);
+  cbor_decref(&item);
+}
+
+static void test_serialize_negint8(void **_CBOR_UNUSED(_state)) {
+  cbor_item_t *item = cbor_new_int8();
+  cbor_set_uint8(item, 42);
+  cbor_mark_negint(item);
+  assert_int_equal(2, cbor_serialize(item, buffer, 512));
+  assert_memory_equal(buffer, ((unsigned char[]){0x38, 0x2a}), 2);
+  assert_int_equal(cbor_serialized_size(item), 2);
   cbor_decref(&item);
 }
 
@@ -71,6 +95,7 @@ static void test_serialize_negint16(void **_CBOR_UNUSED(_state)) {
   cbor_mark_negint(item);
   assert_int_equal(3, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x39, 0x03, 0xE8}), 3);
+  assert_int_equal(cbor_serialized_size(item), 3);
   cbor_decref(&item);
 }
 
@@ -81,6 +106,7 @@ static void test_serialize_negint32(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(5, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x3A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
+  assert_int_equal(cbor_serialized_size(item), 5);
   cbor_decref(&item);
 }
 
@@ -93,6 +119,7 @@ static void test_serialize_negint64(void **_CBOR_UNUSED(_state)) {
       buffer,
       ((unsigned char[]){0x3B, 0x00, 0x00, 0x00, 0xE8, 0xD4, 0xA5, 0x10, 0x00}),
       9);
+  assert_int_equal(cbor_serialized_size(item), 9);
   cbor_decref(&item);
 }
 
@@ -307,10 +334,12 @@ static void test_auto_serialize_no_size(void **_CBOR_UNUSED(_state)) {
 
 int main(void) {
   const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_serialize_uint8_embed),
       cmocka_unit_test(test_serialize_uint8),
       cmocka_unit_test(test_serialize_uint16),
       cmocka_unit_test(test_serialize_uint32),
       cmocka_unit_test(test_serialize_uint64),
+      cmocka_unit_test(test_serialize_negint8_embed),
       cmocka_unit_test(test_serialize_negint8),
       cmocka_unit_test(test_serialize_negint16),
       cmocka_unit_test(test_serialize_negint32),

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -264,6 +264,7 @@ static void test_serialize_tags(void **_CBOR_UNUSED(_state)) {
 
   assert_int_equal(2, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xD5, 0x01}), 2);
+  assert_int_equal(cbor_serialized_size(item), 2);
   cbor_decref(&item);
   cbor_decref(&one);
 }
@@ -274,6 +275,7 @@ static void test_serialize_half(void **_CBOR_UNUSED(_state)) {
 
   assert_int_equal(3, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x7E, 0x00}), 3);
+  assert_int_equal(cbor_serialized_size(item), 3);
   cbor_decref(&item);
 }
 
@@ -284,6 +286,7 @@ static void test_serialize_single(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(5, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xFA, 0x47, 0xC3, 0x50, 0x00}),
                       5);
+  assert_int_equal(cbor_serialized_size(item), 5);
   cbor_decref(&item);
 }
 
@@ -296,6 +299,7 @@ static void test_serialize_double(void **_CBOR_UNUSED(_state)) {
       buffer,
       ((unsigned char[]){0xFB, 0xC0, 0x10, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66}),
       9);
+  assert_int_equal(cbor_serialized_size(item), 9);
   cbor_decref(&item);
 }
 
@@ -304,6 +308,7 @@ static void test_serialize_ctrl(void **_CBOR_UNUSED(_state)) {
 
   assert_int_equal(1, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF7}), 1);
+  assert_int_equal(cbor_serialized_size(item), 1);
   cbor_decref(&item);
 }
 
@@ -313,6 +318,7 @@ static void test_serialize_long_ctrl(void **_CBOR_UNUSED(_state)) {
 
   assert_int_equal(2, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF8, 0xFE}), 2);
+  assert_int_equal(cbor_serialized_size(item), 2);
   cbor_decref(&item);
 }
 
@@ -325,6 +331,7 @@ static void test_auto_serialize(void **_CBOR_UNUSED(_state)) {
   size_t output_size;
   assert_int_equal(37, cbor_serialize_alloc(item, &output, &output_size));
   assert_int_equal(64, output_size);
+  assert_int_equal(cbor_serialized_size(item), 37);
   assert_memory_equal(output, ((unsigned char[]){0x84, 0x1B}), 2);
   cbor_decref(&item);
   _CBOR_FREE(output);

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -154,6 +154,30 @@ static void test_serialize_indefinite_bytestring(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
+static void test_serialize_4b_bytestring(void **_CBOR_UNUSED(_state)) {
+  cbor_item_t *item = cbor_new_definite_bytestring();
+
+  // Fake having a huge chunk of data
+  unsigned char *data = malloc(1);
+  cbor_bytestring_set_handle(item, data, UINT32_MAX);
+
+  assert_int_equal(cbor_serialize(item, buffer, 512), 0);
+  assert_int_equal(cbor_serialized_size(item), (uint64_t)UINT32_MAX + 5);
+  cbor_decref(&item);
+}
+
+static void test_serialize_8b_bytestring(void **_CBOR_UNUSED(_state)) {
+  cbor_item_t *item = cbor_new_definite_bytestring();
+
+  // Fake having a huge chunk of data
+  unsigned char *data = malloc(1);
+  cbor_bytestring_set_handle(item, data, (uint64_t)UINT32_MAX + 1);
+
+  assert_int_equal(cbor_serialize(item, buffer, 512), 0);
+  assert_int_equal(cbor_serialized_size(item), (uint64_t)UINT32_MAX + 1 + 9);
+  cbor_decref(&item);
+}
+
 static void test_serialize_definite_string(void **_CBOR_UNUSED(_state)) {
   cbor_item_t *item = cbor_new_definite_string();
   unsigned char *data = malloc(12);
@@ -361,6 +385,8 @@ int main(void) {
       cmocka_unit_test(test_serialize_negint64),
       cmocka_unit_test(test_serialize_definite_bytestring),
       cmocka_unit_test(test_serialize_indefinite_bytestring),
+      cmocka_unit_test(test_serialize_4b_bytestring),
+      cmocka_unit_test(test_serialize_8b_bytestring),
       cmocka_unit_test(test_serialize_definite_string),
       cmocka_unit_test(test_serialize_indefinite_string),
       cmocka_unit_test(test_serialize_definite_array),

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -131,6 +131,7 @@ static void test_serialize_definite_bytestring(void **_CBOR_UNUSED(_state)) {
   assert_int_equal(256 + 3, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x59, 0x01, 0x00}), 3);
   assert_memory_equal(buffer + 3, data, 256);
+  assert_int_equal(cbor_serialized_size(item), 259);
   cbor_decref(&item);
 }
 
@@ -149,6 +150,7 @@ static void test_serialize_indefinite_bytestring(void **_CBOR_UNUSED(_state)) {
   assert_memory_equal(buffer, ((unsigned char[]){0x5F, 0x59, 0x01, 0x00}), 4);
   assert_memory_equal(buffer + 4, data, 256);
   assert_memory_equal(buffer + 4 + 256, ((unsigned char[]){0xFF}), 1);
+  assert_int_equal(cbor_serialized_size(item), 261);
   cbor_decref(&item);
 }
 

--- a/test/memory_utils_test.c
+++ b/test/memory_utils_test.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2020 Pavel Kalvoda <me@pavelkalvoda.com>
+ *
+ * libcbor is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <cmocka.h>
+
+#include <string.h>
+#include "assertions.h"
+#include "cbor/internal/memory_utils.h"
+
+static void test_safe_multiply(void **_CBOR_UNUSED(_state)) {
+  assert_true(_cbor_safe_to_multiply(1, 1));
+  assert_true(_cbor_safe_to_multiply(SIZE_MAX, 0));
+  assert_true(_cbor_safe_to_multiply(SIZE_MAX, 1));
+  assert_false(_cbor_safe_to_multiply(SIZE_MAX, 2));
+  assert_false(_cbor_safe_to_multiply(SIZE_MAX, SIZE_MAX));
+}
+
+static void test_safe_add(void **_CBOR_UNUSED(_state)) {
+  assert_true(_cbor_safe_to_add(1, 1));
+  assert_true(_cbor_safe_to_add(SIZE_MAX - 1, 1));
+  assert_true(_cbor_safe_to_add(SIZE_MAX, 0));
+  assert_false(_cbor_safe_to_add(SIZE_MAX, 1));
+  assert_false(_cbor_safe_to_add(SIZE_MAX, 2));
+  assert_false(_cbor_safe_to_add(SIZE_MAX, SIZE_MAX));
+  assert_false(_cbor_safe_to_add(SIZE_MAX - 1, SIZE_MAX));
+  assert_false(_cbor_safe_to_add(SIZE_MAX - 1, SIZE_MAX - 1));
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_safe_multiply),
+      cmocka_unit_test(test_safe_add),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/memory_utils_test.c
+++ b/test/memory_utils_test.c
@@ -34,10 +34,19 @@ static void test_safe_add(void **_CBOR_UNUSED(_state)) {
   assert_false(_cbor_safe_to_add(SIZE_MAX - 1, SIZE_MAX - 1));
 }
 
+static void test_safe_signalling_add(void **_CBOR_UNUSED(_state)) {
+  assert_int_equal(_cbor_safe_signaling_add(1, 2), 3);
+  assert_int_equal(_cbor_safe_signaling_add(0, 1), 0);
+  assert_int_equal(_cbor_safe_signaling_add(0, SIZE_MAX), 0);
+  assert_int_equal(_cbor_safe_signaling_add(1, SIZE_MAX), 0);
+  assert_int_equal(_cbor_safe_signaling_add(1, SIZE_MAX - 1), SIZE_MAX);
+}
+
 int main(void) {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_safe_multiply),
       cmocka_unit_test(test_safe_add),
+      cmocka_unit_test(test_safe_signalling_add),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Description

- Prerequisite for fixing the repeated reallocation in cbor_serialize_alloc, which is super wasteful and ugly
- Adding as a part of the public API since it seems generally helpful
- Also add some new related test coverage 

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [x] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
