### PR TITLE
In cbor2cjson.c example, add missing cbor_move to cbor_array_get call

### DIFF
--- a/examples/cbor2cjson.c
+++ b/examples/cbor2cjson.c
@@ -41,7 +41,7 @@ cJSON* cbor_to_cjson(cbor_item_t* item) {
     case CBOR_TYPE_ARRAY: {
       cJSON* result = cJSON_CreateArray();
       for (size_t i = 0; i < cbor_array_size(item); i++) {
-        cJSON_AddItemToArray(result, cbor_to_cjson(cbor_array_get(item, i)));
+        cJSON_AddItemToArray(result, cbor_to_cjson(cbor_move(cbor_array_get(item, i))));
       }
       return result;
     }


### PR DESCRIPTION
## Description

The cbor2cjson.c example contains a call to cbor_array_get, which increments the reference counter, that is not paired with a cbor_move or reference decrement.

I borrowed the cbor_to_cjson function in some test code that was exhibiting a memory leak, until I added a cbor_move call:

https://github.com/whitehse/testing/blob/master/ipfix/ipfix_server.c

There are two kinds of arrays in my test data. I don't know if one or both kinds are triggering an issue:

* An array of maps - success &= cbor_array_push(array_of_templates, cbor_move(template));
* An array of uint16's - success &= cbor_array_push(array_of_fields, cbor_move(cbor_build_uint16(field_type)));

Since this is example code, I have not updated any tests, documentation, or the CHANGELOG. There are no security or performance implications in this one-line change.

## Checklist

- [X] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
