### PR TITLE
make CMAKE_SKIP_INSTALL_ALL_DEPENDENCY an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ SET(CBOR_VERSION_MINOR "10")
 SET(CBOR_VERSION_PATCH "2")
 SET(CBOR_VERSION ${CBOR_VERSION_MAJOR}.${CBOR_VERSION_MINOR}.${CBOR_VERSION_PATCH})
 
-set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
+option(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY "cmake --build --target install does not depend on cmake --build" true)
 include(CheckIncludeFiles)
 
 include(TestBigEndian)


### PR DESCRIPTION
## Description

allow `CMAKE_SKIP_INSTALL_ALL_DEPENDENCY` to be changed so that a `cmake -Dsomeoption -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=OFF  && cmake --build . --target install` can build and install

this does not introduce any new behaviour aside from allowing to override the option in the `cmake` configuration step.