### PR TITLE
Support decoding all tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Next
 - [Fix `cbor_string_set_handle` not setting the codepoint count](https://github.com/PJK/libcbor/pull/286)
 - BREAKING: [`cbor_load` will no longer fail on input strings that are well-formed but not valid UTF-8](https://github.com/PJK/libcbor/pull/286)
   - If you were relying on the validation, please check the result using `cbor_string_codepoint_count` instead 
+- BREAKING: [All decoders like `cbor_load` and `cbor_stream_decode` will accept all well-formed tag values](https://github.com/PJK/libcbor/pull/308) (bug discovered by [dskern-github](https://github.com/dskern-github))
+  - Previously, decoding of certain values would fail with `CBOR_ERR_MALFORMATED` or `CBOR_DECODER_ERROR`
+  - This also makes decoding symmetrical with serialization, which already accepts all values
 
 0.10.2 (2023-01-31)
 ---------------------

--- a/src/cbor/streaming.c
+++ b/src/cbor/streaming.c
@@ -437,23 +437,21 @@ struct cbor_decoder_result cbor_stream_decode(
         callbacks->indef_map_start(context);
         return result;
       }
-    case 0xC0:
-      /* Text date/time - RFC 3339 tag, fallthrough */
-    case 0xC1:
-      /* Epoch date tag, fallthrough */
-    case 0xC2:
-      /* Positive bignum tag, fallthrough */
-    case 0xC3:
-      /* Negative bignum tag, fallthrough */
-    case 0xC4:
-      /* Fraction, fallthrough */
-    case 0xC5:
-      /* Big float */
-      {
-        callbacks->tag(context, (uint64_t)(_cbor_load_uint8(source) -
-                                           0xC0)); /* 0xC0 offset */
-        return result;
-      }
+      /* See https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml for tag
+       * assignment. All well-formed tags are processed regardless of validity
+       * since maintaining the known mapping would be impractical.
+       *
+       * Moreover, even tags in the reserved "standard" range are not assigned
+       * but may get assigned in the future (see e.g.
+       * https://github.com/PJK/libcbor/issues/307), so processing all tags
+       * improves forward compatibility.
+       */
+    case 0xC0: /* Fallthrough */
+    case 0xC1: /* Fallthrough */
+    case 0xC2: /* Fallthrough */
+    case 0xC3: /* Fallthrough */
+    case 0xC4: /* Fallthrough */
+    case 0xC5: /* Fallthrough */
     case 0xC6: /* Fallthrough */
     case 0xC7: /* Fallthrough */
     case 0xC8: /* Fallthrough */
@@ -468,13 +466,10 @@ struct cbor_decoder_result cbor_stream_decode(
     case 0xD1: /* Fallthrough */
     case 0xD2: /* Fallthrough */
     case 0xD3: /* Fallthrough */
-    case 0xD4: /* Unassigned tag value */
-    {
-      return (struct cbor_decoder_result){.status = CBOR_DECODER_ERROR};
-    }
-    case 0xD5: /* Expected b64url conversion tag - fallthrough */
-    case 0xD6: /* Expected b64 conversion tag - fallthrough */
-    case 0xD7: /* Expected b16 conversion tag */
+    case 0xD4: /* Fallthrough */
+    case 0xD5: /* Fallthrough */
+    case 0xD6: /* Fallthrough */
+    case 0xD7: /* Fallthrough */
     {
       callbacks->tag(context, (uint64_t)(_cbor_load_uint8(source) -
                                          0xC0)); /* 0xC0 offset */

--- a/test/cbor_stream_decode_test.c
+++ b/test/cbor_stream_decode_test.c
@@ -613,9 +613,9 @@ static void test_int64_tag_decoding(void **_CBOR_UNUSED(_state)) {
   assert_minimum_input_size(9, int64_tag_data);
 }
 
-unsigned char bad_tag_data[] = {0xC6};
-static void test_bad_tag_decoding(void **_CBOR_UNUSED(_state)) {
-  assert_decoder_result(0, CBOR_DECODER_ERROR, decode(bad_tag_data, 1));
+unsigned char reserved_byte_data[] = {0xDC};
+static void test_reserved_byte_decoding(void **_CBOR_UNUSED(_state)) {
+  assert_decoder_result(0, CBOR_DECODER_ERROR, decode(reserved_byte_data, 1));
 }
 
 unsigned char float2_data[] = {0xF9, 0x7B, 0xFF};
@@ -729,7 +729,7 @@ int main(void) {
       stream_test(test_int16_tag_decoding),
       stream_test(test_int32_tag_decoding),
       stream_test(test_int64_tag_decoding),
-      stream_test(test_bad_tag_decoding),
+      stream_test(test_reserved_byte_decoding),
 
       stream_test(test_float2_decoding),
       stream_test(test_float4_decoding),

--- a/test/tag_test.c
+++ b/test/tag_test.c
@@ -120,6 +120,7 @@ static void test_all_tag_values_supported(void **_CBOR_UNUSED(_state)) {
     assert_null(tag);
     cbor_decref(&tag_item);
     assert_null(tag_item);
+    free(serialized_tag);
   }
 }
 

--- a/test/tag_test.c
+++ b/test/tag_test.c
@@ -102,6 +102,27 @@ static void test_nested_tag(void **_CBOR_UNUSED(_state)) {
   assert_null(nested_tag);
 }
 
+static void test_all_tag_values_supported(void **_CBOR_UNUSED(_state)) {
+  /* Test all items in the protected range of
+   * https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml */
+  for (int64_t tag_value = 0; tag_value <= 32767; tag_value++) {
+    cbor_item_t *tag_item =
+        cbor_build_tag(tag_value, cbor_move(cbor_build_uint8(42)));
+    unsigned char *serialized_tag;
+    size_t serialized_tag_size =
+        cbor_serialize_alloc(tag_item, &serialized_tag, NULL);
+    assert_true(serialized_tag_size > 0);
+    tag = cbor_load(serialized_tag, serialized_tag_size, &res);
+    assert_true(res.read == serialized_tag_size);
+    assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
+    assert_true(cbor_tag_value(tag) == tag_value);
+    cbor_decref(&tag);
+    assert_null(tag);
+    cbor_decref(&tag_item);
+    assert_null(tag_item);
+  }
+}
+
 static void test_build_tag(void **_CBOR_UNUSED(_state)) {
   tag = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
 
@@ -134,6 +155,7 @@ int main(void) {
       cmocka_unit_test(test_int32_tag),
       cmocka_unit_test(test_int64_tag),
       cmocka_unit_test(test_nested_tag),
+      cmocka_unit_test(test_all_tag_values_supported),
       cmocka_unit_test(test_build_tag),
       cmocka_unit_test(test_build_tag_failure),
       cmocka_unit_test(test_tag_creation),


### PR DESCRIPTION
## Description

The decoder would only accept tag values in the protected range that were registered when it was originally written. See inline comment for accepting all values is better

Fixes https://github.com/PJK/libcbor/issues/307

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [x] I have added tests
	- [x] I have updated the documentation
	- [x] I have updated the CHANGELOG
- [x] Are there any breaking changes?
	- [x] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
