### PR TITLE
Fix CBOR_ASSERT test behavior in release builds, add release CI, minor release mode imrovements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ workflows:
       - static-test
       - build-and-test
       - build-and-test-clang
+      - build-and-test-release-clang
       - build-and-test-arm
       - build-bazel
       - llvm-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,13 @@ commands:
           -DCOVERAGE="${CMAKE_COVERAGE:='OFF'}" \
           .
     - run: make -j 16 VERBOSE=1
+  build-release:
+    steps:
+    - run: >
+        cmake -DWITH_TESTS=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          .
+    - run: make -j 16 VERBOSE=1
   test:
     steps:
     - run: ctest -VV
@@ -80,6 +87,18 @@ jobs:
       - build
       - test
 
+  build-and-test-release-clang:
+    machine:
+      image: ubuntu-2204:2022.10.2
+    environment:
+      TOOLCHAIN_PACKAGE: clang
+      CC: clang
+      CXX: clang++
+    steps:
+      - checkout
+      - linux-setup
+      - build-release
+      - test
 
   llvm-coverage:
     machine:

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -60,11 +60,20 @@ extern bool _cbor_enable_assert;
 // Like `assert`, but can be dynamically disabled in tests to allow testing
 // invalid behaviors.
 #define CBOR_ASSERT(e) assert(!_cbor_enable_assert || (e))
+#define _CBOR_TEST_DISABLE_ASSERT(block) \
+  do {                                   \
+    _cbor_enable_assert = false;         \
+    block _cbor_enable_assert = true;    \
+  } while (0)
 #else
 #define debug_print(fmt, ...) \
   do {                        \
   } while (0)
 #define CBOR_ASSERT(e)
+#define _CBOR_TEST_DISABLE_ASSERT(block) \
+  do {                                   \
+    block                                \
+  } while (0)
 #endif
 
 #define _CBOR_TO_STR_(x) #x

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -159,11 +159,10 @@ size_t cbor_serialize_alloc(const cbor_item_t *item, unsigned char **buffer,
     return 0;
   }
 
-  size_t written __attribute__((unused)) =
-      cbor_serialize(item, *buffer, serialized_size);
+  size_t written = cbor_serialize(item, *buffer, serialized_size);
   CBOR_ASSERT(written == serialized_size);
   if (buffer_size != NULL) *buffer_size = serialized_size;
-  return serialized_size;
+  return written;
 }
 
 size_t cbor_serialize_uint(const cbor_item_t *item, unsigned char *buffer,

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -159,7 +159,8 @@ size_t cbor_serialize_alloc(const cbor_item_t *item, unsigned char **buffer,
     return 0;
   }
 
-  size_t written = cbor_serialize(item, *buffer, serialized_size);
+  size_t written __attribute__((unused)) =
+      cbor_serialize(item, *buffer, serialized_size);
   CBOR_ASSERT(written == serialized_size);
   if (buffer_size != NULL) *buffer_size = serialized_size;
   return serialized_size;

--- a/test/float_ctrl_test.c
+++ b/test/float_ctrl_test.c
@@ -84,29 +84,27 @@ static void test_undef(void **_CBOR_UNUSED(_state)) {
 unsigned char bool_data[] = {0xF4, 0xF5};
 
 static void test_bool(void **_CBOR_UNUSED(_state)) {
-  _cbor_enable_assert = false;
+  _CBOR_TEST_DISABLE_ASSERT({
+    float_ctrl = cbor_load(bool_data, 1, &res);
+    assert_true(cbor_isa_float_ctrl(float_ctrl));
+    assert_true(cbor_is_bool(float_ctrl));
+    assert_false(cbor_get_bool(float_ctrl));
+    cbor_set_bool(float_ctrl, true);
+    assert_true(cbor_get_bool(float_ctrl));
+    assert_true(isnan(cbor_float_get_float(float_ctrl)));
+    cbor_decref(&float_ctrl);
+    assert_null(float_ctrl);
 
-  float_ctrl = cbor_load(bool_data, 1, &res);
-  assert_true(cbor_isa_float_ctrl(float_ctrl));
-  assert_true(cbor_is_bool(float_ctrl));
-  assert_false(cbor_get_bool(float_ctrl));
-  cbor_set_bool(float_ctrl, true);
-  assert_true(cbor_get_bool(float_ctrl));
-  assert_true(isnan(cbor_float_get_float(float_ctrl)));
-  cbor_decref(&float_ctrl);
-  assert_null(float_ctrl);
-
-  float_ctrl = cbor_load(bool_data + 1, 1, &res);
-  assert_true(cbor_isa_float_ctrl(float_ctrl));
-  assert_true(cbor_is_bool(float_ctrl));
-  assert_true(cbor_get_bool(float_ctrl));
-  cbor_set_bool(float_ctrl, false);
-  assert_false(cbor_get_bool(float_ctrl));
-  assert_true(isnan(cbor_float_get_float(float_ctrl)));
-  cbor_decref(&float_ctrl);
-  assert_null(float_ctrl);
-
-  _cbor_enable_assert = true;
+    float_ctrl = cbor_load(bool_data + 1, 1, &res);
+    assert_true(cbor_isa_float_ctrl(float_ctrl));
+    assert_true(cbor_is_bool(float_ctrl));
+    assert_true(cbor_get_bool(float_ctrl));
+    cbor_set_bool(float_ctrl, false);
+    assert_false(cbor_get_bool(float_ctrl));
+    assert_true(isnan(cbor_float_get_float(float_ctrl)));
+    cbor_decref(&float_ctrl);
+    assert_null(float_ctrl);
+  });
 }
 
 static void test_float_ctrl_creation(void **_CBOR_UNUSED(_state)) {


### PR DESCRIPTION
Small bug introduced in https://github.com/PJK/libcbor/pull/254 -- tests wouldn't compile in release mode since _cbor_enable_assert is no defined.