### PR TITLE
include project directory with target instead of globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,8 +199,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/cbor/configuration.h.in
                ${PROJECT_BINARY_DIR}/cbor/configuration.h)
 install(FILES ${PROJECT_BINARY_DIR}/cbor/configuration.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cbor)
-# Make the header visible at compile time
-include_directories(${PROJECT_BINARY_DIR})
 
 # CMake >= 3.9.0 enables LTO for GCC and Clang with INTERPROCEDURAL_OPTIMIZATION
 # Policy CMP0069 enables this behavior when we set the minimum CMake version <

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(cbor ${SOURCES})
 target_include_directories(cbor PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 set_target_properties(cbor PROPERTIES EXPORT_NAME libcbor)
 # For vendored builds


### PR DESCRIPTION
## Description

adds the PROJECT_BINARY_DIR include directly to the cbor target instead of using `include_directories`.

`include_directories` is limited to the current CMakeLists.txt and anything loaded under it, this makes it impossible to use libcbor as a submodule or via FetchContent since the include path never gets propagated.

## Checklist

- [X] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
