### PR TITLE
Add Cirrus-CI config file to build & test on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,22 @@
+freebsd_task:
+    install_script:
+    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f && pkg install -y cmocka cmake ninja
+    build_script:
+    - mkdir build
+    - cd build
+    - cmake -GNinja -DWITH_TESTS=ON
+      -DCBOR_CUSTOM_ALLOC=ON
+      -DCMAKE_BUILD_TYPE=Debug
+      -DSANITIZE=OFF
+      ..
+    - ninja -j $(sysctl -n hw.ncpu)
+    test_script:
+    - cd build
+    - ctest -VV
+    matrix:
+    - name: freebsd12-4-amd64
+      freebsd_instance:
+        image: freebsd-12-4-release-amd64
+    - name: freebsd13-2-amd64
+      freebsd_instance:
+        image: freebsd-13-2-release-amd64


### PR DESCRIPTION
Test on FreeBSD 12.4 and FreeBSD 13.2, the two currently supported releases.

## Description

Add CI for FreeBSD using Cirrus-CI
Example run: https://cirrus-ci.com/task/6708320812138496

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?

I did not see a changelog entry for CircleCI, but if this PR is welcome and a changelog entry is desired I will push an update.