### PR TITLE
README: Remove CBOR_CUSTOM_ALLOC flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ```bash
 git clone https://github.com/PJK/libcbor
-cmake -DCMAKE_BUILD_TYPE=Release -DCBOR_CUSTOM_ALLOC=ON libcbor
+cmake -DCMAKE_BUILD_TYPE=Release libcbor
 make
 make install
 ```


### PR DESCRIPTION
According to documentation:
* https://libcbor.readthedocs.io/en/latest/getting_started.html#building-installing-libcbor

> CBOR_CUSTOM_ALLOC has been removed. Custom allocators (historically a controlled by a build flag) are always enabled.

Documentation seems conflicting.