### PR TITLE
CI: Add FreeBSD 14.0 and drop FreeBSD 12.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,9 +14,13 @@ freebsd_task:
     - cd build
     - ctest -VV
     matrix:
-    - name: freebsd13-2-amd64
+    # From gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images
+    - name: freebsd-13-2
       freebsd_instance:
-        image: freebsd-13-2-release-amd64
-    - name: freebsd14-0-amd64
+        image_family: freebsd-13-2
+    - name: freebsd-14-0
       freebsd_instance:
-        image: freebsd-14-0-release-amd64
+        image_family: freebsd-14-0
+    - name: freebsd-15-0-snap
+      freebsd_instance:
+        image_family: freebsd-15-0-snap

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,9 +14,9 @@ freebsd_task:
     - cd build
     - ctest -VV
     matrix:
-    - name: freebsd12-4-amd64
-      freebsd_instance:
-        image: freebsd-12-4-release-amd64
     - name: freebsd13-2-amd64
       freebsd_instance:
         image: freebsd-13-2-release-amd64
+    - name: freebsd14-0-amd64
+      freebsd_instance:
+        image: freebsd-14-0-release-amd64


### PR DESCRIPTION
FreeBSD 14.0 was released recently.  FreeBSD 12.4 is EOL at the end of 2023.

## Description

FreeBSD 14.0 added to Cirrus-CI. FreeBSD 12.4 removed from Cirrus-CI.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
