### PR TITLE
Rework cbor_serialize_alloc to allocate exact buffer size upfront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Next
   - Previously, the failures were not handled in the interface. Now, `cbor_copy` may return `NULL` upon failure; clients should check the return value
 - [Fix `cbor_build_tag` illegal memory behavior when the allocator fails](https://github.com/PJK/libcbor/pull/249)
 - [Add a new `cbor_serialized_size` API](https://github.com/PJK/libcbor/pull/250)
+- [Reworked `cbor_serialize_alloc` to allocate the exact amount of memory necessary upfront](https://github.com/PJK/libcbor/pull/251)
+  - This should significantly speed up `cbor_serialize_alloc` for large items by avoiding multiple reallocation iterations
+  - Clients should not use the return value of `cbor_serialize_alloc`. It may be removed in the future.
 
 
 0.9.0 (2021-11-14)

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ int main(int argc, char * argv[])
 		.key = cbor_move(cbor_build_uint8(42)),
 		.value = cbor_move(cbor_build_string("Is the answer"))
 	});
-	/* Output: `length` bytes of data in the `buffer` */
+	/* Output: `buffer_size` bytes of data in the `buffer` */
 	unsigned char * buffer;
-	size_t buffer_size,
-		length = cbor_serialize_alloc(root, &buffer, &buffer_size);
+	size_t buffer_size;
+	cbor_serialize_alloc(root, &buffer, &buffer_size);
 
-	fwrite(buffer, 1, length, stdout);
+	fwrite(buffer, 1, buffer_size, stdout);
 	free(buffer);
 
 	fflush(stdout);

--- a/doc/source/using.rst
+++ b/doc/source/using.rst
@@ -75,11 +75,12 @@ of what is it CBOR does, the examples (located in the ``examples`` directory) sh
             .key = cbor_move(cbor_build_uint8(42)),
             .value = cbor_move(cbor_build_string("Is the answer"))
         });
-        /* Output: `length` bytes of data in the `buffer` */
+        /* Output: `buffer_size` bytes of data in the `buffer` */
         unsigned char * buffer;
-        size_t buffer_size, length = cbor_serialize_alloc(root, &buffer, &buffer_size);
+        size_t buffer_size;
+        cbor_serialize_alloc(root, &buffer, &buffer_size);
 
-        fwrite(buffer, 1, length, stdout);
+        fwrite(buffer, 1, buffer_size, stdout);
         free(buffer);
 
         fflush(stdout);

--- a/examples/cjson2cbor.c
+++ b/examples/cjson2cbor.c
@@ -133,10 +133,10 @@ int main(int argc, char *argv[]) {
 
   /* Print out CBOR bytes */
   unsigned char *buffer;
-  size_t buffer_size,
-      cbor_length = cbor_serialize_alloc(cbor, &buffer, &buffer_size);
+  size_t buffer_size;
+  cbor_serialize_alloc(cbor, &buffer, &buffer_size);
 
-  fwrite(buffer, 1, cbor_length, stdout);
+  fwrite(buffer, 1, buffer_size, stdout);
 
   free(buffer);
   fflush(stdout);

--- a/src/cbor/serialization.h
+++ b/src/cbor/serialization.h
@@ -46,8 +46,12 @@ cbor_serialized_size(const cbor_item_t *item);
 
 /** Serialize the given item, allocating buffers as needed
  *
+ * Since libcbor v0.10, the return value is always the same as `buffer_size` (if
+ * provided, see https://github.com/PJK/libcbor/pull/251/). New clients should
+ * ignore the return value.
+ *
  * \rst
- * .. warning:: It is your responsibility to free the buffer using an
+ * .. warning:: It is the caller's responsibility to free the buffer using an
  *  appropriate ``free`` implementation.
  * \endrst
  *
@@ -57,8 +61,9 @@ cbor_serialized_size(const cbor_item_t *item);
  * @return Length of the result. 0 on failure, in which case \p buffer is
  * ``NULL``.
  */
-_CBOR_NODISCARD CBOR_DEPRECATED CBOR_EXPORT size_t cbor_serialize_alloc(
-    const cbor_item_t *item, cbor_mutable_data *buffer, size_t *buffer_size);
+CBOR_EXPORT size_t cbor_serialize_alloc(const cbor_item_t *item,
+                                        cbor_mutable_data *buffer,
+                                        size_t *buffer_size);
 
 /** Serialize an uint
  *

--- a/src/cbor/serialization.h
+++ b/src/cbor/serialization.h
@@ -57,7 +57,7 @@ cbor_serialized_size(const cbor_item_t *item);
  * @return Length of the result. 0 on failure, in which case \p buffer is
  * ``NULL``.
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_alloc(
+_CBOR_NODISCARD CBOR_DEPRECATED CBOR_EXPORT size_t cbor_serialize_alloc(
     const cbor_item_t *item, cbor_mutable_data *buffer, size_t *buffer_size);
 
 /** Serialize an uint

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -5,6 +5,10 @@
  * it under the terms of the MIT license. See LICENSE for details.
  */
 
+// cbor_serialize_alloc
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -353,8 +357,8 @@ static void test_auto_serialize(void **_CBOR_UNUSED(_state)) {
 
   unsigned char *output;
   size_t output_size;
-  assert_int_equal(37, cbor_serialize_alloc(item, &output, &output_size));
-  assert_int_equal(64, output_size);
+  assert_int_equal(cbor_serialize_alloc(item, &output, &output_size), 37);
+  assert_int_equal(output_size, 37);
   assert_int_equal(cbor_serialized_size(item), 37);
   assert_memory_equal(output, ((unsigned char[]){0x84, 0x1B}), 2);
   cbor_decref(&item);
@@ -365,8 +369,9 @@ static void test_auto_serialize_no_size(void **_CBOR_UNUSED(_state)) {
   cbor_item_t *item = cbor_build_uint8(1);
 
   unsigned char *output;
-  assert_int_equal(1, cbor_serialize_alloc(item, &output, NULL));
+  assert_int_equal(cbor_serialize_alloc(item, &output, NULL), 1);
   assert_memory_equal(output, ((unsigned char[]){0x01}), 1);
+  assert_int_equal(cbor_serialized_size(item), 1);
   cbor_decref(&item);
   _CBOR_FREE(output);
 }


### PR DESCRIPTION
## Description

- The allocate-serialize-retry loop was ugly and inefficient, especially for large items that might take a number of tries to succeed
- Will also waste less memory
- The downside is that the old API doesn't match the new logic so well, the return value and the output parameter are redundant now. Given the number of clients (https://github.com/search?q=cbor_serialize_alloc&type=code), I will keep the function as-is for now since it is backwards compatible

## Checklist

- [ ] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [x] I have added tests
	- [x] I have updated the documentation
	- [x] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
