### PR TITLE
Fixed code coverage option typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ add_custom_target(
 
 include_directories(src)
 
-option(c "Enable code coverage instrumentation" OFF)
+option(COVERAGE "Enable code coverage instrumentation" OFF)
 if(COVERAGE)
   message("Configuring code coverage instrumentation")
   if(CMAKE_C_COMPILER_ID MATCHES "GNU")


### PR DESCRIPTION
## Description

It appears that a typo was introduced in CMakeLists.txt over 2 years ago in commit a4535264d046bf9713ef58a5a5eb9fc12384aa91 that effectively disabled the code coverage option. I fixed it.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?