### PR TITLE
Print CBOR_TYPE_BYTESTRING value as hex string

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -325,7 +325,12 @@ static void _cbor_nested_describe(cbor_item_t *item, FILE *out, int indent) {
           _cbor_nested_describe(cbor_bytestring_chunks_handle(item)[i], out,
                                 indent + 4);
       } else {
+        const unsigned char* data = cbor_bytestring_handle(item);
         fprintf(out, "Definite, length %zuB\n", cbor_bytestring_length(item));
+        fprintf(out, "%*s", indent + 4, " ");
+        for (size_t i = 0; i < cbor_bytestring_length(item); i++)
+          fprintf(out, "%02x", (int)(data[i] & 0xff));
+        fprintf(out, "\n");
       }
       break;
     }


### PR DESCRIPTION
## Description

Add data as hex string in `cbor_describe` for type `CBOR_TYPE_BYTESTRING`

I did find it useful to have the data printed out just like for `CBOR_TYPE_STRING`.
