### PR TITLE
CMakeLists.txt: install configuration.h following CMAKE_INSTALL_INCLU…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(libcbor)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/")
 include(CTest)
+include(GNUInstallDirs) # Provides CMAKE_INSTALL_ variables
 
 SET(CBOR_VERSION_MAJOR "0")
 SET(CBOR_VERSION_MINOR "10")
@@ -138,14 +139,8 @@ if (COVERAGE)
     endif()
 endif (COVERAGE)
 
-
-message("top level")
-message(${CMAKE_INSTALL_INCLUDEDIR})
-message(${CMAKE_INSTALL_INCLUDEDIR}/cbor)
-
 # We want to generate configuration.h from the template and make it so that it is accessible using the same
 # path during both library build and installed header use, without littering the source dir.
-# Using cbor/configuration.h in the build dir works b/c headers will be installed to <prefix>/cbor
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/cbor/configuration.h.in ${PROJECT_BINARY_DIR}/cbor/configuration.h)
 install(FILES ${PROJECT_BINARY_DIR}/cbor/configuration.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbor)
 # Make the header visible at compile time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ endif (COVERAGE)
 # path during both library build and installed header use, without littering the source dir.
 # Using cbor/configuration.h in the build dir works b/c headers will be installed to <prefix>/cbor
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/cbor/configuration.h.in ${PROJECT_BINARY_DIR}/cbor/configuration.h)
-install(FILES ${PROJECT_BINARY_DIR}/cbor/configuration.h DESTINATION include/cbor)
+install(FILES ${PROJECT_BINARY_DIR}/cbor/configuration.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbor)
 # Make the header visible at compile time
 include_directories(${PROJECT_BINARY_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,10 @@ if (COVERAGE)
 endif (COVERAGE)
 
 
+message("top level")
+message(${CMAKE_INSTALL_INCLUDEDIR})
+message(${CMAKE_INSTALL_INCLUDEDIR}/cbor)
+
 # We want to generate configuration.h from the template and make it so that it is accessible using the same
 # path during both library build and installed header use, without littering the source dir.
 # Using cbor/configuration.h in the build dir works b/c headers will be installed to <prefix>/cbor

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 # Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(SOURCES cbor.c allocators.c cbor/streaming.c cbor/internal/encoders.c cbor/internal/builder_callbacks.c cbor/internal/loaders.c cbor/internal/memory_utils.c cbor/internal/stack.c cbor/internal/unicode.c cbor/encoding.c cbor/serialization.c cbor/arrays.c cbor/common.c cbor/floats_ctrls.c cbor/bytestrings.c cbor/callbacks.c cbor/strings.c cbor/maps.c cbor/tags.c cbor/ints.c)
 
-include(GNUInstallDirs)
 include(JoinPaths)
 include(CheckFunctionExists)
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
@@ -22,8 +21,6 @@ include(GenerateExportHeader)
 generate_export_header(cbor EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/cbor/cbor_export.h)
 target_include_directories(cbor PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cbor/cbor_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbor)
-message(${CMAKE_INSTALL_INCLUDEDIR})
-message(${CMAKE_INSTALL_INCLUDEDIR}/cbor)
 
 if (NOT ${CBOR_VERSION_MAJOR} EQUAL 0)
 	MESSAGE(FATAL_ERROR "Change the shared library version scheme to reflect https://github.com/PJK/libcbor/issues/52.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,8 @@ include(GenerateExportHeader)
 generate_export_header(cbor EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/cbor/cbor_export.h)
 target_include_directories(cbor PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cbor/cbor_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbor)
+message(${CMAKE_INSTALL_INCLUDEDIR})
+message(${CMAKE_INSTALL_INCLUDEDIR}/cbor)
 
 if (NOT ${CBOR_VERSION_MAJOR} EQUAL 0)
 	MESSAGE(FATAL_ERROR "Change the shared library version scheme to reflect https://github.com/PJK/libcbor/issues/52.")


### PR DESCRIPTION
…DEDIR path

Without the change when `-DCMAKE_INSTALL_INCLUDEDIR=` is passed explicitly all ehaders except `configuration.h` are installed to specified directory.

The change puts `configuration.h` along with the rest of headers.

Noticed in` nixpkgs` package repository when tried to move headers out into a separate directory to split out developer's files.

## Description

What changes and why

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
