### PR TITLE
Remove no-op pragma clang lines

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -9,7 +9,6 @@
 #include "cbor/internal/builder_callbacks.h"
 #include "cbor/internal/loaders.h"
 
-#pragma clang diagnostic push
 cbor_item_t *cbor_load(cbor_data source, size_t source_size,
                        struct cbor_load_result *result) {
   /* Context stack */

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -6,7 +6,6 @@
  */
 
 // cbor_serialize_alloc
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 #include <math.h>


### PR DESCRIPTION
## Description

The two uses of `#pragma clang` in the tree don't do anything and cause GCC to whine about unknown pragmas in some cases so remove them.

Noticed the `push` when trying to build FreeBSD and it's embedded copy of libcbor with GCC 13.

I've not updated the CHANGELOG as these commits don't have any functional effect.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
