### PR TITLE
Fix mutiple "pedantic" compiler warnings, mostly around unused parameters

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,7 +52,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,19 @@ else()
   add_definitions(-DEIGHT_BYTE_SIZE_T)
 endif()
 
+include(CheckCSourceCompiles)
+
+check_c_source_compiles("
+    int main() {
+        __builtin_unreachable();
+        return 0;
+    }
+" HAS_BUILTIN_UNREACHABLE)
+
+if (HAS_BUILTIN_UNREACHABLE)
+  add_definitions(-D_CBOR_HAS_BUILTIN_UNREACHABLE)
+endif()
+
 enable_testing()
 
 set(CTEST_MEMORYCHECK_COMMAND "/usr/bin/valgrind")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,8 @@ else()
   set(CBOR_RESTRICT_SPECIFIER "restrict")
 
   set(CMAKE_C_FLAGS_DEBUG
-      "${CMAKE_C_FLAGS_DEBUG} -O0 -Wall -g -ggdb -DDEBUG=true")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -Wall -DNDEBUG")
+      "${CMAKE_C_FLAGS_DEBUG} -O0 -pedantic -Wall -Wextra -g -ggdb -DDEBUG=true")
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3-pedantic -Wall -Wextra -DNDEBUG")
 
   if(SANITIZE)
     set(CMAKE_C_FLAGS_DEBUG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ else()
 
   set(CMAKE_C_FLAGS_DEBUG
       "${CMAKE_C_FLAGS_DEBUG} -O0 -pedantic -Wall -Wextra -g -ggdb -DDEBUG=true")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3-pedantic -Wall -Wextra -DNDEBUG")
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -pedantic -Wall -Wextra -DNDEBUG")
 
   if(SANITIZE)
     set(CMAKE_C_FLAGS_DEBUG

--- a/examples/cjson2cbor.c
+++ b/examples/cjson2cbor.c
@@ -22,10 +22,10 @@
 #include "cbor/internal/builder_callbacks.h"
 #include "cbor/internal/loaders.h"
 
-typedef void (*cbor_load_callback_t)(cJSON *, const struct cbor_callbacks *,
-                                     void *);
+typedef void (*cbor_load_callback_t)(cJSON*, const struct cbor_callbacks*,
+                                     void*);
 
-cbor_item_t *cjson_cbor_load(void *source,
+cbor_item_t* cjson_cbor_load(void* source,
                              cbor_load_callback_t cbor_load_callback) {
   static struct cbor_callbacks callbacks = {
       .uint64 = &cbor_builder_uint64_callback,
@@ -51,9 +51,9 @@ cbor_item_t *cjson_cbor_load(void *source,
   return context.root;
 }
 
-void cjson_cbor_stream_decode(cJSON *source,
-                              const struct cbor_callbacks *callbacks,
-                              void *context) {
+void cjson_cbor_stream_decode(cJSON* source,
+                              const struct cbor_callbacks* callbacks,
+                              void* context) {
   switch (source->type) {
     case cJSON_False: {
       callbacks->boolean(context, false);
@@ -83,13 +83,13 @@ void cjson_cbor_stream_decode(cJSON *source,
     }
     case cJSON_String: {
       // XXX: Assume cJSON handled unicode correctly
-      callbacks->string(context, (unsigned char *)source->valuestring,
+      callbacks->string(context, (unsigned char*)source->valuestring,
                         strlen(source->valuestring));
       return;
     }
     case cJSON_Array: {
       callbacks->array_start(context, cJSON_GetArraySize(source));
-      cJSON *item = source->child;
+      cJSON* item = source->child;
       while (item != NULL) {
         cjson_cbor_stream_decode(item, callbacks, context);
         item = item->next;
@@ -98,9 +98,9 @@ void cjson_cbor_stream_decode(cJSON *source,
     }
     case cJSON_Object: {
       callbacks->map_start(context, cJSON_GetArraySize(source));
-      cJSON *item = source->child;
+      cJSON* item = source->child;
       while (item != NULL) {
-        callbacks->string(context, (unsigned char *)item->string,
+        callbacks->string(context, (unsigned char*)item->string,
                           strlen(item->string));
         cjson_cbor_stream_decode(item, callbacks, context);
         item = item->next;
@@ -115,24 +115,24 @@ void usage(void) {
   exit(1);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   if (argc != 2) usage();
-  FILE *f = fopen(argv[1], "rb");
+  FILE* f = fopen(argv[1], "rb");
   if (f == NULL) usage();
   /* Read input file into a buffer (cJSON doesn't work with streams) */
   fseek(f, 0, SEEK_END);
   size_t length = (size_t)ftell(f);
   fseek(f, 0, SEEK_SET);
-  char *json_buffer = malloc(length + 1);
+  char* json_buffer = malloc(length + 1);
   fread(json_buffer, length, 1, f);
   json_buffer[length] = '\0';
 
   /* Convert between JSON and CBOR */
-  cJSON *json = cJSON_Parse(json_buffer);
-  cbor_item_t *cbor = cjson_cbor_load(json, cjson_cbor_stream_decode);
+  cJSON* json = cJSON_Parse(json_buffer);
+  cbor_item_t* cbor = cjson_cbor_load(json, cjson_cbor_stream_decode);
 
   /* Print out CBOR bytes */
-  unsigned char *buffer;
+  unsigned char* buffer;
   size_t buffer_size;
   cbor_serialize_alloc(cbor, &buffer, &buffer_size);
 

--- a/examples/sort.c
+++ b/examples/sort.c
@@ -14,9 +14,9 @@
  * standard library functions.
  */
 
-int compareUint(const void *a, const void *b) {
-  uint8_t av = cbor_get_uint8(*(cbor_item_t **)a),
-          bv = cbor_get_uint8(*(cbor_item_t **)b);
+int compareUint(const void* a, const void* b) {
+  uint8_t av = cbor_get_uint8(*(cbor_item_t**)a),
+          bv = cbor_get_uint8(*(cbor_item_t**)b);
 
   if (av < bv)
     return -1;
@@ -27,14 +27,14 @@ int compareUint(const void *a, const void *b) {
 }
 
 int main(void) {
-  cbor_item_t *array = cbor_new_definite_array(4);
+  cbor_item_t* array = cbor_new_definite_array(4);
   bool success = cbor_array_push(array, cbor_move(cbor_build_uint8(4)));
   success &= cbor_array_push(array, cbor_move(cbor_build_uint8(3)));
   success &= cbor_array_push(array, cbor_move(cbor_build_uint8(1)));
   success &= cbor_array_push(array, cbor_move(cbor_build_uint8(2)));
   if (!success) return 1;
 
-  qsort(cbor_array_handle(array), cbor_array_size(array), sizeof(cbor_item_t *),
+  qsort(cbor_array_handle(array), cbor_array_size(array), sizeof(cbor_item_t*),
         compareUint);
 
   cbor_describe(array, stdout);

--- a/examples/sort.c
+++ b/examples/sort.c
@@ -14,7 +14,7 @@
  * standard library functions.
  */
 
-int compareUint(const void* a, const void* b) {
+int compare_uint(const void* a, const void* b) {
   uint8_t av = cbor_get_uint8(*(cbor_item_t**)a),
           bv = cbor_get_uint8(*(cbor_item_t**)b);
 
@@ -35,7 +35,7 @@ int main(void) {
   if (!success) return 1;
 
   qsort(cbor_array_handle(array), cbor_array_size(array), sizeof(cbor_item_t*),
-        compareUint);
+        compare_uint);
 
   cbor_describe(array, stdout);
   fflush(stdout);

--- a/examples/streaming_array.c
+++ b/examples/streaming_array.c
@@ -30,7 +30,8 @@ void flush(size_t bytes) {
  */
 int main(int argc, char* argv[]) {
   if (argc != 2) usage();
-  long n = strtol(argv[1], NULL, 10);
+  size_t n;
+  scanf(argv[1], "%zu", &n);
   out = freopen(NULL, "wb", stdout);
   if (!out) exit(1);
 

--- a/examples/streaming_parser.c
+++ b/examples/streaming_parser.c
@@ -9,12 +9,6 @@
 #include <string.h>
 #include "cbor.h"
 
-#ifdef __GNUC__
-#define UNUSED(x) __attribute__((__unused__)) x
-#else
-#define UNUSED(x) x
-#endif
-
 void usage(void) {
   printf("Usage: streaming_parser [input file]\n");
   exit(1);
@@ -30,7 +24,7 @@ void usage(void) {
 const char* key = "a secret key";
 bool key_found = false;
 
-void find_string(void* UNUSED(_ctx), cbor_data buffer, uint64_t len) {
+void find_string(void* _ctx _CBOR_UNUSED, cbor_data buffer, uint64_t len) {
   if (key_found) {
     printf("Found the value: %.*s\n", (int)len, buffer);
     key_found = false;

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -9,8 +9,8 @@
 #include "cbor/internal/builder_callbacks.h"
 #include "cbor/internal/loaders.h"
 
-cbor_item_t *cbor_load(cbor_data source, size_t source_size,
-                       struct cbor_load_result *result) {
+cbor_item_t* cbor_load(cbor_data source, size_t source_size,
+                       struct cbor_load_result* result) {
   /* Context stack */
   static struct cbor_callbacks callbacks = {
       .uint8 = &cbor_builder_uint8_callback,
@@ -114,8 +114,8 @@ error:
   return NULL;
 }
 
-static cbor_item_t *_cbor_copy_int(cbor_item_t *item, bool negative) {
-  cbor_item_t *res = NULL;
+static cbor_item_t* _cbor_copy_int(cbor_item_t* item, bool negative) {
+  cbor_item_t* res = NULL;
   switch (cbor_int_get_width(item)) {
     case CBOR_INT_8:
       res = cbor_build_uint8(cbor_get_uint8(item));
@@ -136,7 +136,7 @@ static cbor_item_t *_cbor_copy_int(cbor_item_t *item, bool negative) {
   return res;
 }
 
-static cbor_item_t *_cbor_copy_float_ctrl(cbor_item_t *item) {
+static cbor_item_t* _cbor_copy_float_ctrl(cbor_item_t* item) {
   switch (cbor_float_get_width(item)) {
     case CBOR_FLOAT_0:
       return cbor_build_ctrl(cbor_ctrl_value(item));
@@ -152,7 +152,7 @@ static cbor_item_t *_cbor_copy_float_ctrl(cbor_item_t *item) {
   }
 }
 
-cbor_item_t *cbor_copy(cbor_item_t *item) {
+cbor_item_t* cbor_copy(cbor_item_t* item) {
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
       return _cbor_copy_int(item, false);
@@ -163,13 +163,13 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
         return cbor_build_bytestring(cbor_bytestring_handle(item),
                                      cbor_bytestring_length(item));
       } else {
-        cbor_item_t *res = cbor_new_indefinite_bytestring();
+        cbor_item_t* res = cbor_new_indefinite_bytestring();
         if (res == NULL) {
           return NULL;
         }
 
         for (size_t i = 0; i < cbor_bytestring_chunk_count(item); i++) {
-          cbor_item_t *chunk_copy =
+          cbor_item_t* chunk_copy =
               cbor_copy(cbor_bytestring_chunks_handle(item)[i]);
           if (chunk_copy == NULL) {
             cbor_decref(&res);
@@ -186,16 +186,16 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
       }
     case CBOR_TYPE_STRING:
       if (cbor_string_is_definite(item)) {
-        return cbor_build_stringn((const char *)cbor_string_handle(item),
+        return cbor_build_stringn((const char*)cbor_string_handle(item),
                                   cbor_string_length(item));
       } else {
-        cbor_item_t *res = cbor_new_indefinite_string();
+        cbor_item_t* res = cbor_new_indefinite_string();
         if (res == NULL) {
           return NULL;
         }
 
         for (size_t i = 0; i < cbor_string_chunk_count(item); i++) {
-          cbor_item_t *chunk_copy =
+          cbor_item_t* chunk_copy =
               cbor_copy(cbor_string_chunks_handle(item)[i]);
           if (chunk_copy == NULL) {
             cbor_decref(&res);
@@ -211,7 +211,7 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
         return res;
       }
     case CBOR_TYPE_ARRAY: {
-      cbor_item_t *res;
+      cbor_item_t* res;
       if (cbor_array_is_definite(item)) {
         res = cbor_new_definite_array(cbor_array_size(item));
       } else {
@@ -222,7 +222,7 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
       }
 
       for (size_t i = 0; i < cbor_array_size(item); i++) {
-        cbor_item_t *entry_copy = cbor_copy(cbor_move(cbor_array_get(item, i)));
+        cbor_item_t* entry_copy = cbor_copy(cbor_move(cbor_array_get(item, i)));
         if (entry_copy == NULL) {
           cbor_decref(&res);
           return NULL;
@@ -237,7 +237,7 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
       return res;
     }
     case CBOR_TYPE_MAP: {
-      cbor_item_t *res;
+      cbor_item_t* res;
       if (cbor_map_is_definite(item)) {
         res = cbor_new_definite_map(cbor_map_size(item));
       } else {
@@ -247,14 +247,14 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
         return NULL;
       }
 
-      struct cbor_pair *it = cbor_map_handle(item);
+      struct cbor_pair* it = cbor_map_handle(item);
       for (size_t i = 0; i < cbor_map_size(item); i++) {
-        cbor_item_t *key_copy = cbor_copy(it[i].key);
+        cbor_item_t* key_copy = cbor_copy(it[i].key);
         if (key_copy == NULL) {
           cbor_decref(&res);
           return NULL;
         }
-        cbor_item_t *value_copy = cbor_copy(it[i].value);
+        cbor_item_t* value_copy = cbor_copy(it[i].value);
         if (value_copy == NULL) {
           cbor_decref(&res);
           cbor_decref(&key_copy);
@@ -273,11 +273,11 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
       return res;
     }
     case CBOR_TYPE_TAG: {
-      cbor_item_t *item_copy = cbor_copy(cbor_move(cbor_tag_item(item)));
+      cbor_item_t* item_copy = cbor_copy(cbor_move(cbor_tag_item(item)));
       if (item_copy == NULL) {
         return NULL;
       }
-      cbor_item_t *tag = cbor_build_tag(cbor_tag_value(item), item_copy);
+      cbor_item_t* tag = cbor_build_tag(cbor_tag_value(item), item_copy);
       cbor_decref(&item_copy);
       return tag;
     }
@@ -304,11 +304,11 @@ static int _pow(int b, int ex) {
   return res;
 }
 
-static void _cbor_type_marquee(FILE *out, char *label, int indent) {
+static void _cbor_type_marquee(FILE* out, char* label, int indent) {
   fprintf(out, "%*.*s[%s] ", indent, indent, " ", label);
 }
 
-static void _cbor_nested_describe(cbor_item_t *item, FILE *out, int indent) {
+static void _cbor_nested_describe(cbor_item_t* item, FILE* out, int indent) {
   const int indent_offset = 4;
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT: {
@@ -332,7 +332,7 @@ static void _cbor_nested_describe(cbor_item_t *item, FILE *out, int indent) {
           _cbor_nested_describe(cbor_bytestring_chunks_handle(item)[i], out,
                                 indent + indent_offset);
       } else {
-        const unsigned char *data = cbor_bytestring_handle(item);
+        const unsigned char* data = cbor_bytestring_handle(item);
         fprintf(out, "Definite, Length: %zuB, Data:\n",
                 cbor_bytestring_length(item));
         fprintf(out, "%*s", indent + indent_offset, " ");
@@ -421,7 +421,7 @@ static void _cbor_nested_describe(cbor_item_t *item, FILE *out, int indent) {
   }
 }
 
-void cbor_describe(cbor_item_t *item, FILE *out) {
+void cbor_describe(cbor_item_t* item, FILE* out) {
   _cbor_nested_describe(item, out, 0);
 }
 

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -137,7 +137,6 @@ static cbor_item_t *_cbor_copy_int(cbor_item_t *item, bool negative) {
 }
 
 static cbor_item_t *_cbor_copy_float_ctrl(cbor_item_t *item) {
-  // cppcheck-suppress missingReturn
   switch (cbor_float_get_width(item)) {
     case CBOR_FLOAT_0:
       return cbor_build_ctrl(cbor_ctrl_value(item));
@@ -147,11 +146,13 @@ static cbor_item_t *_cbor_copy_float_ctrl(cbor_item_t *item) {
       return cbor_build_float4(cbor_float_get_float4(item));
     case CBOR_FLOAT_64:
       return cbor_build_float8(cbor_float_get_float8(item));
+    default:
+      _CBOR_UNREACHABLE;
+      return NULL;
   }
 }
 
 cbor_item_t *cbor_copy(cbor_item_t *item) {
-  // cppcheck-suppress missingReturn
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
       return _cbor_copy_int(item, false);
@@ -282,6 +283,9 @@ cbor_item_t *cbor_copy(cbor_item_t *item) {
     }
     case CBOR_TYPE_FLOAT_CTRL:
       return _cbor_copy_float_ctrl(item);
+    default:
+      _CBOR_UNREACHABLE;
+      return NULL;
   }
 }
 

--- a/src/cbor/arrays.c
+++ b/src/cbor/arrays.c
@@ -9,21 +9,21 @@
 #include <string.h>
 #include "internal/memory_utils.h"
 
-size_t cbor_array_size(const cbor_item_t *item) {
+size_t cbor_array_size(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_array(item));
   return item->metadata.array_metadata.end_ptr;
 }
 
-size_t cbor_array_allocated(const cbor_item_t *item) {
+size_t cbor_array_allocated(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_array(item));
   return item->metadata.array_metadata.allocated;
 }
 
-cbor_item_t *cbor_array_get(const cbor_item_t *item, size_t index) {
-  return cbor_incref(((cbor_item_t **)item->data)[index]);
+cbor_item_t* cbor_array_get(const cbor_item_t* item, size_t index) {
+  return cbor_incref(((cbor_item_t**)item->data)[index]);
 }
 
-bool cbor_array_set(cbor_item_t *item, size_t index, cbor_item_t *value) {
+bool cbor_array_set(cbor_item_t* item, size_t index, cbor_item_t* value) {
   if (index == item->metadata.array_metadata.end_ptr) {
     return cbor_array_push(item, value);
   } else if (index < item->metadata.array_metadata.end_ptr) {
@@ -33,19 +33,19 @@ bool cbor_array_set(cbor_item_t *item, size_t index, cbor_item_t *value) {
   }
 }
 
-bool cbor_array_replace(cbor_item_t *item, size_t index, cbor_item_t *value) {
+bool cbor_array_replace(cbor_item_t* item, size_t index, cbor_item_t* value) {
   if (index >= item->metadata.array_metadata.end_ptr) return false;
   /* We cannot use cbor_array_get as that would increase the refcount */
-  cbor_intermediate_decref(((cbor_item_t **)item->data)[index]);
-  ((cbor_item_t **)item->data)[index] = cbor_incref(value);
+  cbor_intermediate_decref(((cbor_item_t**)item->data)[index]);
+  ((cbor_item_t**)item->data)[index] = cbor_incref(value);
   return true;
 }
 
-bool cbor_array_push(cbor_item_t *array, cbor_item_t *pushee) {
+bool cbor_array_push(cbor_item_t* array, cbor_item_t* pushee) {
   CBOR_ASSERT(cbor_isa_array(array));
-  struct _cbor_array_metadata *metadata =
-      (struct _cbor_array_metadata *)&array->metadata;
-  cbor_item_t **data = (cbor_item_t **)array->data;
+  struct _cbor_array_metadata* metadata =
+      (struct _cbor_array_metadata*)&array->metadata;
+  cbor_item_t** data = (cbor_item_t**)array->data;
   if (cbor_array_is_definite(array)) {
     /* Do not reallocate definite arrays */
     if (metadata->end_ptr >= metadata->allocated) {
@@ -64,8 +64,8 @@ bool cbor_array_push(cbor_item_t *array, cbor_item_t *pushee) {
                                   ? 1
                                   : CBOR_BUFFER_GROWTH * metadata->allocated;
 
-      unsigned char *new_data = _cbor_realloc_multiple(
-          array->data, sizeof(cbor_item_t *), new_allocation);
+      unsigned char* new_data = _cbor_realloc_multiple(
+          array->data, sizeof(cbor_item_t*), new_allocation);
       if (new_data == NULL) {
         return false;
       }
@@ -73,31 +73,31 @@ bool cbor_array_push(cbor_item_t *array, cbor_item_t *pushee) {
       array->data = new_data;
       metadata->allocated = new_allocation;
     }
-    ((cbor_item_t **)array->data)[metadata->end_ptr++] = pushee;
+    ((cbor_item_t**)array->data)[metadata->end_ptr++] = pushee;
   }
   cbor_incref(pushee);
   return true;
 }
 
-bool cbor_array_is_definite(const cbor_item_t *item) {
+bool cbor_array_is_definite(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_array(item));
   return item->metadata.array_metadata.type == _CBOR_METADATA_DEFINITE;
 }
 
-bool cbor_array_is_indefinite(const cbor_item_t *item) {
+bool cbor_array_is_indefinite(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_array(item));
   return item->metadata.array_metadata.type == _CBOR_METADATA_INDEFINITE;
 }
 
-cbor_item_t **cbor_array_handle(const cbor_item_t *item) {
+cbor_item_t** cbor_array_handle(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_array(item));
-  return (cbor_item_t **)item->data;
+  return (cbor_item_t**)item->data;
 }
 
-cbor_item_t *cbor_new_definite_array(size_t size) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_definite_array(size_t size) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
-  cbor_item_t **data = _cbor_alloc_multiple(sizeof(cbor_item_t *), size);
+  cbor_item_t** data = _cbor_alloc_multiple(sizeof(cbor_item_t*), size);
   _CBOR_DEPENDENT_NOTNULL(item, data);
 
   for (size_t i = 0; i < size; i++) {
@@ -110,13 +110,13 @@ cbor_item_t *cbor_new_definite_array(size_t size) {
       .metadata = {.array_metadata = {.type = _CBOR_METADATA_DEFINITE,
                                       .allocated = size,
                                       .end_ptr = 0}},
-      .data = (unsigned char *)data};
+      .data = (unsigned char*)data};
 
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_array(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_indefinite_array(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){

--- a/src/cbor/bytestrings.c
+++ b/src/cbor/bytestrings.c
@@ -9,27 +9,27 @@
 #include <string.h>
 #include "internal/memory_utils.h"
 
-size_t cbor_bytestring_length(const cbor_item_t *item) {
+size_t cbor_bytestring_length(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
   return item->metadata.bytestring_metadata.length;
 }
 
-unsigned char *cbor_bytestring_handle(const cbor_item_t *item) {
+unsigned char* cbor_bytestring_handle(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
   return item->data;
 }
 
-bool cbor_bytestring_is_definite(const cbor_item_t *item) {
+bool cbor_bytestring_is_definite(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
   return item->metadata.bytestring_metadata.type == _CBOR_METADATA_DEFINITE;
 }
 
-bool cbor_bytestring_is_indefinite(const cbor_item_t *item) {
+bool cbor_bytestring_is_indefinite(const cbor_item_t* item) {
   return !cbor_bytestring_is_definite(item);
 }
 
-cbor_item_t *cbor_new_definite_bytestring(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_definite_bytestring(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){
       .refcount = 1,
@@ -39,8 +39,8 @@ cbor_item_t *cbor_new_definite_bytestring(void) {
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_bytestring(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_indefinite_bytestring(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){
       .refcount = 1,
@@ -49,7 +49,7 @@ cbor_item_t *cbor_new_indefinite_bytestring(void) {
                                            .length = 0}},
       .data = _cbor_malloc(sizeof(struct cbor_indefinite_string_data))};
   _CBOR_DEPENDENT_NOTNULL(item, item->data);
-  *((struct cbor_indefinite_string_data *)item->data) =
+  *((struct cbor_indefinite_string_data*)item->data) =
       (struct cbor_indefinite_string_data){
           .chunk_count = 0,
           .chunk_capacity = 0,
@@ -58,17 +58,17 @@ cbor_item_t *cbor_new_indefinite_bytestring(void) {
   return item;
 }
 
-cbor_item_t *cbor_build_bytestring(cbor_data handle, size_t length) {
-  cbor_item_t *item = cbor_new_definite_bytestring();
+cbor_item_t* cbor_build_bytestring(cbor_data handle, size_t length) {
+  cbor_item_t* item = cbor_new_definite_bytestring();
   _CBOR_NOTNULL(item);
-  void *content = _cbor_malloc(length);
+  void* content = _cbor_malloc(length);
   _CBOR_DEPENDENT_NOTNULL(item, content);
   memcpy(content, handle, length);
   cbor_bytestring_set_handle(item, content, length);
   return item;
 }
 
-void cbor_bytestring_set_handle(cbor_item_t *item,
+void cbor_bytestring_set_handle(cbor_item_t* item,
                                 cbor_mutable_data CBOR_RESTRICT_POINTER data,
                                 size_t length) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
@@ -77,25 +77,25 @@ void cbor_bytestring_set_handle(cbor_item_t *item,
   item->metadata.bytestring_metadata.length = length;
 }
 
-cbor_item_t **cbor_bytestring_chunks_handle(const cbor_item_t *item) {
+cbor_item_t** cbor_bytestring_chunks_handle(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
   CBOR_ASSERT(cbor_bytestring_is_indefinite(item));
-  return ((struct cbor_indefinite_string_data *)item->data)->chunks;
+  return ((struct cbor_indefinite_string_data*)item->data)->chunks;
 }
 
-size_t cbor_bytestring_chunk_count(const cbor_item_t *item) {
+size_t cbor_bytestring_chunk_count(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
   CBOR_ASSERT(cbor_bytestring_is_indefinite(item));
-  return ((struct cbor_indefinite_string_data *)item->data)->chunk_count;
+  return ((struct cbor_indefinite_string_data*)item->data)->chunk_count;
 }
 
-bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
+bool cbor_bytestring_add_chunk(cbor_item_t* item, cbor_item_t* chunk) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
   CBOR_ASSERT(cbor_bytestring_is_indefinite(item));
   CBOR_ASSERT(cbor_isa_bytestring(chunk));
   CBOR_ASSERT(cbor_bytestring_is_definite(chunk));
-  struct cbor_indefinite_string_data *data =
-      (struct cbor_indefinite_string_data *)item->data;
+  struct cbor_indefinite_string_data* data =
+      (struct cbor_indefinite_string_data*)item->data;
   if (data->chunk_count == data->chunk_capacity) {
     if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
       return false;
@@ -105,8 +105,8 @@ bool cbor_bytestring_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
         data->chunk_capacity == 0 ? 1
                                   : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
 
-    cbor_item_t **new_chunks_data = _cbor_realloc_multiple(
-        data->chunks, sizeof(cbor_item_t *), new_chunk_capacity);
+    cbor_item_t** new_chunks_data = _cbor_realloc_multiple(
+        data->chunks, sizeof(cbor_item_t*), new_chunk_capacity);
 
     if (new_chunks_data == NULL) {
       return false;

--- a/src/cbor/bytestrings.h
+++ b/src/cbor/bytestrings.h
@@ -29,7 +29,7 @@ extern "C" {
  * @return length of the binary data. Zero if no chunk has been attached yet
  */
 _CBOR_NODISCARD
-CBOR_EXPORT size_t cbor_bytestring_length(const cbor_item_t *item);
+CBOR_EXPORT size_t cbor_bytestring_length(const cbor_item_t* item);
 
 /** Is the byte string definite?
  *
@@ -37,7 +37,7 @@ CBOR_EXPORT size_t cbor_bytestring_length(const cbor_item_t *item);
  * @return Is the byte string definite?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_bytestring_is_definite(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_bytestring_is_definite(const cbor_item_t* item);
 
 /** Is the byte string indefinite?
  *
@@ -45,7 +45,7 @@ CBOR_EXPORT bool cbor_bytestring_is_definite(const cbor_item_t *item);
  * @return Is the byte string indefinite?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_bytestring_is_indefinite(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_bytestring_is_indefinite(const cbor_item_t* item);
 
 /** Get the handle to the binary data
  *
@@ -58,7 +58,7 @@ CBOR_EXPORT bool cbor_bytestring_is_indefinite(const cbor_item_t *item);
  * yet.
  */
 _CBOR_NODISCARD
-CBOR_EXPORT cbor_mutable_data cbor_bytestring_handle(const cbor_item_t *item);
+CBOR_EXPORT cbor_mutable_data cbor_bytestring_handle(const cbor_item_t* item);
 
 /** Set the handle to the binary data
  *
@@ -69,7 +69,7 @@ CBOR_EXPORT cbor_mutable_data cbor_bytestring_handle(const cbor_item_t *item);
  * @param length Length of the data block
  */
 CBOR_EXPORT void cbor_bytestring_set_handle(
-    cbor_item_t *item, cbor_mutable_data CBOR_RESTRICT_POINTER data,
+    cbor_item_t* item, cbor_mutable_data CBOR_RESTRICT_POINTER data,
     size_t length);
 
 /** Get the handle to the array of chunks
@@ -81,8 +81,8 @@ CBOR_EXPORT void cbor_bytestring_set_handle(
  * @return array of #cbor_bytestring_chunk_count definite bytestrings
  */
 _CBOR_NODISCARD
-CBOR_EXPORT cbor_item_t **cbor_bytestring_chunks_handle(
-    const cbor_item_t *item);
+CBOR_EXPORT cbor_item_t** cbor_bytestring_chunks_handle(
+    const cbor_item_t* item);
 
 /** Get the number of chunks this string consist of
  *
@@ -90,7 +90,7 @@ CBOR_EXPORT cbor_item_t **cbor_bytestring_chunks_handle(
  * @return The chunk count. 0 for freshly created items.
  */
 _CBOR_NODISCARD
-CBOR_EXPORT size_t cbor_bytestring_chunk_count(const cbor_item_t *item);
+CBOR_EXPORT size_t cbor_bytestring_chunk_count(const cbor_item_t* item);
 
 /** Appends a chunk to the bytestring
  *
@@ -105,8 +105,8 @@ CBOR_EXPORT size_t cbor_bytestring_chunk_count(const cbor_item_t *item);
  * of `chunk` is not increased and the `item` is left intact.
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_bytestring_add_chunk(cbor_item_t *item,
-                                           cbor_item_t *chunk);
+CBOR_EXPORT bool cbor_bytestring_add_chunk(cbor_item_t* item,
+                                           cbor_item_t* chunk);
 
 /** Creates a new definite byte string
  *
@@ -117,7 +117,7 @@ CBOR_EXPORT bool cbor_bytestring_add_chunk(cbor_item_t *item,
  * @return `NULL` if memory allocation fails
  */
 _CBOR_NODISCARD
-CBOR_EXPORT cbor_item_t *cbor_new_definite_bytestring(void);
+CBOR_EXPORT cbor_item_t* cbor_new_definite_bytestring(void);
 
 /** Creates a new indefinite byte string
  *
@@ -128,7 +128,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_definite_bytestring(void);
  * @return `NULL` if memory allocation fails
  */
 _CBOR_NODISCARD
-CBOR_EXPORT cbor_item_t *cbor_new_indefinite_bytestring(void);
+CBOR_EXPORT cbor_item_t* cbor_new_indefinite_bytestring(void);
 
 /** Creates a new byte string and initializes it
  *
@@ -141,7 +141,7 @@ CBOR_EXPORT cbor_item_t *cbor_new_indefinite_bytestring(void);
  * @return `NULL` if memory allocation fails
  */
 _CBOR_NODISCARD
-CBOR_EXPORT cbor_item_t *cbor_build_bytestring(cbor_data handle, size_t length);
+CBOR_EXPORT cbor_item_t* cbor_build_bytestring(cbor_data handle, size_t length);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/callbacks.c
+++ b/src/cbor/callbacks.c
@@ -7,72 +7,72 @@
 
 #include "callbacks.h"
 
-void cbor_null_uint8_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_uint8_callback(void* _ctx _CBOR_UNUSED,
                               uint8_t _CBOR_UNUSED _val) {}
 
-void cbor_null_uint16_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_uint16_callback(void* _ctx _CBOR_UNUSED,
                                uint16_t _CBOR_UNUSED _val) {}
 
-void cbor_null_uint32_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_uint32_callback(void* _ctx _CBOR_UNUSED,
                                uint32_t _CBOR_UNUSED _val) {}
 
-void cbor_null_uint64_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_uint64_callback(void* _ctx _CBOR_UNUSED,
                                uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint8_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_negint8_callback(void* _ctx _CBOR_UNUSED,
                                 uint8_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint16_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_negint16_callback(void* _ctx _CBOR_UNUSED,
                                  uint16_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint32_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_negint32_callback(void* _ctx _CBOR_UNUSED,
                                  uint32_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint64_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_negint64_callback(void* _ctx _CBOR_UNUSED,
                                  uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_string_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_string_callback(void* _ctx _CBOR_UNUSED,
                                cbor_data _CBOR_UNUSED _val,
                                uint64_t _CBOR_UNUSED _val2) {}
 
-void cbor_null_string_start_callback(void *_CBOR_UNUSED _ctx) {}
+void cbor_null_string_start_callback(void* _ctx _CBOR_UNUSED) {}
 
-void cbor_null_byte_string_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_byte_string_callback(void* _ctx _CBOR_UNUSED,
                                     cbor_data _CBOR_UNUSED _val,
                                     uint64_t _CBOR_UNUSED _val2) {}
 
-void cbor_null_byte_string_start_callback(void *_CBOR_UNUSED _ctx) {}
+void cbor_null_byte_string_start_callback(void* _ctx _CBOR_UNUSED) {}
 
-void cbor_null_array_start_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_array_start_callback(void* _ctx _CBOR_UNUSED,
                                     uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_indef_array_start_callback(void *_CBOR_UNUSED _ctx) {}
+void cbor_null_indef_array_start_callback(void* _ctx _CBOR_UNUSED) {}
 
-void cbor_null_map_start_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_map_start_callback(void* _ctx _CBOR_UNUSED,
                                   uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_indef_map_start_callback(void *_CBOR_UNUSED _ctx) {}
+void cbor_null_indef_map_start_callback(void* _ctx _CBOR_UNUSED) {}
 
-void cbor_null_tag_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_tag_callback(void* _ctx _CBOR_UNUSED,
                             uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_float2_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_float2_callback(void* _ctx _CBOR_UNUSED,
                                float _CBOR_UNUSED _val) {}
 
-void cbor_null_float4_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_float4_callback(void* _ctx _CBOR_UNUSED,
                                float _CBOR_UNUSED _val) {}
 
-void cbor_null_float8_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_float8_callback(void* _ctx _CBOR_UNUSED,
                                double _CBOR_UNUSED _val) {}
 
-void cbor_null_null_callback(void *_CBOR_UNUSED _ctx) {}
+void cbor_null_null_callback(void* _ctx _CBOR_UNUSED) {}
 
-void cbor_null_undefined_callback(void *_CBOR_UNUSED _ctx) {}
+void cbor_null_undefined_callback(void* _ctx _CBOR_UNUSED) {}
 
-void cbor_null_boolean_callback(void *_CBOR_UNUSED _ctx,
+void cbor_null_boolean_callback(void* _ctx _CBOR_UNUSED,
                                 bool _CBOR_UNUSED _val) {}
 
-void cbor_null_indef_break_callback(void *_CBOR_UNUSED _ctx) {}
+void cbor_null_indef_break_callback(void* _ctx _CBOR_UNUSED) {}
 
 CBOR_EXPORT const struct cbor_callbacks cbor_empty_callbacks = {
     /* Type 0 - Unsigned integers */

--- a/src/cbor/callbacks.c
+++ b/src/cbor/callbacks.c
@@ -7,72 +7,72 @@
 
 #include "callbacks.h"
 
-void cbor_null_uint8_callback(void *_CBOR_UNUSED(_ctx),
-                              uint8_t _CBOR_UNUSED(_val)) {}
+void cbor_null_uint8_callback(void *_CBOR_UNUSED _ctx,
+                              uint8_t _CBOR_UNUSED _val) {}
 
-void cbor_null_uint16_callback(void *_CBOR_UNUSED(_ctx),
-                               uint16_t _CBOR_UNUSED(_val)) {}
+void cbor_null_uint16_callback(void *_CBOR_UNUSED _ctx,
+                               uint16_t _CBOR_UNUSED _val) {}
 
-void cbor_null_uint32_callback(void *_CBOR_UNUSED(_ctx),
-                               uint32_t _CBOR_UNUSED(_val)) {}
+void cbor_null_uint32_callback(void *_CBOR_UNUSED _ctx,
+                               uint32_t _CBOR_UNUSED _val) {}
 
-void cbor_null_uint64_callback(void *_CBOR_UNUSED(_ctx),
-                               uint64_t _CBOR_UNUSED(_val)) {}
+void cbor_null_uint64_callback(void *_CBOR_UNUSED _ctx,
+                               uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint8_callback(void *_CBOR_UNUSED(_ctx),
-                                uint8_t _CBOR_UNUSED(_val)) {}
+void cbor_null_negint8_callback(void *_CBOR_UNUSED _ctx,
+                                uint8_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint16_callback(void *_CBOR_UNUSED(_ctx),
-                                 uint16_t _CBOR_UNUSED(_val)) {}
+void cbor_null_negint16_callback(void *_CBOR_UNUSED _ctx,
+                                 uint16_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint32_callback(void *_CBOR_UNUSED(_ctx),
-                                 uint32_t _CBOR_UNUSED(_val)) {}
+void cbor_null_negint32_callback(void *_CBOR_UNUSED _ctx,
+                                 uint32_t _CBOR_UNUSED _val) {}
 
-void cbor_null_negint64_callback(void *_CBOR_UNUSED(_ctx),
-                                 uint64_t _CBOR_UNUSED(_val)) {}
+void cbor_null_negint64_callback(void *_CBOR_UNUSED _ctx,
+                                 uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_string_callback(void *_CBOR_UNUSED(_ctx),
-                               cbor_data _CBOR_UNUSED(_val),
-                               uint64_t _CBOR_UNUSED(_val2)) {}
+void cbor_null_string_callback(void *_CBOR_UNUSED _ctx,
+                               cbor_data _CBOR_UNUSED _val,
+                               uint64_t _CBOR_UNUSED _val2) {}
 
-void cbor_null_string_start_callback(void *_CBOR_UNUSED(_ctx)) {}
+void cbor_null_string_start_callback(void *_CBOR_UNUSED _ctx) {}
 
-void cbor_null_byte_string_callback(void *_CBOR_UNUSED(_ctx),
-                                    cbor_data _CBOR_UNUSED(_val),
-                                    uint64_t _CBOR_UNUSED(_val2)) {}
+void cbor_null_byte_string_callback(void *_CBOR_UNUSED _ctx,
+                                    cbor_data _CBOR_UNUSED _val,
+                                    uint64_t _CBOR_UNUSED _val2) {}
 
-void cbor_null_byte_string_start_callback(void *_CBOR_UNUSED(_ctx)) {}
+void cbor_null_byte_string_start_callback(void *_CBOR_UNUSED _ctx) {}
 
-void cbor_null_array_start_callback(void *_CBOR_UNUSED(_ctx),
-                                    uint64_t _CBOR_UNUSED(_val)) {}
+void cbor_null_array_start_callback(void *_CBOR_UNUSED _ctx,
+                                    uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_indef_array_start_callback(void *_CBOR_UNUSED(_ctx)) {}
+void cbor_null_indef_array_start_callback(void *_CBOR_UNUSED _ctx) {}
 
-void cbor_null_map_start_callback(void *_CBOR_UNUSED(_ctx),
-                                  uint64_t _CBOR_UNUSED(_val)) {}
+void cbor_null_map_start_callback(void *_CBOR_UNUSED _ctx,
+                                  uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_indef_map_start_callback(void *_CBOR_UNUSED(_ctx)) {}
+void cbor_null_indef_map_start_callback(void *_CBOR_UNUSED _ctx) {}
 
-void cbor_null_tag_callback(void *_CBOR_UNUSED(_ctx),
-                            uint64_t _CBOR_UNUSED(_val)) {}
+void cbor_null_tag_callback(void *_CBOR_UNUSED _ctx,
+                            uint64_t _CBOR_UNUSED _val) {}
 
-void cbor_null_float2_callback(void *_CBOR_UNUSED(_ctx),
-                               float _CBOR_UNUSED(_val)) {}
+void cbor_null_float2_callback(void *_CBOR_UNUSED _ctx,
+                               float _CBOR_UNUSED _val) {}
 
-void cbor_null_float4_callback(void *_CBOR_UNUSED(_ctx),
-                               float _CBOR_UNUSED(_val)) {}
+void cbor_null_float4_callback(void *_CBOR_UNUSED _ctx,
+                               float _CBOR_UNUSED _val) {}
 
-void cbor_null_float8_callback(void *_CBOR_UNUSED(_ctx),
-                               double _CBOR_UNUSED(_val)) {}
+void cbor_null_float8_callback(void *_CBOR_UNUSED _ctx,
+                               double _CBOR_UNUSED _val) {}
 
-void cbor_null_null_callback(void *_CBOR_UNUSED(_ctx)) {}
+void cbor_null_null_callback(void *_CBOR_UNUSED _ctx) {}
 
-void cbor_null_undefined_callback(void *_CBOR_UNUSED(_ctx)) {}
+void cbor_null_undefined_callback(void *_CBOR_UNUSED _ctx) {}
 
-void cbor_null_boolean_callback(void *_CBOR_UNUSED(_ctx),
-                                bool _CBOR_UNUSED(_val)) {}
+void cbor_null_boolean_callback(void *_CBOR_UNUSED _ctx,
+                                bool _CBOR_UNUSED _val) {}
 
-void cbor_null_indef_break_callback(void *_CBOR_UNUSED(_ctx)) {}
+void cbor_null_indef_break_callback(void *_CBOR_UNUSED _ctx) {}
 
 CBOR_EXPORT const struct cbor_callbacks cbor_empty_callbacks = {
     /* Type 0 - Unsigned integers */

--- a/src/cbor/callbacks.h
+++ b/src/cbor/callbacks.h
@@ -18,34 +18,34 @@ extern "C" {
 #endif
 
 /** Callback prototype */
-typedef void (*cbor_int8_callback)(void *, uint8_t);
+typedef void (*cbor_int8_callback)(void*, uint8_t);
 
 /** Callback prototype */
-typedef void (*cbor_int16_callback)(void *, uint16_t);
+typedef void (*cbor_int16_callback)(void*, uint16_t);
 
 /** Callback prototype */
-typedef void (*cbor_int32_callback)(void *, uint32_t);
+typedef void (*cbor_int32_callback)(void*, uint32_t);
 
 /** Callback prototype */
-typedef void (*cbor_int64_callback)(void *, uint64_t);
+typedef void (*cbor_int64_callback)(void*, uint64_t);
 
 /** Callback prototype */
-typedef void (*cbor_simple_callback)(void *);
+typedef void (*cbor_simple_callback)(void*);
 
 /** Callback prototype */
-typedef void (*cbor_string_callback)(void *, cbor_data, uint64_t);
+typedef void (*cbor_string_callback)(void*, cbor_data, uint64_t);
 
 /** Callback prototype */
-typedef void (*cbor_collection_callback)(void *, uint64_t);
+typedef void (*cbor_collection_callback)(void*, uint64_t);
 
 /** Callback prototype */
-typedef void (*cbor_float_callback)(void *, float);
+typedef void (*cbor_float_callback)(void*, float);
 
 /** Callback prototype */
-typedef void (*cbor_double_callback)(void *, double);
+typedef void (*cbor_double_callback)(void*, double);
 
 /** Callback prototype */
-typedef void (*cbor_bool_callback)(void *, bool);
+typedef void (*cbor_bool_callback)(void*, bool);
 
 /** Callback bundle -- passed to the decoder */
 struct cbor_callbacks {
@@ -108,76 +108,76 @@ struct cbor_callbacks {
 };
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_uint8_callback(void *, uint8_t);
+CBOR_EXPORT void cbor_null_uint8_callback(void*, uint8_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_uint16_callback(void *, uint16_t);
+CBOR_EXPORT void cbor_null_uint16_callback(void*, uint16_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_uint32_callback(void *, uint32_t);
+CBOR_EXPORT void cbor_null_uint32_callback(void*, uint32_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_uint64_callback(void *, uint64_t);
+CBOR_EXPORT void cbor_null_uint64_callback(void*, uint64_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_negint8_callback(void *, uint8_t);
+CBOR_EXPORT void cbor_null_negint8_callback(void*, uint8_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_negint16_callback(void *, uint16_t);
+CBOR_EXPORT void cbor_null_negint16_callback(void*, uint16_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_negint32_callback(void *, uint32_t);
+CBOR_EXPORT void cbor_null_negint32_callback(void*, uint32_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_negint64_callback(void *, uint64_t);
+CBOR_EXPORT void cbor_null_negint64_callback(void*, uint64_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_string_callback(void *, cbor_data, uint64_t);
+CBOR_EXPORT void cbor_null_string_callback(void*, cbor_data, uint64_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_string_start_callback(void *);
+CBOR_EXPORT void cbor_null_string_start_callback(void*);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_byte_string_callback(void *, cbor_data, uint64_t);
+CBOR_EXPORT void cbor_null_byte_string_callback(void*, cbor_data, uint64_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_byte_string_start_callback(void *);
+CBOR_EXPORT void cbor_null_byte_string_start_callback(void*);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_array_start_callback(void *, uint64_t);
+CBOR_EXPORT void cbor_null_array_start_callback(void*, uint64_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_indef_array_start_callback(void *);
+CBOR_EXPORT void cbor_null_indef_array_start_callback(void*);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_map_start_callback(void *, uint64_t);
+CBOR_EXPORT void cbor_null_map_start_callback(void*, uint64_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_indef_map_start_callback(void *);
+CBOR_EXPORT void cbor_null_indef_map_start_callback(void*);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_tag_callback(void *, uint64_t);
+CBOR_EXPORT void cbor_null_tag_callback(void*, uint64_t);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_float2_callback(void *, float);
+CBOR_EXPORT void cbor_null_float2_callback(void*, float);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_float4_callback(void *, float);
+CBOR_EXPORT void cbor_null_float4_callback(void*, float);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_float8_callback(void *, double);
+CBOR_EXPORT void cbor_null_float8_callback(void*, double);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_null_callback(void *);
+CBOR_EXPORT void cbor_null_null_callback(void*);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_undefined_callback(void *);
+CBOR_EXPORT void cbor_null_undefined_callback(void*);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_boolean_callback(void *, bool);
+CBOR_EXPORT void cbor_null_boolean_callback(void*, bool);
 
 /** Dummy callback implementation - does nothing */
-CBOR_EXPORT void cbor_null_indef_break_callback(void *);
+CBOR_EXPORT void cbor_null_indef_break_callback(void*);
 
 /** Dummy callback bundle - does nothing */
 CBOR_EXPORT extern const struct cbor_callbacks cbor_empty_callbacks;

--- a/src/cbor/common.c
+++ b/src/cbor/common.c
@@ -19,69 +19,69 @@
 bool _cbor_enable_assert = true;
 #endif
 
-bool cbor_isa_uint(const cbor_item_t *item) {
+bool cbor_isa_uint(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_UINT;
 }
 
-bool cbor_isa_negint(const cbor_item_t *item) {
+bool cbor_isa_negint(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_NEGINT;
 }
 
-bool cbor_isa_bytestring(const cbor_item_t *item) {
+bool cbor_isa_bytestring(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_BYTESTRING;
 }
 
-bool cbor_isa_string(const cbor_item_t *item) {
+bool cbor_isa_string(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_STRING;
 }
 
-bool cbor_isa_array(const cbor_item_t *item) {
+bool cbor_isa_array(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_ARRAY;
 }
 
-bool cbor_isa_map(const cbor_item_t *item) {
+bool cbor_isa_map(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_MAP;
 }
 
-bool cbor_isa_tag(const cbor_item_t *item) {
+bool cbor_isa_tag(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_TAG;
 }
 
-bool cbor_isa_float_ctrl(const cbor_item_t *item) {
+bool cbor_isa_float_ctrl(const cbor_item_t* item) {
   return item->type == CBOR_TYPE_FLOAT_CTRL;
 }
 
-cbor_type cbor_typeof(const cbor_item_t *item) { return item->type; }
+cbor_type cbor_typeof(const cbor_item_t* item) { return item->type; }
 
-bool cbor_is_int(const cbor_item_t *item) {
+bool cbor_is_int(const cbor_item_t* item) {
   return cbor_isa_uint(item) || cbor_isa_negint(item);
 }
 
-bool cbor_is_bool(const cbor_item_t *item) {
+bool cbor_is_bool(const cbor_item_t* item) {
   return cbor_isa_float_ctrl(item) &&
          (cbor_ctrl_value(item) == CBOR_CTRL_FALSE ||
           cbor_ctrl_value(item) == CBOR_CTRL_TRUE);
 }
 
-bool cbor_is_null(const cbor_item_t *item) {
+bool cbor_is_null(const cbor_item_t* item) {
   return cbor_isa_float_ctrl(item) && cbor_ctrl_value(item) == CBOR_CTRL_NULL;
 }
 
-bool cbor_is_undef(const cbor_item_t *item) {
+bool cbor_is_undef(const cbor_item_t* item) {
   return cbor_isa_float_ctrl(item) && cbor_ctrl_value(item) == CBOR_CTRL_UNDEF;
 }
 
-bool cbor_is_float(const cbor_item_t *item) {
+bool cbor_is_float(const cbor_item_t* item) {
   return cbor_isa_float_ctrl(item) && !cbor_float_ctrl_is_ctrl(item);
 }
 
-cbor_item_t *cbor_incref(cbor_item_t *item) {
+cbor_item_t* cbor_incref(cbor_item_t* item) {
   item->refcount++;
   return item;
 }
 
-void cbor_decref(cbor_item_t **item_ref) {
-  cbor_item_t *item = *item_ref;
+void cbor_decref(cbor_item_t** item_ref) {
+  cbor_item_t* item = *item_ref;
   CBOR_ASSERT(item->refcount > 0);
   if (--item->refcount == 0) {
     switch (item->type) {
@@ -95,11 +95,10 @@ void cbor_decref(cbor_item_t **item_ref) {
           _cbor_free(item->data);
         } else {
           /* We need to decref all chunks */
-          cbor_item_t **handle = cbor_bytestring_chunks_handle(item);
+          cbor_item_t** handle = cbor_bytestring_chunks_handle(item);
           for (size_t i = 0; i < cbor_bytestring_chunk_count(item); i++)
             cbor_decref(&handle[i]);
-          _cbor_free(
-              ((struct cbor_indefinite_string_data *)item->data)->chunks);
+          _cbor_free(((struct cbor_indefinite_string_data*)item->data)->chunks);
           _cbor_free(item->data);
         }
         break;
@@ -109,18 +108,17 @@ void cbor_decref(cbor_item_t **item_ref) {
           _cbor_free(item->data);
         } else {
           /* We need to decref all chunks */
-          cbor_item_t **handle = cbor_string_chunks_handle(item);
+          cbor_item_t** handle = cbor_string_chunks_handle(item);
           for (size_t i = 0; i < cbor_string_chunk_count(item); i++)
             cbor_decref(&handle[i]);
-          _cbor_free(
-              ((struct cbor_indefinite_string_data *)item->data)->chunks);
+          _cbor_free(((struct cbor_indefinite_string_data*)item->data)->chunks);
           _cbor_free(item->data);
         }
         break;
       }
       case CBOR_TYPE_ARRAY: {
         /* Get all items and decref them */
-        cbor_item_t **handle = cbor_array_handle(item);
+        cbor_item_t** handle = cbor_array_handle(item);
         size_t size = cbor_array_size(item);
         for (size_t i = 0; i < size; i++)
           if (handle[i] != NULL) cbor_decref(&handle[i]);
@@ -128,7 +126,7 @@ void cbor_decref(cbor_item_t **item_ref) {
         break;
       }
       case CBOR_TYPE_MAP: {
-        struct cbor_pair *handle = cbor_map_handle(item);
+        struct cbor_pair* handle = cbor_map_handle(item);
         for (size_t i = 0; i < item->metadata.map_metadata.end_ptr;
              i++, handle++) {
           cbor_decref(&handle->key);
@@ -153,11 +151,11 @@ void cbor_decref(cbor_item_t **item_ref) {
   }
 }
 
-void cbor_intermediate_decref(cbor_item_t *item) { cbor_decref(&item); }
+void cbor_intermediate_decref(cbor_item_t* item) { cbor_decref(&item); }
 
-size_t cbor_refcount(const cbor_item_t *item) { return item->refcount; }
+size_t cbor_refcount(const cbor_item_t* item) { return item->refcount; }
 
-cbor_item_t *cbor_move(cbor_item_t *item) {
+cbor_item_t* cbor_move(cbor_item_t* item) {
   item->refcount--;
   return item;
 }

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -86,10 +86,10 @@ extern bool _cbor_enable_assert;
 // available
 #define _CBOR_NODISCARD __attribute__((warn_unused_result))
 #elif defined(_MSC_VER)
-#define _CBOR_UNUSED x __pragma(warning(suppress : 4100 4101)) x
+#define _CBOR_UNUSED __pragma(warning(suppress : 4100 4101))
 #define _CBOR_NODISCARD
 #else
-#define _CBOR_UNUSED x x
+#define _CBOR_UNUSED
 #define _CBOR_NODISCARD
 #endif
 

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -99,9 +99,9 @@ extern bool _cbor_enable_assert;
 #define _CBOR_UNREACHABLE
 #endif
 
-typedef void *(*_cbor_malloc_t)(size_t);
-typedef void *(*_cbor_realloc_t)(void *, size_t);
-typedef void (*_cbor_free_t)(void *);
+typedef void* (*_cbor_malloc_t)(size_t);
+typedef void* (*_cbor_realloc_t)(void*, size_t);
+typedef void (*_cbor_free_t)(void*);
 
 CBOR_EXPORT extern _cbor_malloc_t _cbor_malloc;
 CBOR_EXPORT extern _cbor_realloc_t _cbor_realloc;
@@ -161,7 +161,7 @@ CBOR_EXPORT void cbor_set_allocs(_cbor_malloc_t custom_malloc,
  */
 _CBOR_NODISCARD
 CBOR_EXPORT cbor_type cbor_typeof(
-    const cbor_item_t *item); /* Will be inlined iff link-time opt is enabled */
+    const cbor_item_t* item); /* Will be inlined iff link-time opt is enabled */
 
 /* Standard CBOR Major item types */
 
@@ -170,56 +170,56 @@ CBOR_EXPORT cbor_type cbor_typeof(
  * @return Is the item an #CBOR_TYPE_UINT?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_uint(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_uint(const cbor_item_t* item);
 
 /** Does the item have the appropriate major type?
  * @param item the item
  * @return Is the item a #CBOR_TYPE_NEGINT?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_negint(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_negint(const cbor_item_t* item);
 
 /** Does the item have the appropriate major type?
  * @param item the item
  * @return Is the item a #CBOR_TYPE_BYTESTRING?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_bytestring(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_bytestring(const cbor_item_t* item);
 
 /** Does the item have the appropriate major type?
  * @param item the item
  * @return Is the item a #CBOR_TYPE_STRING?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_string(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_string(const cbor_item_t* item);
 
 /** Does the item have the appropriate major type?
  * @param item the item
  * @return Is the item an #CBOR_TYPE_ARRAY?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_array(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_array(const cbor_item_t* item);
 
 /** Does the item have the appropriate major type?
  * @param item the item
  * @return Is the item a #CBOR_TYPE_MAP?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_map(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_map(const cbor_item_t* item);
 
 /** Does the item have the appropriate major type?
  * @param item the item
  * @return Is the item a #CBOR_TYPE_TAG?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_tag(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_tag(const cbor_item_t* item);
 
 /** Does the item have the appropriate major type?
  * @param item the item
  * @return Is the item a #CBOR_TYPE_FLOAT_CTRL?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_isa_float_ctrl(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_isa_float_ctrl(const cbor_item_t* item);
 
 /* Practical types with respect to their semantics (but not tag values) */
 
@@ -228,21 +228,21 @@ CBOR_EXPORT bool cbor_isa_float_ctrl(const cbor_item_t *item);
  * @return  Is the item an integer, either positive or negative?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_is_int(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_is_int(const cbor_item_t* item);
 
 /** Is the item an a floating point number?
  * @param item the item
  * @return  Is the item a floating point number?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_is_float(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_is_float(const cbor_item_t* item);
 
 /** Is the item an a boolean?
  * @param item the item
  * @return  Is the item a boolean?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_is_bool(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_is_bool(const cbor_item_t* item);
 
 /** Does this item represent `null`
  *
@@ -255,7 +255,7 @@ CBOR_EXPORT bool cbor_is_bool(const cbor_item_t *item);
  * @return  Is the item (CBOR logical) null?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_is_null(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_is_null(const cbor_item_t* item);
 
 /** Does this item represent `undefined`
  *
@@ -268,7 +268,7 @@ CBOR_EXPORT bool cbor_is_null(const cbor_item_t *item);
  * @return Is the item (CBOR logical) undefined?
  */
 _CBOR_NODISCARD
-CBOR_EXPORT bool cbor_is_undef(const cbor_item_t *item);
+CBOR_EXPORT bool cbor_is_undef(const cbor_item_t* item);
 
 /*
  * ============================================================================
@@ -286,7 +286,7 @@ CBOR_EXPORT bool cbor_is_undef(const cbor_item_t *item);
  * @param item Reference to an item
  * @return The input \p item
  */
-CBOR_EXPORT cbor_item_t *cbor_incref(cbor_item_t *item);
+CBOR_EXPORT cbor_item_t* cbor_incref(cbor_item_t* item);
 
 /** Decreases the item's reference count by one, deallocating the item if needed
  *
@@ -295,7 +295,7 @@ CBOR_EXPORT cbor_item_t *cbor_incref(cbor_item_t *item);
  *
  * @param item Reference to an item. Will be set to `NULL` if deallocated
  */
-CBOR_EXPORT void cbor_decref(cbor_item_t **item);
+CBOR_EXPORT void cbor_decref(cbor_item_t** item);
 
 /** Decreases the item's reference count by one, deallocating the item if needed
  *
@@ -304,7 +304,7 @@ CBOR_EXPORT void cbor_decref(cbor_item_t **item);
  *
  * @param item Reference to an item
  */
-CBOR_EXPORT void cbor_intermediate_decref(cbor_item_t *item);
+CBOR_EXPORT void cbor_intermediate_decref(cbor_item_t* item);
 
 /** Get the item's reference count
  *
@@ -318,7 +318,7 @@ CBOR_EXPORT void cbor_intermediate_decref(cbor_item_t *item);
  * @return the reference count
  */
 _CBOR_NODISCARD
-CBOR_EXPORT size_t cbor_refcount(const cbor_item_t *item);
+CBOR_EXPORT size_t cbor_refcount(const cbor_item_t* item);
 
 /** Provides CPP-like move construct
  *
@@ -336,7 +336,7 @@ CBOR_EXPORT size_t cbor_refcount(const cbor_item_t *item);
  * @return the item with reference count decreased by one
  */
 _CBOR_NODISCARD
-CBOR_EXPORT cbor_item_t *cbor_move(cbor_item_t *item);
+CBOR_EXPORT cbor_item_t* cbor_move(cbor_item_t* item);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -93,6 +93,12 @@ extern bool _cbor_enable_assert;
 #define _CBOR_NODISCARD
 #endif
 
+#ifdef CBOR_HAS_BUILTIN_UNREACHABLE
+#define _CBOR_UNREACHABLE __builtin_unreachable()
+#else
+#define _CBOR_UNREACHABLE
+#endif
+
 typedef void *(*_cbor_malloc_t)(size_t);
 typedef void *(*_cbor_realloc_t)(void *, size_t);
 typedef void (*_cbor_free_t)(void *);

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -81,15 +81,15 @@ extern bool _cbor_enable_assert;
 #define _CBOR_TO_STR(x) _CBOR_TO_STR_(x) /* enables proper double expansion */
 
 #ifdef __GNUC__
-#define _CBOR_UNUSED(x) __attribute__((__unused__)) x
+#define _CBOR_UNUSED __attribute__((__unused__))
 // TODO(https://github.com/PJK/libcbor/issues/247): Prefer [[nodiscard]] if
 // available
 #define _CBOR_NODISCARD __attribute__((warn_unused_result))
 #elif defined(_MSC_VER)
-#define _CBOR_UNUSED(x) __pragma(warning(suppress : 4100 4101)) x
+#define _CBOR_UNUSED x __pragma(warning(suppress : 4100 4101)) x
 #define _CBOR_NODISCARD
 #else
-#define _CBOR_UNUSED(x) x
+#define _CBOR_UNUSED x x
 #define _CBOR_NODISCARD
 #endif
 

--- a/src/cbor/encoding.c
+++ b/src/cbor/encoding.c
@@ -11,62 +11,62 @@
 
 #include "internal/encoders.h"
 
-size_t cbor_encode_uint8(uint8_t value, unsigned char *buffer,
+size_t cbor_encode_uint8(uint8_t value, unsigned char* buffer,
                          size_t buffer_size) {
   return _cbor_encode_uint8(value, buffer, buffer_size, 0x00);
 }
 
-size_t cbor_encode_uint16(uint16_t value, unsigned char *buffer,
+size_t cbor_encode_uint16(uint16_t value, unsigned char* buffer,
                           size_t buffer_size) {
   return _cbor_encode_uint16(value, buffer, buffer_size, 0x00);
 }
 
-size_t cbor_encode_uint32(uint32_t value, unsigned char *buffer,
+size_t cbor_encode_uint32(uint32_t value, unsigned char* buffer,
                           size_t buffer_size) {
   return _cbor_encode_uint32(value, buffer, buffer_size, 0x00);
 }
 
-size_t cbor_encode_uint64(uint64_t value, unsigned char *buffer,
+size_t cbor_encode_uint64(uint64_t value, unsigned char* buffer,
                           size_t buffer_size) {
   return _cbor_encode_uint64(value, buffer, buffer_size, 0x00);
 }
 
-size_t cbor_encode_uint(uint64_t value, unsigned char *buffer,
+size_t cbor_encode_uint(uint64_t value, unsigned char* buffer,
                         size_t buffer_size) {
   return _cbor_encode_uint(value, buffer, buffer_size, 0x00);
 }
 
-size_t cbor_encode_negint8(uint8_t value, unsigned char *buffer,
+size_t cbor_encode_negint8(uint8_t value, unsigned char* buffer,
                            size_t buffer_size) {
   return _cbor_encode_uint8(value, buffer, buffer_size, 0x20);
 }
 
-size_t cbor_encode_negint16(uint16_t value, unsigned char *buffer,
+size_t cbor_encode_negint16(uint16_t value, unsigned char* buffer,
                             size_t buffer_size) {
   return _cbor_encode_uint16(value, buffer, buffer_size, 0x20);
 }
 
-size_t cbor_encode_negint32(uint32_t value, unsigned char *buffer,
+size_t cbor_encode_negint32(uint32_t value, unsigned char* buffer,
                             size_t buffer_size) {
   return _cbor_encode_uint32(value, buffer, buffer_size, 0x20);
 }
 
-size_t cbor_encode_negint64(uint64_t value, unsigned char *buffer,
+size_t cbor_encode_negint64(uint64_t value, unsigned char* buffer,
                             size_t buffer_size) {
   return _cbor_encode_uint64(value, buffer, buffer_size, 0x20);
 }
 
-size_t cbor_encode_negint(uint64_t value, unsigned char *buffer,
+size_t cbor_encode_negint(uint64_t value, unsigned char* buffer,
                           size_t buffer_size) {
   return _cbor_encode_uint(value, buffer, buffer_size, 0x20);
 }
 
-size_t cbor_encode_bytestring_start(size_t length, unsigned char *buffer,
+size_t cbor_encode_bytestring_start(size_t length, unsigned char* buffer,
                                     size_t buffer_size) {
   return _cbor_encode_uint((size_t)length, buffer, buffer_size, 0x40);
 }
 
-size_t _cbor_encode_byte(uint8_t value, unsigned char *buffer,
+size_t _cbor_encode_byte(uint8_t value, unsigned char* buffer,
                          size_t buffer_size) {
   if (buffer_size >= 1) {
     buffer[0] = value;
@@ -75,59 +75,59 @@ size_t _cbor_encode_byte(uint8_t value, unsigned char *buffer,
     return 0;
 }
 
-size_t cbor_encode_indef_bytestring_start(unsigned char *buffer,
+size_t cbor_encode_indef_bytestring_start(unsigned char* buffer,
                                           size_t buffer_size) {
   return _cbor_encode_byte(0x5F, buffer, buffer_size);
 }
 
-size_t cbor_encode_string_start(size_t length, unsigned char *buffer,
+size_t cbor_encode_string_start(size_t length, unsigned char* buffer,
                                 size_t buffer_size) {
   return _cbor_encode_uint((size_t)length, buffer, buffer_size, 0x60);
 }
 
-size_t cbor_encode_indef_string_start(unsigned char *buffer,
+size_t cbor_encode_indef_string_start(unsigned char* buffer,
                                       size_t buffer_size) {
   return _cbor_encode_byte(0x7F, buffer, buffer_size);
 }
 
-size_t cbor_encode_array_start(size_t length, unsigned char *buffer,
+size_t cbor_encode_array_start(size_t length, unsigned char* buffer,
                                size_t buffer_size) {
   return _cbor_encode_uint((size_t)length, buffer, buffer_size, 0x80);
 }
 
-size_t cbor_encode_indef_array_start(unsigned char *buffer,
+size_t cbor_encode_indef_array_start(unsigned char* buffer,
                                      size_t buffer_size) {
   return _cbor_encode_byte(0x9F, buffer, buffer_size);
 }
 
-size_t cbor_encode_map_start(size_t length, unsigned char *buffer,
+size_t cbor_encode_map_start(size_t length, unsigned char* buffer,
                              size_t buffer_size) {
   return _cbor_encode_uint((size_t)length, buffer, buffer_size, 0xA0);
 }
 
-size_t cbor_encode_indef_map_start(unsigned char *buffer, size_t buffer_size) {
+size_t cbor_encode_indef_map_start(unsigned char* buffer, size_t buffer_size) {
   return _cbor_encode_byte(0xBF, buffer, buffer_size);
 }
 
-size_t cbor_encode_tag(uint64_t value, unsigned char *buffer,
+size_t cbor_encode_tag(uint64_t value, unsigned char* buffer,
                        size_t buffer_size) {
   return _cbor_encode_uint(value, buffer, buffer_size, 0xC0);
 }
 
-size_t cbor_encode_bool(bool value, unsigned char *buffer, size_t buffer_size) {
+size_t cbor_encode_bool(bool value, unsigned char* buffer, size_t buffer_size) {
   return value ? _cbor_encode_byte(0xF5, buffer, buffer_size)
                : _cbor_encode_byte(0xF4, buffer, buffer_size);
 }
 
-size_t cbor_encode_null(unsigned char *buffer, size_t buffer_size) {
+size_t cbor_encode_null(unsigned char* buffer, size_t buffer_size) {
   return _cbor_encode_byte(0xF6, buffer, buffer_size);
 }
 
-size_t cbor_encode_undef(unsigned char *buffer, size_t buffer_size) {
+size_t cbor_encode_undef(unsigned char* buffer, size_t buffer_size) {
   return _cbor_encode_byte(0xF7, buffer, buffer_size);
 }
 
-size_t cbor_encode_half(float value, unsigned char *buffer,
+size_t cbor_encode_half(float value, unsigned char* buffer,
                         size_t buffer_size) {
   // TODO: Broken on systems that do not use IEEE 754
   /* Assuming value is normalized */
@@ -177,7 +177,7 @@ size_t cbor_encode_half(float value, unsigned char *buffer,
   return _cbor_encode_uint16(res, buffer, buffer_size, 0xE0);
 }
 
-size_t cbor_encode_single(float value, unsigned char *buffer,
+size_t cbor_encode_single(float value, unsigned char* buffer,
                           size_t buffer_size) {
   // Note: Values of signaling NaNs are discarded. There is no standard
   // way to extract it without assumptions about the internal float
@@ -191,7 +191,7 @@ size_t cbor_encode_single(float value, unsigned char *buffer,
       buffer_size, 0xE0);
 }
 
-size_t cbor_encode_double(double value, unsigned char *buffer,
+size_t cbor_encode_double(double value, unsigned char* buffer,
                           size_t buffer_size) {
   // Note: Values of signaling NaNs are discarded. See `cbor_encode_single`.
   if (isnan(value)) {
@@ -204,11 +204,11 @@ size_t cbor_encode_double(double value, unsigned char *buffer,
       buffer_size, 0xE0);
 }
 
-size_t cbor_encode_break(unsigned char *buffer, size_t buffer_size) {
+size_t cbor_encode_break(unsigned char* buffer, size_t buffer_size) {
   return _cbor_encode_byte(0xFF, buffer, buffer_size);
 }
 
-size_t cbor_encode_ctrl(uint8_t value, unsigned char *buffer,
+size_t cbor_encode_ctrl(uint8_t value, unsigned char* buffer,
                         size_t buffer_size) {
   return _cbor_encode_uint8(value, buffer, buffer_size, 0xE0);
 }

--- a/src/cbor/encoding.h
+++ b/src/cbor/encoding.h
@@ -27,76 +27,72 @@ extern "C" {
  * case it is not modified).
  */
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint8(uint8_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint8(uint8_t, unsigned char*,
                                                      size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint16(uint16_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint16(uint16_t, unsigned char*,
                                                       size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint32(uint32_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint32(uint32_t, unsigned char*,
                                                       size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint64(uint64_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint64(uint64_t, unsigned char*,
                                                       size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint(uint64_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_uint(uint64_t, unsigned char*,
                                                     size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint8(uint8_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint8(uint8_t, unsigned char*,
                                                        size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint16(uint16_t,
-                                                        unsigned char *,
-                                                        size_t);
+                                                        unsigned char*, size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint32(uint32_t,
-                                                        unsigned char *,
-                                                        size_t);
+                                                        unsigned char*, size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint64(uint64_t,
-                                                        unsigned char *,
-                                                        size_t);
+                                                        unsigned char*, size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint(uint64_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_negint(uint64_t, unsigned char*,
                                                       size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_bytestring_start(size_t,
-                                                                unsigned char *,
+                                                                unsigned char*,
                                                                 size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t
-cbor_encode_indef_bytestring_start(unsigned char *, size_t);
+cbor_encode_indef_bytestring_start(unsigned char*, size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_string_start(size_t,
-                                                            unsigned char *,
+                                                            unsigned char*,
                                                             size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t
-cbor_encode_indef_string_start(unsigned char *, size_t);
+cbor_encode_indef_string_start(unsigned char*, size_t);
 
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_array_start(size_t,
-                                                           unsigned char *,
+                                                           unsigned char*,
                                                            size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t
-cbor_encode_indef_array_start(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_indef_array_start(unsigned char*,
+                                                                 size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_map_start(size_t,
-                                                         unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_map_start(size_t, unsigned char*,
                                                          size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_indef_map_start(unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_indef_map_start(unsigned char*,
                                                                size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_tag(uint64_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_tag(uint64_t, unsigned char*,
                                                    size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_bool(bool, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_bool(bool, unsigned char*,
                                                     size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_null(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_null(unsigned char*, size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_undef(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_undef(unsigned char*, size_t);
 
 /** Encodes a half-precision float
  *
@@ -121,25 +117,25 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_undef(unsigned char *, size_t);
  *
  * Note: Signaling NaNs are encoded as a standard, "quiet" NaN.
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_half(float, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_half(float, unsigned char*,
                                                     size_t);
 /** Encodes a single precision float
  *
  * Note: Signaling NaNs are encoded as a standard, "quiet" NaN.
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_single(float, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_single(float, unsigned char*,
                                                       size_t);
 
 /** Encodes a double precision float
  *
  * Note: Signaling NaNs are encoded as a standard, "quiet" NaN.
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_double(double, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_double(double, unsigned char*,
                                                       size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_break(unsigned char *, size_t);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_break(unsigned char*, size_t);
 
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_ctrl(uint8_t, unsigned char *,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_encode_ctrl(uint8_t, unsigned char*,
                                                     size_t);
 
 #ifdef __cplusplus

--- a/src/cbor/floats_ctrls.c
+++ b/src/cbor/floats_ctrls.c
@@ -9,41 +9,41 @@
 #include <math.h>
 #include "assert.h"
 
-cbor_float_width cbor_float_get_width(const cbor_item_t *item) {
+cbor_float_width cbor_float_get_width(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_float_ctrl(item));
   return item->metadata.float_ctrl_metadata.width;
 }
 
-uint8_t cbor_ctrl_value(const cbor_item_t *item) {
+uint8_t cbor_ctrl_value(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_float_ctrl(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_0);
   return item->metadata.float_ctrl_metadata.ctrl;
 }
 
-bool cbor_float_ctrl_is_ctrl(const cbor_item_t *item) {
+bool cbor_float_ctrl_is_ctrl(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_float_ctrl(item));
   return cbor_float_get_width(item) == CBOR_FLOAT_0;
 }
 
-float cbor_float_get_float2(const cbor_item_t *item) {
+float cbor_float_get_float2(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_float(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_16);
-  return *(float *)item->data;
+  return *(float*)item->data;
 }
 
-float cbor_float_get_float4(const cbor_item_t *item) {
+float cbor_float_get_float4(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_float(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_32);
-  return *(float *)item->data;
+  return *(float*)item->data;
 }
 
-double cbor_float_get_float8(const cbor_item_t *item) {
+double cbor_float_get_float8(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_float(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_64);
-  return *(double *)item->data;
+  return *(double*)item->data;
 }
 
-double cbor_float_get_float(const cbor_item_t *item) {
+double cbor_float_get_float(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_float(item));
   switch (cbor_float_get_width(item)) {
     case CBOR_FLOAT_0:
@@ -60,43 +60,43 @@ double cbor_float_get_float(const cbor_item_t *item) {
   }
 }
 
-bool cbor_get_bool(const cbor_item_t *item) {
+bool cbor_get_bool(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_bool(item));
   return item->metadata.float_ctrl_metadata.ctrl == CBOR_CTRL_TRUE;
 }
 
-void cbor_set_float2(cbor_item_t *item, float value) {
+void cbor_set_float2(cbor_item_t* item, float value) {
   CBOR_ASSERT(cbor_is_float(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_16);
-  *((float *)item->data) = value;
+  *((float*)item->data) = value;
 }
 
-void cbor_set_float4(cbor_item_t *item, float value) {
+void cbor_set_float4(cbor_item_t* item, float value) {
   CBOR_ASSERT(cbor_is_float(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_32);
-  *((float *)item->data) = value;
+  *((float*)item->data) = value;
 }
 
-void cbor_set_float8(cbor_item_t *item, double value) {
+void cbor_set_float8(cbor_item_t* item, double value) {
   CBOR_ASSERT(cbor_is_float(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_64);
-  *((double *)item->data) = value;
+  *((double*)item->data) = value;
 }
 
-void cbor_set_ctrl(cbor_item_t *item, uint8_t value) {
+void cbor_set_ctrl(cbor_item_t* item, uint8_t value) {
   CBOR_ASSERT(cbor_isa_float_ctrl(item));
   CBOR_ASSERT(cbor_float_get_width(item) == CBOR_FLOAT_0);
   item->metadata.float_ctrl_metadata.ctrl = value;
 }
 
-void cbor_set_bool(cbor_item_t *item, bool value) {
+void cbor_set_bool(cbor_item_t* item, bool value) {
   CBOR_ASSERT(cbor_is_bool(item));
   item->metadata.float_ctrl_metadata.ctrl =
       value ? CBOR_CTRL_TRUE : CBOR_CTRL_FALSE;
 }
 
-cbor_item_t *cbor_new_ctrl(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_ctrl(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){
@@ -108,83 +108,83 @@ cbor_item_t *cbor_new_ctrl(void) {
   return item;
 }
 
-cbor_item_t *cbor_new_float2(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t) + 4);
+cbor_item_t* cbor_new_float2(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t) + 4);
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){
       .type = CBOR_TYPE_FLOAT_CTRL,
-      .data = (unsigned char *)item + sizeof(cbor_item_t),
+      .data = (unsigned char*)item + sizeof(cbor_item_t),
       .refcount = 1,
       .metadata = {.float_ctrl_metadata = {.width = CBOR_FLOAT_16}}};
   return item;
 }
 
-cbor_item_t *cbor_new_float4(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t) + 4);
+cbor_item_t* cbor_new_float4(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t) + 4);
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){
       .type = CBOR_TYPE_FLOAT_CTRL,
-      .data = (unsigned char *)item + sizeof(cbor_item_t),
+      .data = (unsigned char*)item + sizeof(cbor_item_t),
       .refcount = 1,
       .metadata = {.float_ctrl_metadata = {.width = CBOR_FLOAT_32}}};
   return item;
 }
 
-cbor_item_t *cbor_new_float8(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t) + 8);
+cbor_item_t* cbor_new_float8(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t) + 8);
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){
       .type = CBOR_TYPE_FLOAT_CTRL,
-      .data = (unsigned char *)item + sizeof(cbor_item_t),
+      .data = (unsigned char*)item + sizeof(cbor_item_t),
       .refcount = 1,
       .metadata = {.float_ctrl_metadata = {.width = CBOR_FLOAT_64}}};
   return item;
 }
 
-cbor_item_t *cbor_new_null(void) {
-  cbor_item_t *item = cbor_new_ctrl();
+cbor_item_t* cbor_new_null(void) {
+  cbor_item_t* item = cbor_new_ctrl();
   _CBOR_NOTNULL(item);
   cbor_set_ctrl(item, CBOR_CTRL_NULL);
   return item;
 }
 
-cbor_item_t *cbor_new_undef(void) {
-  cbor_item_t *item = cbor_new_ctrl();
+cbor_item_t* cbor_new_undef(void) {
+  cbor_item_t* item = cbor_new_ctrl();
   _CBOR_NOTNULL(item);
   cbor_set_ctrl(item, CBOR_CTRL_UNDEF);
   return item;
 }
 
-cbor_item_t *cbor_build_bool(bool value) {
+cbor_item_t* cbor_build_bool(bool value) {
   return cbor_build_ctrl(value ? CBOR_CTRL_TRUE : CBOR_CTRL_FALSE);
 }
 
-cbor_item_t *cbor_build_float2(float value) {
-  cbor_item_t *item = cbor_new_float2();
+cbor_item_t* cbor_build_float2(float value) {
+  cbor_item_t* item = cbor_new_float2();
   _CBOR_NOTNULL(item);
   cbor_set_float2(item, value);
   return item;
 }
 
-cbor_item_t *cbor_build_float4(float value) {
-  cbor_item_t *item = cbor_new_float4();
+cbor_item_t* cbor_build_float4(float value) {
+  cbor_item_t* item = cbor_new_float4();
   _CBOR_NOTNULL(item);
   cbor_set_float4(item, value);
   return item;
 }
 
-cbor_item_t *cbor_build_float8(double value) {
-  cbor_item_t *item = cbor_new_float8();
+cbor_item_t* cbor_build_float8(double value) {
+  cbor_item_t* item = cbor_new_float8();
   _CBOR_NOTNULL(item);
   cbor_set_float8(item, value);
   return item;
 }
 
-cbor_item_t *cbor_build_ctrl(uint8_t value) {
-  cbor_item_t *item = cbor_new_ctrl();
+cbor_item_t* cbor_build_ctrl(uint8_t value) {
+  cbor_item_t* item = cbor_new_ctrl();
   _CBOR_NOTNULL(item);
   cbor_set_ctrl(item, value);
   return item;

--- a/src/cbor/floats_ctrls.c
+++ b/src/cbor/floats_ctrls.c
@@ -45,7 +45,6 @@ double cbor_float_get_float8(const cbor_item_t *item) {
 
 double cbor_float_get_float(const cbor_item_t *item) {
   CBOR_ASSERT(cbor_is_float(item));
-  // cppcheck-suppress missingReturn
   switch (cbor_float_get_width(item)) {
     case CBOR_FLOAT_0:
       return NAN;
@@ -55,6 +54,9 @@ double cbor_float_get_float(const cbor_item_t *item) {
       return cbor_float_get_float4(item);
     case CBOR_FLOAT_64:
       return cbor_float_get_float8(item);
+    default:
+      _CBOR_UNREACHABLE;
+      return 0;
   }
 }
 

--- a/src/cbor/floats_ctrls.h
+++ b/src/cbor/floats_ctrls.h
@@ -27,7 +27,7 @@ extern "C" {
  * @return Is this a ctrl value?
  */
 _CBOR_NODISCARD CBOR_EXPORT bool cbor_float_ctrl_is_ctrl(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Get the float width
  *
@@ -35,7 +35,7 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_float_ctrl_is_ctrl(
  * @return The width.
  */
 _CBOR_NODISCARD CBOR_EXPORT cbor_float_width
-cbor_float_get_width(const cbor_item_t *item);
+cbor_float_get_width(const cbor_item_t* item);
 
 /** Get a half precision float
  *
@@ -45,7 +45,7 @@ cbor_float_get_width(const cbor_item_t *item);
  * @return half precision value
  */
 _CBOR_NODISCARD CBOR_EXPORT float cbor_float_get_float2(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Get a single precision float
  *
@@ -55,7 +55,7 @@ _CBOR_NODISCARD CBOR_EXPORT float cbor_float_get_float2(
  * @return single precision value
  */
 _CBOR_NODISCARD CBOR_EXPORT float cbor_float_get_float4(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Get a double precision float
  *
@@ -65,7 +65,7 @@ _CBOR_NODISCARD CBOR_EXPORT float cbor_float_get_float4(
  * @return double precision value
  */
 _CBOR_NODISCARD CBOR_EXPORT double cbor_float_get_float8(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Get the float value represented as double
  *
@@ -75,14 +75,14 @@ _CBOR_NODISCARD CBOR_EXPORT double cbor_float_get_float8(
  * @return double precision value
  */
 _CBOR_NODISCARD CBOR_EXPORT double cbor_float_get_float(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Get value from a boolean ctrl item
  *
  * @param item A ctrl item
  * @return boolean value
  */
-_CBOR_NODISCARD CBOR_EXPORT bool cbor_get_bool(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_get_bool(const cbor_item_t* item);
 
 /** Constructs a new ctrl item
  *
@@ -92,7 +92,7 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_get_bool(const cbor_item_t *item);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_ctrl(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_ctrl(void);
 
 /** Constructs a new float item
  *
@@ -102,7 +102,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_ctrl(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float2(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_float2(void);
 
 /** Constructs a new float item
  *
@@ -112,7 +112,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float2(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float4(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_float4(void);
 
 /** Constructs a new float item
  *
@@ -122,7 +122,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float4(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float8(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_float8(void);
 
 /** Constructs new null ctrl item
  *
@@ -130,7 +130,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_float8(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_null(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_null(void);
 
 /** Constructs new undef ctrl item
  *
@@ -138,7 +138,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_null(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_undef(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_undef(void);
 
 /** Constructs new boolean ctrl item
  *
@@ -147,7 +147,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_undef(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_bool(bool value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_bool(bool value);
 
 /** Assign a control value
  *
@@ -160,42 +160,42 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_bool(bool value);
  * @param value The simple value to assign. Please consult the standard for
  * 	allowed values
  */
-CBOR_EXPORT void cbor_set_ctrl(cbor_item_t *item, uint8_t value);
+CBOR_EXPORT void cbor_set_ctrl(cbor_item_t* item, uint8_t value);
 
 /** Assign a boolean value to a boolean ctrl item
  *
  * @param item A ctrl item
  * @param value The simple value to assign.
  */
-CBOR_EXPORT void cbor_set_bool(cbor_item_t *item, bool value);
+CBOR_EXPORT void cbor_set_bool(cbor_item_t* item, bool value);
 
 /** Assigns a float value
  *
  * @param item A half precision float
  * @param value The value to assign
  */
-CBOR_EXPORT void cbor_set_float2(cbor_item_t *item, float value);
+CBOR_EXPORT void cbor_set_float2(cbor_item_t* item, float value);
 
 /** Assigns a float value
  *
  * @param item A single precision float
  * @param value The value to assign
  */
-CBOR_EXPORT void cbor_set_float4(cbor_item_t *item, float value);
+CBOR_EXPORT void cbor_set_float4(cbor_item_t* item, float value);
 
 /** Assigns a float value
  *
  * @param item A double precision float
  * @param value The value to assign
  */
-CBOR_EXPORT void cbor_set_float8(cbor_item_t *item, double value);
+CBOR_EXPORT void cbor_set_float8(cbor_item_t* item, double value);
 
 /** Reads the control value
  *
  * @param item A ctrl item
  * @return the simple value
  */
-_CBOR_NODISCARD CBOR_EXPORT uint8_t cbor_ctrl_value(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint8_t cbor_ctrl_value(const cbor_item_t* item);
 
 /** Constructs a new float
  *
@@ -204,7 +204,7 @@ _CBOR_NODISCARD CBOR_EXPORT uint8_t cbor_ctrl_value(const cbor_item_t *item);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float2(float value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_float2(float value);
 
 /** Constructs a new float
  *
@@ -213,7 +213,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float2(float value);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float4(float value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_float4(float value);
 
 /** Constructs a new float
  *
@@ -222,7 +222,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float4(float value);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float8(double value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_float8(double value);
 
 /** Constructs a ctrl item
  *
@@ -231,7 +231,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_float8(double value);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_ctrl(uint8_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_ctrl(uint8_t value);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/internal/builder_callbacks.c
+++ b/src/cbor/internal/builder_callbacks.c
@@ -21,8 +21,8 @@
 
 // `_cbor_builder_append` takes ownership of `item`. If adding the item to
 // parent container fails, `item` will be deallocated to prevent memory.
-void _cbor_builder_append(cbor_item_t *item,
-                          struct _cbor_decoder_context *ctx) {
+void _cbor_builder_append(cbor_item_t* item,
+                          struct _cbor_decoder_context* ctx) {
   if (ctx->stack->size == 0) {
     /* Top level item */
     ctx->root = item;
@@ -49,7 +49,7 @@ void _cbor_builder_append(cbor_item_t *item,
         cbor_decref(&item);
         ctx->stack->top->subitems--;
         if (ctx->stack->top->subitems == 0) {
-          cbor_item_t *stack_item = ctx->stack->top->item;
+          cbor_item_t* stack_item = ctx->stack->top->item;
           _cbor_stack_pop(ctx->stack);
           _cbor_builder_append(stack_item, ctx);
         }
@@ -86,7 +86,7 @@ void _cbor_builder_append(cbor_item_t *item,
         CBOR_ASSERT(ctx->stack->top->subitems > 0);
         ctx->stack->top->subitems--;
         if (ctx->stack->top->subitems == 0) {
-          cbor_item_t *map_entry = ctx->stack->top->item;
+          cbor_item_t* map_entry = ctx->stack->top->item;
           _cbor_stack_pop(ctx->stack);
           _cbor_builder_append(map_entry, ctx);
         }
@@ -100,7 +100,7 @@ void _cbor_builder_append(cbor_item_t *item,
       CBOR_ASSERT(ctx->stack->top->subitems == 1);
       cbor_tag_set_item(ctx->stack->top->item, item);
       cbor_decref(&item); /* Give up on our reference */
-      cbor_item_t *tagged_item = ctx->stack->top->item;
+      cbor_item_t* tagged_item = ctx->stack->top->item;
       _cbor_stack_pop(ctx->stack);
       _cbor_builder_append(tagged_item, ctx);
       break;
@@ -139,90 +139,90 @@ void _cbor_builder_append(cbor_item_t *item,
     }                                                          \
   } while (0)
 
-void cbor_builder_uint8_callback(void *context, uint8_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int8();
+void cbor_builder_uint8_callback(void* context, uint8_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int8();
   CHECK_RES(ctx, res);
   cbor_mark_uint(res);
   cbor_set_uint8(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_uint16_callback(void *context, uint16_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int16();
+void cbor_builder_uint16_callback(void* context, uint16_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int16();
   CHECK_RES(ctx, res);
   cbor_mark_uint(res);
   cbor_set_uint16(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_uint32_callback(void *context, uint32_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int32();
+void cbor_builder_uint32_callback(void* context, uint32_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int32();
   CHECK_RES(ctx, res);
   cbor_mark_uint(res);
   cbor_set_uint32(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_uint64_callback(void *context, uint64_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int64();
+void cbor_builder_uint64_callback(void* context, uint64_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int64();
   CHECK_RES(ctx, res);
   cbor_mark_uint(res);
   cbor_set_uint64(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_negint8_callback(void *context, uint8_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int8();
+void cbor_builder_negint8_callback(void* context, uint8_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int8();
   CHECK_RES(ctx, res);
   cbor_mark_negint(res);
   cbor_set_uint8(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_negint16_callback(void *context, uint16_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int16();
+void cbor_builder_negint16_callback(void* context, uint16_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int16();
   CHECK_RES(ctx, res);
   cbor_mark_negint(res);
   cbor_set_uint16(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_negint32_callback(void *context, uint32_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int32();
+void cbor_builder_negint32_callback(void* context, uint32_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int32();
   CHECK_RES(ctx, res);
   cbor_mark_negint(res);
   cbor_set_uint32(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_negint64_callback(void *context, uint64_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_int64();
+void cbor_builder_negint64_callback(void* context, uint64_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_int64();
   CHECK_RES(ctx, res);
   cbor_mark_negint(res);
   cbor_set_uint64(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_byte_string_callback(void *context, cbor_data data,
+void cbor_builder_byte_string_callback(void* context, cbor_data data,
                                        uint64_t length) {
-  struct _cbor_decoder_context *ctx = context;
+  struct _cbor_decoder_context* ctx = context;
   CHECK_LENGTH(ctx, length);
-  unsigned char *new_handle = _cbor_malloc(length);
+  unsigned char* new_handle = _cbor_malloc(length);
   if (new_handle == NULL) {
     ctx->creation_failed = true;
     return;
   }
 
   memcpy(new_handle, data, length);
-  cbor_item_t *new_chunk = cbor_new_definite_bytestring();
+  cbor_item_t* new_chunk = cbor_new_definite_bytestring();
 
   if (new_chunk == NULL) {
     _cbor_free(new_handle);
@@ -245,26 +245,26 @@ void cbor_builder_byte_string_callback(void *context, cbor_data data,
   }
 }
 
-void cbor_builder_byte_string_start_callback(void *context) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_indefinite_bytestring();
+void cbor_builder_byte_string_start_callback(void* context) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_indefinite_bytestring();
   CHECK_RES(ctx, res);
   PUSH_CTX_STACK(ctx, res, 0);
 }
 
-void cbor_builder_string_callback(void *context, cbor_data data,
+void cbor_builder_string_callback(void* context, cbor_data data,
                                   uint64_t length) {
-  struct _cbor_decoder_context *ctx = context;
+  struct _cbor_decoder_context* ctx = context;
   CHECK_LENGTH(ctx, length);
 
-  unsigned char *new_handle = _cbor_malloc(length);
+  unsigned char* new_handle = _cbor_malloc(length);
   if (new_handle == NULL) {
     ctx->creation_failed = true;
     return;
   }
 
   memcpy(new_handle, data, length);
-  cbor_item_t *new_chunk = cbor_new_definite_string();
+  cbor_item_t* new_chunk = cbor_new_definite_string();
   if (new_chunk == NULL) {
     _cbor_free(new_handle);
     ctx->creation_failed = true;
@@ -285,17 +285,17 @@ void cbor_builder_string_callback(void *context, cbor_data data,
   }
 }
 
-void cbor_builder_string_start_callback(void *context) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_indefinite_string();
+void cbor_builder_string_start_callback(void* context) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_indefinite_string();
   CHECK_RES(ctx, res);
   PUSH_CTX_STACK(ctx, res, 0);
 }
 
-void cbor_builder_array_start_callback(void *context, uint64_t size) {
-  struct _cbor_decoder_context *ctx = context;
+void cbor_builder_array_start_callback(void* context, uint64_t size) {
+  struct _cbor_decoder_context* ctx = context;
   CHECK_LENGTH(ctx, size);
-  cbor_item_t *res = cbor_new_definite_array(size);
+  cbor_item_t* res = cbor_new_definite_array(size);
   CHECK_RES(ctx, res);
   if (size > 0) {
     PUSH_CTX_STACK(ctx, res, size);
@@ -304,24 +304,24 @@ void cbor_builder_array_start_callback(void *context, uint64_t size) {
   }
 }
 
-void cbor_builder_indef_array_start_callback(void *context) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_indefinite_array();
+void cbor_builder_indef_array_start_callback(void* context) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_indefinite_array();
   CHECK_RES(ctx, res);
   PUSH_CTX_STACK(ctx, res, 0);
 }
 
-void cbor_builder_indef_map_start_callback(void *context) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_indefinite_map();
+void cbor_builder_indef_map_start_callback(void* context) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_indefinite_map();
   CHECK_RES(ctx, res);
   PUSH_CTX_STACK(ctx, res, 0);
 }
 
-void cbor_builder_map_start_callback(void *context, uint64_t size) {
-  struct _cbor_decoder_context *ctx = context;
+void cbor_builder_map_start_callback(void* context, uint64_t size) {
+  struct _cbor_decoder_context* ctx = context;
   CHECK_LENGTH(ctx, size);
-  cbor_item_t *res = cbor_new_definite_map(size);
+  cbor_item_t* res = cbor_new_definite_map(size);
   CHECK_RES(ctx, res);
   if (size > 0) {
     PUSH_CTX_STACK(ctx, res, size * 2);
@@ -333,7 +333,7 @@ void cbor_builder_map_start_callback(void *context, uint64_t size) {
 /**
  * Is the (partially constructed) item indefinite?
  */
-bool _cbor_is_indefinite(cbor_item_t *item) {
+bool _cbor_is_indefinite(cbor_item_t* item) {
   switch (item->type) {
     case CBOR_TYPE_BYTESTRING:
       return cbor_bytestring_is_indefinite(item);
@@ -350,11 +350,11 @@ bool _cbor_is_indefinite(cbor_item_t *item) {
   }
 }
 
-void cbor_builder_indef_break_callback(void *context) {
-  struct _cbor_decoder_context *ctx = context;
+void cbor_builder_indef_break_callback(void* context) {
+  struct _cbor_decoder_context* ctx = context;
   /* There must be an item to break out of*/
   if (ctx->stack->size > 0) {
-    cbor_item_t *item = ctx->stack->top->item;
+    cbor_item_t* item = ctx->stack->top->item;
     if (_cbor_is_indefinite(
             item) && /* Only indefinite items can be terminated by 0xFF */
         /* Special case: we cannot append up if an indefinite map is incomplete
@@ -369,54 +369,54 @@ void cbor_builder_indef_break_callback(void *context) {
   ctx->syntax_error = true;
 }
 
-void cbor_builder_float2_callback(void *context, float value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_float2();
+void cbor_builder_float2_callback(void* context, float value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_float2();
   CHECK_RES(ctx, res);
   cbor_set_float2(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_float4_callback(void *context, float value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_float4();
+void cbor_builder_float4_callback(void* context, float value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_float4();
   CHECK_RES(ctx, res);
   cbor_set_float4(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_float8_callback(void *context, double value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_float8();
+void cbor_builder_float8_callback(void* context, double value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_float8();
   CHECK_RES(ctx, res);
   cbor_set_float8(res, value);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_null_callback(void *context) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_null();
+void cbor_builder_null_callback(void* context) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_null();
   CHECK_RES(ctx, res);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_undefined_callback(void *context) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_undef();
+void cbor_builder_undefined_callback(void* context) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_undef();
   CHECK_RES(ctx, res);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_boolean_callback(void *context, bool value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_build_bool(value);
+void cbor_builder_boolean_callback(void* context, bool value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_build_bool(value);
   CHECK_RES(ctx, res);
   _cbor_builder_append(res, ctx);
 }
 
-void cbor_builder_tag_callback(void *context, uint64_t value) {
-  struct _cbor_decoder_context *ctx = context;
-  cbor_item_t *res = cbor_new_tag(value);
+void cbor_builder_tag_callback(void* context, uint64_t value) {
+  struct _cbor_decoder_context* ctx = context;
+  cbor_item_t* res = cbor_new_tag(value);
   CHECK_RES(ctx, res);
   PUSH_CTX_STACK(ctx, res, 1);
 }

--- a/src/cbor/internal/builder_callbacks.h
+++ b/src/cbor/internal/builder_callbacks.h
@@ -22,61 +22,61 @@ struct _cbor_decoder_context {
   bool creation_failed;
   /** Stack expectation mismatch */
   bool syntax_error;
-  cbor_item_t *root;
-  struct _cbor_stack *stack;
+  cbor_item_t* root;
+  struct _cbor_stack* stack;
 };
 
 /** Internal helper: Append item to the top of the stack while handling errors.
  */
-void _cbor_builder_append(cbor_item_t *item, struct _cbor_decoder_context *ctx);
+void _cbor_builder_append(cbor_item_t* item, struct _cbor_decoder_context* ctx);
 
-void cbor_builder_uint8_callback(void *, uint8_t);
+void cbor_builder_uint8_callback(void*, uint8_t);
 
-void cbor_builder_uint16_callback(void *, uint16_t);
+void cbor_builder_uint16_callback(void*, uint16_t);
 
-void cbor_builder_uint32_callback(void *, uint32_t);
+void cbor_builder_uint32_callback(void*, uint32_t);
 
-void cbor_builder_uint64_callback(void *, uint64_t);
+void cbor_builder_uint64_callback(void*, uint64_t);
 
-void cbor_builder_negint8_callback(void *, uint8_t);
+void cbor_builder_negint8_callback(void*, uint8_t);
 
-void cbor_builder_negint16_callback(void *, uint16_t);
+void cbor_builder_negint16_callback(void*, uint16_t);
 
-void cbor_builder_negint32_callback(void *, uint32_t);
+void cbor_builder_negint32_callback(void*, uint32_t);
 
-void cbor_builder_negint64_callback(void *, uint64_t);
+void cbor_builder_negint64_callback(void*, uint64_t);
 
-void cbor_builder_string_callback(void *, cbor_data, uint64_t);
+void cbor_builder_string_callback(void*, cbor_data, uint64_t);
 
-void cbor_builder_string_start_callback(void *);
+void cbor_builder_string_start_callback(void*);
 
-void cbor_builder_byte_string_callback(void *, cbor_data, uint64_t);
+void cbor_builder_byte_string_callback(void*, cbor_data, uint64_t);
 
-void cbor_builder_byte_string_start_callback(void *);
+void cbor_builder_byte_string_start_callback(void*);
 
-void cbor_builder_array_start_callback(void *, uint64_t);
+void cbor_builder_array_start_callback(void*, uint64_t);
 
-void cbor_builder_indef_array_start_callback(void *);
+void cbor_builder_indef_array_start_callback(void*);
 
-void cbor_builder_map_start_callback(void *, uint64_t);
+void cbor_builder_map_start_callback(void*, uint64_t);
 
-void cbor_builder_indef_map_start_callback(void *);
+void cbor_builder_indef_map_start_callback(void*);
 
-void cbor_builder_tag_callback(void *, uint64_t);
+void cbor_builder_tag_callback(void*, uint64_t);
 
-void cbor_builder_float2_callback(void *, float);
+void cbor_builder_float2_callback(void*, float);
 
-void cbor_builder_float4_callback(void *, float);
+void cbor_builder_float4_callback(void*, float);
 
-void cbor_builder_float8_callback(void *, double);
+void cbor_builder_float8_callback(void*, double);
 
-void cbor_builder_null_callback(void *);
+void cbor_builder_null_callback(void*);
 
-void cbor_builder_undefined_callback(void *);
+void cbor_builder_undefined_callback(void*);
 
-void cbor_builder_boolean_callback(void *, bool);
+void cbor_builder_boolean_callback(void*, bool);
 
-void cbor_builder_indef_break_callback(void *);
+void cbor_builder_indef_break_callback(void*);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/internal/encoders.c
+++ b/src/cbor/internal/encoders.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-size_t _cbor_encode_uint8(uint8_t value, unsigned char *buffer,
+size_t _cbor_encode_uint8(uint8_t value, unsigned char* buffer,
                           size_t buffer_size, uint8_t offset) {
   if (value <= 23) {
     if (buffer_size >= 1) {
@@ -26,7 +26,7 @@ size_t _cbor_encode_uint8(uint8_t value, unsigned char *buffer,
   return 0;
 }
 
-size_t _cbor_encode_uint16(uint16_t value, unsigned char *buffer,
+size_t _cbor_encode_uint16(uint16_t value, unsigned char* buffer,
                            size_t buffer_size, uint8_t offset) {
   if (buffer_size < 3) {
     return 0;
@@ -43,7 +43,7 @@ size_t _cbor_encode_uint16(uint16_t value, unsigned char *buffer,
   return 3;
 }
 
-size_t _cbor_encode_uint32(uint32_t value, unsigned char *buffer,
+size_t _cbor_encode_uint32(uint32_t value, unsigned char* buffer,
                            size_t buffer_size, uint8_t offset) {
   if (buffer_size < 5) {
     return 0;
@@ -62,7 +62,7 @@ size_t _cbor_encode_uint32(uint32_t value, unsigned char *buffer,
   return 5;
 }
 
-size_t _cbor_encode_uint64(uint64_t value, unsigned char *buffer,
+size_t _cbor_encode_uint64(uint64_t value, unsigned char* buffer,
                            size_t buffer_size, uint8_t offset) {
   if (buffer_size >= 9) {
     buffer[0] = 0x1B + offset;
@@ -85,7 +85,7 @@ size_t _cbor_encode_uint64(uint64_t value, unsigned char *buffer,
     return 0;
 }
 
-size_t _cbor_encode_uint(uint64_t value, unsigned char *buffer,
+size_t _cbor_encode_uint(uint64_t value, unsigned char* buffer,
                          size_t buffer_size, uint8_t offset) {
   if (value <= UINT16_MAX)
     if (value <= UINT8_MAX)

--- a/src/cbor/internal/encoders.h
+++ b/src/cbor/internal/encoders.h
@@ -15,23 +15,23 @@ extern "C" {
 #endif
 
 _CBOR_NODISCARD
-size_t _cbor_encode_uint8(uint8_t value, unsigned char *buffer,
+size_t _cbor_encode_uint8(uint8_t value, unsigned char* buffer,
                           size_t buffer_size, uint8_t offset);
 
 _CBOR_NODISCARD
-size_t _cbor_encode_uint16(uint16_t value, unsigned char *buffer,
+size_t _cbor_encode_uint16(uint16_t value, unsigned char* buffer,
                            size_t buffer_size, uint8_t offset);
 
 _CBOR_NODISCARD
-size_t _cbor_encode_uint32(uint32_t value, unsigned char *buffer,
+size_t _cbor_encode_uint32(uint32_t value, unsigned char* buffer,
                            size_t buffer_size, uint8_t offset);
 
 _CBOR_NODISCARD
-size_t _cbor_encode_uint64(uint64_t value, unsigned char *buffer,
+size_t _cbor_encode_uint64(uint64_t value, unsigned char* buffer,
                            size_t buffer_size, uint8_t offset);
 
 _CBOR_NODISCARD
-size_t _cbor_encode_uint(uint64_t value, unsigned char *buffer,
+size_t _cbor_encode_uint(uint64_t value, unsigned char* buffer,
                          size_t buffer_size, uint8_t offset);
 
 #ifdef __cplusplus

--- a/src/cbor/internal/loaders.c
+++ b/src/cbor/internal/loaders.c
@@ -11,7 +11,7 @@
 
 uint8_t _cbor_load_uint8(cbor_data source) { return (uint8_t)*source; }
 
-uint16_t _cbor_load_uint16(const unsigned char *source) {
+uint16_t _cbor_load_uint16(const unsigned char* source) {
 #ifdef IS_BIG_ENDIAN
   uint16_t result;
   memcpy(&result, source, 2);
@@ -21,7 +21,7 @@ uint16_t _cbor_load_uint16(const unsigned char *source) {
 #endif
 }
 
-uint32_t _cbor_load_uint32(const unsigned char *source) {
+uint32_t _cbor_load_uint32(const unsigned char* source) {
 #ifdef IS_BIG_ENDIAN
   uint32_t result;
   memcpy(&result, source, 4);
@@ -33,7 +33,7 @@ uint32_t _cbor_load_uint32(const unsigned char *source) {
 #endif
 }
 
-uint64_t _cbor_load_uint64(const unsigned char *source) {
+uint64_t _cbor_load_uint64(const unsigned char* source) {
 #ifdef IS_BIG_ENDIAN
   uint64_t result;
   memcpy(&result, source, 8);
@@ -50,7 +50,7 @@ uint64_t _cbor_load_uint64(const unsigned char *source) {
 }
 
 /* As per https://www.rfc-editor.org/rfc/rfc8949.html#name-half-precision */
-float _cbor_decode_half(unsigned char *halfp) {
+float _cbor_decode_half(unsigned char* halfp) {
   // TODO: Broken if we are not on IEEE 754
   // (https://github.com/PJK/libcbor/issues/336)
   int half = (halfp[0] << 8) + halfp[1];
@@ -68,7 +68,7 @@ float _cbor_decode_half(unsigned char *halfp) {
 
 float _cbor_load_half(cbor_data source) {
   /* Discard const */
-  return _cbor_decode_half((unsigned char *)source);
+  return _cbor_decode_half((unsigned char*)source);
 }
 
 float _cbor_load_float(cbor_data source) {

--- a/src/cbor/internal/loaders.h
+++ b/src/cbor/internal/loaders.h
@@ -16,16 +16,16 @@ extern "C" {
 
 /* Read the given uint from the given location, no questions asked */
 _CBOR_NODISCARD
-uint8_t _cbor_load_uint8(const unsigned char *source);
+uint8_t _cbor_load_uint8(const unsigned char* source);
 
 _CBOR_NODISCARD
-uint16_t _cbor_load_uint16(const unsigned char *source);
+uint16_t _cbor_load_uint16(const unsigned char* source);
 
 _CBOR_NODISCARD
-uint32_t _cbor_load_uint32(const unsigned char *source);
+uint32_t _cbor_load_uint32(const unsigned char* source);
 
 _CBOR_NODISCARD
-uint64_t _cbor_load_uint64(const unsigned char *source);
+uint64_t _cbor_load_uint64(const unsigned char* source);
 
 _CBOR_NODISCARD
 float _cbor_load_half(cbor_data source);

--- a/src/cbor/internal/stack.c
+++ b/src/cbor/internal/stack.c
@@ -11,18 +11,18 @@ struct _cbor_stack _cbor_stack_init(void) {
   return (struct _cbor_stack){.top = NULL, .size = 0};
 }
 
-void _cbor_stack_pop(struct _cbor_stack *stack) {
-  struct _cbor_stack_record *top = stack->top;
+void _cbor_stack_pop(struct _cbor_stack* stack) {
+  struct _cbor_stack_record* top = stack->top;
   stack->top = stack->top->lower;
   _cbor_free(top);
   stack->size--;
 }
 
-struct _cbor_stack_record *_cbor_stack_push(struct _cbor_stack *stack,
-                                            cbor_item_t *item,
+struct _cbor_stack_record* _cbor_stack_push(struct _cbor_stack* stack,
+                                            cbor_item_t* item,
                                             size_t subitems) {
   if (stack->size == CBOR_MAX_STACK_SIZE) return NULL;
-  struct _cbor_stack_record *new_top =
+  struct _cbor_stack_record* new_top =
       _cbor_malloc(sizeof(struct _cbor_stack_record));
   if (new_top == NULL) return NULL;
 

--- a/src/cbor/internal/stack.h
+++ b/src/cbor/internal/stack.h
@@ -17,9 +17,9 @@ extern "C" {
 /** Simple stack record for the parser */
 struct _cbor_stack_record {
   /** Pointer to the parent stack frame */
-  struct _cbor_stack_record *lower;
+  struct _cbor_stack_record* lower;
   /** Item under construction */
-  cbor_item_t *item;
+  cbor_item_t* item;
   /**
    * How many outstanding subitems are expected.
    *
@@ -33,17 +33,17 @@ struct _cbor_stack_record {
 
 /** Stack handle - contents and size */
 struct _cbor_stack {
-  struct _cbor_stack_record *top;
+  struct _cbor_stack_record* top;
   size_t size;
 };
 
 _CBOR_NODISCARD
 struct _cbor_stack _cbor_stack_init(void);
 
-void _cbor_stack_pop(struct _cbor_stack *);
+void _cbor_stack_pop(struct _cbor_stack*);
 
 _CBOR_NODISCARD
-struct _cbor_stack_record *_cbor_stack_push(struct _cbor_stack *, cbor_item_t *,
+struct _cbor_stack_record* _cbor_stack_push(struct _cbor_stack*, cbor_item_t*,
                                             size_t);
 
 #ifdef __cplusplus

--- a/src/cbor/ints.c
+++ b/src/cbor/ints.c
@@ -7,36 +7,36 @@
 
 #include "ints.h"
 
-cbor_int_width cbor_int_get_width(const cbor_item_t *item) {
+cbor_int_width cbor_int_get_width(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   return item->metadata.int_metadata.width;
 }
 
-uint8_t cbor_get_uint8(const cbor_item_t *item) {
+uint8_t cbor_get_uint8(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_8);
   return *item->data;
 }
 
-uint16_t cbor_get_uint16(const cbor_item_t *item) {
+uint16_t cbor_get_uint16(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_16);
-  return *(uint16_t *)item->data;
+  return *(uint16_t*)item->data;
 }
 
-uint32_t cbor_get_uint32(const cbor_item_t *item) {
+uint32_t cbor_get_uint32(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_32);
-  return *(uint32_t *)item->data;
+  return *(uint32_t*)item->data;
 }
 
-uint64_t cbor_get_uint64(const cbor_item_t *item) {
+uint64_t cbor_get_uint64(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_64);
-  return *(uint64_t *)item->data;
+  return *(uint64_t*)item->data;
 }
 
-uint64_t cbor_get_int(const cbor_item_t *item) {
+uint64_t cbor_get_int(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   // cppcheck-suppress missingReturn
   switch (cbor_int_get_width(item)) {
@@ -54,138 +54,138 @@ uint64_t cbor_get_int(const cbor_item_t *item) {
   }
 }
 
-void cbor_set_uint8(cbor_item_t *item, uint8_t value) {
+void cbor_set_uint8(cbor_item_t* item, uint8_t value) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_8);
   *item->data = value;
 }
 
-void cbor_set_uint16(cbor_item_t *item, uint16_t value) {
+void cbor_set_uint16(cbor_item_t* item, uint16_t value) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_16);
-  *(uint16_t *)item->data = value;
+  *(uint16_t*)item->data = value;
 }
 
-void cbor_set_uint32(cbor_item_t *item, uint32_t value) {
+void cbor_set_uint32(cbor_item_t* item, uint32_t value) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_32);
-  *(uint32_t *)item->data = value;
+  *(uint32_t*)item->data = value;
 }
 
-void cbor_set_uint64(cbor_item_t *item, uint64_t value) {
+void cbor_set_uint64(cbor_item_t* item, uint64_t value) {
   CBOR_ASSERT(cbor_is_int(item));
   CBOR_ASSERT(cbor_int_get_width(item) == CBOR_INT_64);
-  *(uint64_t *)item->data = value;
+  *(uint64_t*)item->data = value;
 }
 
-void cbor_mark_uint(cbor_item_t *item) {
+void cbor_mark_uint(cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   item->type = CBOR_TYPE_UINT;
 }
 
-void cbor_mark_negint(cbor_item_t *item) {
+void cbor_mark_negint(cbor_item_t* item) {
   CBOR_ASSERT(cbor_is_int(item));
   item->type = CBOR_TYPE_NEGINT;
 }
 
-cbor_item_t *cbor_new_int8(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t) + 1);
+cbor_item_t* cbor_new_int8(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t) + 1);
   _CBOR_NOTNULL(item);
-  *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),
+  *item = (cbor_item_t){.data = (unsigned char*)item + sizeof(cbor_item_t),
                         .refcount = 1,
                         .metadata = {.int_metadata = {.width = CBOR_INT_8}},
                         .type = CBOR_TYPE_UINT};
   return item;
 }
 
-cbor_item_t *cbor_new_int16(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t) + 2);
+cbor_item_t* cbor_new_int16(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t) + 2);
   _CBOR_NOTNULL(item);
-  *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),
+  *item = (cbor_item_t){.data = (unsigned char*)item + sizeof(cbor_item_t),
                         .refcount = 1,
                         .metadata = {.int_metadata = {.width = CBOR_INT_16}},
                         .type = CBOR_TYPE_UINT};
   return item;
 }
 
-cbor_item_t *cbor_new_int32(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t) + 4);
+cbor_item_t* cbor_new_int32(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t) + 4);
   _CBOR_NOTNULL(item);
-  *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),
+  *item = (cbor_item_t){.data = (unsigned char*)item + sizeof(cbor_item_t),
                         .refcount = 1,
                         .metadata = {.int_metadata = {.width = CBOR_INT_32}},
                         .type = CBOR_TYPE_UINT};
   return item;
 }
 
-cbor_item_t *cbor_new_int64(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t) + 8);
+cbor_item_t* cbor_new_int64(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t) + 8);
   _CBOR_NOTNULL(item);
-  *item = (cbor_item_t){.data = (unsigned char *)item + sizeof(cbor_item_t),
+  *item = (cbor_item_t){.data = (unsigned char*)item + sizeof(cbor_item_t),
                         .refcount = 1,
                         .metadata = {.int_metadata = {.width = CBOR_INT_64}},
                         .type = CBOR_TYPE_UINT};
   return item;
 }
 
-cbor_item_t *cbor_build_uint8(uint8_t value) {
-  cbor_item_t *item = cbor_new_int8();
+cbor_item_t* cbor_build_uint8(uint8_t value) {
+  cbor_item_t* item = cbor_new_int8();
   _CBOR_NOTNULL(item);
   cbor_set_uint8(item, value);
   cbor_mark_uint(item);
   return item;
 }
 
-cbor_item_t *cbor_build_uint16(uint16_t value) {
-  cbor_item_t *item = cbor_new_int16();
+cbor_item_t* cbor_build_uint16(uint16_t value) {
+  cbor_item_t* item = cbor_new_int16();
   _CBOR_NOTNULL(item);
   cbor_set_uint16(item, value);
   cbor_mark_uint(item);
   return item;
 }
 
-cbor_item_t *cbor_build_uint32(uint32_t value) {
-  cbor_item_t *item = cbor_new_int32();
+cbor_item_t* cbor_build_uint32(uint32_t value) {
+  cbor_item_t* item = cbor_new_int32();
   _CBOR_NOTNULL(item);
   cbor_set_uint32(item, value);
   cbor_mark_uint(item);
   return item;
 }
 
-cbor_item_t *cbor_build_uint64(uint64_t value) {
-  cbor_item_t *item = cbor_new_int64();
+cbor_item_t* cbor_build_uint64(uint64_t value) {
+  cbor_item_t* item = cbor_new_int64();
   _CBOR_NOTNULL(item);
   cbor_set_uint64(item, value);
   cbor_mark_uint(item);
   return item;
 }
 
-cbor_item_t *cbor_build_negint8(uint8_t value) {
-  cbor_item_t *item = cbor_new_int8();
+cbor_item_t* cbor_build_negint8(uint8_t value) {
+  cbor_item_t* item = cbor_new_int8();
   _CBOR_NOTNULL(item);
   cbor_set_uint8(item, value);
   cbor_mark_negint(item);
   return item;
 }
 
-cbor_item_t *cbor_build_negint16(uint16_t value) {
-  cbor_item_t *item = cbor_new_int16();
+cbor_item_t* cbor_build_negint16(uint16_t value) {
+  cbor_item_t* item = cbor_new_int16();
   _CBOR_NOTNULL(item);
   cbor_set_uint16(item, value);
   cbor_mark_negint(item);
   return item;
 }
 
-cbor_item_t *cbor_build_negint32(uint32_t value) {
-  cbor_item_t *item = cbor_new_int32();
+cbor_item_t* cbor_build_negint32(uint32_t value) {
+  cbor_item_t* item = cbor_new_int32();
   _CBOR_NOTNULL(item);
   cbor_set_uint32(item, value);
   cbor_mark_negint(item);
   return item;
 }
 
-cbor_item_t *cbor_build_negint64(uint64_t value) {
-  cbor_item_t *item = cbor_new_int64();
+cbor_item_t* cbor_build_negint64(uint64_t value) {
+  cbor_item_t* item = cbor_new_int64();
   _CBOR_NOTNULL(item);
   cbor_set_uint64(item, value);
   cbor_mark_negint(item);

--- a/src/cbor/ints.c
+++ b/src/cbor/ints.c
@@ -48,6 +48,9 @@ uint64_t cbor_get_int(const cbor_item_t *item) {
       return cbor_get_uint32(item);
     case CBOR_INT_64:
       return cbor_get_uint64(item);
+    default:
+      _CBOR_UNREACHABLE;
+      return 0;
   }
 }
 

--- a/src/cbor/ints.h
+++ b/src/cbor/ints.h
@@ -26,35 +26,35 @@ extern "C" {
  * @param item positive or negative integer
  * @return the value
  */
-_CBOR_NODISCARD CBOR_EXPORT uint8_t cbor_get_uint8(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint8_t cbor_get_uint8(const cbor_item_t* item);
 
 /** Extracts the integer value
  *
  * @param item positive or negative integer
  * @return the value
  */
-_CBOR_NODISCARD CBOR_EXPORT uint16_t cbor_get_uint16(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint16_t cbor_get_uint16(const cbor_item_t* item);
 
 /** Extracts the integer value
  *
  * @param item positive or negative integer
  * @return the value
  */
-_CBOR_NODISCARD CBOR_EXPORT uint32_t cbor_get_uint32(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint32_t cbor_get_uint32(const cbor_item_t* item);
 
 /** Extracts the integer value
  *
  * @param item positive or negative integer
  * @return the value
  */
-_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_get_uint64(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_get_uint64(const cbor_item_t* item);
 
 /** Extracts the integer value
  *
  * @param item positive or negative integer
  * @return the value, extended to `uint64_t`
  */
-_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_get_int(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_get_int(const cbor_item_t* item);
 
 /** Assigns the integer value
  *
@@ -62,7 +62,7 @@ _CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_get_int(const cbor_item_t *item);
  * @param value the value to assign. For negative integer, the logical value is
  * `-value - 1`
  */
-CBOR_EXPORT void cbor_set_uint8(cbor_item_t *item, uint8_t value);
+CBOR_EXPORT void cbor_set_uint8(cbor_item_t* item, uint8_t value);
 
 /** Assigns the integer value
  *
@@ -70,7 +70,7 @@ CBOR_EXPORT void cbor_set_uint8(cbor_item_t *item, uint8_t value);
  * @param value the value to assign. For negative integer, the logical value is
  * `-value - 1`
  */
-CBOR_EXPORT void cbor_set_uint16(cbor_item_t *item, uint16_t value);
+CBOR_EXPORT void cbor_set_uint16(cbor_item_t* item, uint16_t value);
 
 /** Assigns the integer value
  *
@@ -78,7 +78,7 @@ CBOR_EXPORT void cbor_set_uint16(cbor_item_t *item, uint16_t value);
  * @param value the value to assign. For negative integer, the logical value is
  * `-value - 1`
  */
-CBOR_EXPORT void cbor_set_uint32(cbor_item_t *item, uint32_t value);
+CBOR_EXPORT void cbor_set_uint32(cbor_item_t* item, uint32_t value);
 
 /** Assigns the integer value
  *
@@ -86,7 +86,7 @@ CBOR_EXPORT void cbor_set_uint32(cbor_item_t *item, uint32_t value);
  * @param value the value to assign. For negative integer, the logical value is
  * `-value - 1`
  */
-CBOR_EXPORT void cbor_set_uint64(cbor_item_t *item, uint64_t value);
+CBOR_EXPORT void cbor_set_uint64(cbor_item_t* item, uint64_t value);
 
 /** Queries the integer width
  *
@@ -94,7 +94,7 @@ CBOR_EXPORT void cbor_set_uint64(cbor_item_t *item, uint64_t value);
  *  @return the width
  */
 _CBOR_NODISCARD CBOR_EXPORT cbor_int_width
-cbor_int_get_width(const cbor_item_t *item);
+cbor_int_get_width(const cbor_item_t* item);
 
 /** Marks the integer item as a positive integer
  *
@@ -102,7 +102,7 @@ cbor_int_get_width(const cbor_item_t *item);
  *
  * @param item positive or negative integer item
  */
-CBOR_EXPORT void cbor_mark_uint(cbor_item_t *item);
+CBOR_EXPORT void cbor_mark_uint(cbor_item_t* item);
 
 /** Marks the integer item as a negative integer
  *
@@ -110,7 +110,7 @@ CBOR_EXPORT void cbor_mark_uint(cbor_item_t *item);
  *
  * @param item positive or negative integer item
  */
-CBOR_EXPORT void cbor_mark_negint(cbor_item_t *item);
+CBOR_EXPORT void cbor_mark_negint(cbor_item_t* item);
 
 /** Allocates new integer with 1B width
  *
@@ -119,7 +119,7 @@ CBOR_EXPORT void cbor_mark_negint(cbor_item_t *item);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int8(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_int8(void);
 
 /** Allocates new integer with 2B width
  *
@@ -128,7 +128,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int8(void);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int16(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_int16(void);
 
 /** Allocates new integer with 4B width
  *
@@ -137,7 +137,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int16(void);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int32(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_int32(void);
 
 /** Allocates new integer with 8B width
  *
@@ -146,63 +146,63 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int32(void);
  * @return **new** positive integer or `NULL` on memory allocation failure. The
  * value is not initialized
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_int64(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_int64(void);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint8(uint8_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_uint8(uint8_t value);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint16(uint16_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_uint16(uint16_t value);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint32(uint32_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_uint32(uint32_t value);
 
 /** Constructs a new positive integer
  *
  * @param value the value to use
  * @return **new** positive integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_uint64(uint64_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_uint64(uint64_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint8(uint8_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_negint8(uint8_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint16(uint16_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_negint16(uint16_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint32(uint32_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_negint32(uint32_t value);
 
 /** Constructs a new negative integer
  *
  * @param value the value to use
  * @return **new** negative integer or `NULL` on memory allocation failure
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_negint64(uint64_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_negint64(uint64_t value);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/maps.c
+++ b/src/cbor/maps.c
@@ -8,18 +8,18 @@
 #include "maps.h"
 #include "internal/memory_utils.h"
 
-size_t cbor_map_size(const cbor_item_t *item) {
+size_t cbor_map_size(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_map(item));
   return item->metadata.map_metadata.end_ptr;
 }
 
-size_t cbor_map_allocated(const cbor_item_t *item) {
+size_t cbor_map_allocated(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_map(item));
   return item->metadata.map_metadata.allocated;
 }
 
-cbor_item_t *cbor_new_definite_map(size_t size) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_definite_map(size_t size) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){
@@ -34,8 +34,8 @@ cbor_item_t *cbor_new_definite_map(size_t size) {
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_map(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_indefinite_map(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){
@@ -49,12 +49,12 @@ cbor_item_t *cbor_new_indefinite_map(void) {
   return item;
 }
 
-bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key) {
+bool _cbor_map_add_key(cbor_item_t* item, cbor_item_t* key) {
   CBOR_ASSERT(cbor_isa_map(item));
-  struct _cbor_map_metadata *metadata =
-      (struct _cbor_map_metadata *)&item->metadata;
+  struct _cbor_map_metadata* metadata =
+      (struct _cbor_map_metadata*)&item->metadata;
   if (cbor_map_is_definite(item)) {
-    struct cbor_pair *data = cbor_map_handle(item);
+    struct cbor_pair* data = cbor_map_handle(item);
     if (metadata->end_ptr >= metadata->allocated) {
       /* Don't realloc definite preallocated map */
       return false;
@@ -74,7 +74,7 @@ bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key) {
                                   ? 1
                                   : CBOR_BUFFER_GROWTH * metadata->allocated;
 
-      unsigned char *new_data = _cbor_realloc_multiple(
+      unsigned char* new_data = _cbor_realloc_multiple(
           item->data, sizeof(struct cbor_pair), new_allocation);
 
       if (new_data == NULL) {
@@ -84,7 +84,7 @@ bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key) {
       item->data = new_data;
       metadata->allocated = new_allocation;
     }
-    struct cbor_pair *data = cbor_map_handle(item);
+    struct cbor_pair* data = cbor_map_handle(item);
     data[metadata->end_ptr].key = key;
     data[metadata->end_ptr++].value = NULL;
   }
@@ -92,7 +92,7 @@ bool _cbor_map_add_key(cbor_item_t *item, cbor_item_t *key) {
   return true;
 }
 
-bool _cbor_map_add_value(cbor_item_t *item, cbor_item_t *value) {
+bool _cbor_map_add_value(cbor_item_t* item, cbor_item_t* value) {
   CBOR_ASSERT(cbor_isa_map(item));
   cbor_incref(value);
   cbor_map_handle(item)[
@@ -104,22 +104,22 @@ bool _cbor_map_add_value(cbor_item_t *item, cbor_item_t *value) {
 }
 
 // TODO: Add a more convenient API like add(item, key, val)
-bool cbor_map_add(cbor_item_t *item, struct cbor_pair pair) {
+bool cbor_map_add(cbor_item_t* item, struct cbor_pair pair) {
   CBOR_ASSERT(cbor_isa_map(item));
   if (!_cbor_map_add_key(item, pair.key)) return false;
   return _cbor_map_add_value(item, pair.value);
 }
 
-bool cbor_map_is_definite(const cbor_item_t *item) {
+bool cbor_map_is_definite(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_map(item));
   return item->metadata.map_metadata.type == _CBOR_METADATA_DEFINITE;
 }
 
-bool cbor_map_is_indefinite(const cbor_item_t *item) {
+bool cbor_map_is_indefinite(const cbor_item_t* item) {
   return !cbor_map_is_definite(item);
 }
 
-struct cbor_pair *cbor_map_handle(const cbor_item_t *item) {
+struct cbor_pair* cbor_map_handle(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_map(item));
-  return (struct cbor_pair *)item->data;
+  return (struct cbor_pair*)item->data;
 }

--- a/src/cbor/maps.h
+++ b/src/cbor/maps.h
@@ -26,14 +26,14 @@ extern "C" {
  * @param item A map
  * @return The number of pairs
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_map_size(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_map_size(const cbor_item_t* item);
 
 /** Get the size of the allocated storage
  *
  * @param item A map
  * @return Allocated storage size (as the number of #cbor_pair items)
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_map_allocated(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_map_allocated(const cbor_item_t* item);
 
 /** Create a new definite map
  *
@@ -42,7 +42,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_map_allocated(const cbor_item_t *item);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_definite_map(size_t size);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_definite_map(size_t size);
 
 /** Create a new indefinite map
  *
@@ -50,7 +50,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_definite_map(size_t size);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_indefinite_map(void);
 
 /** Add a pair to the map
  *
@@ -63,7 +63,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_indefinite_map(void);
  * @return `true` on success, `false` if memory allocation failed (indefinite
  * maps) or the preallocated storage is full (definite maps)
  */
-_CBOR_NODISCARD CBOR_EXPORT bool cbor_map_add(cbor_item_t *item,
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_map_add(cbor_item_t* item,
                                               struct cbor_pair pair);
 
 /** Add a key to the map
@@ -75,8 +75,8 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_map_add(cbor_item_t *item,
  * @return `true` on success, `false` if either reallocation failed or the
  * preallocated storage is full
  */
-_CBOR_NODISCARD CBOR_EXPORT bool _cbor_map_add_key(cbor_item_t *item,
-                                                   cbor_item_t *key);
+_CBOR_NODISCARD CBOR_EXPORT bool _cbor_map_add_key(cbor_item_t* item,
+                                                   cbor_item_t* key);
 
 /** Add a value to the map
  *
@@ -87,15 +87,15 @@ _CBOR_NODISCARD CBOR_EXPORT bool _cbor_map_add_key(cbor_item_t *item,
  * @return `true` on success, `false` if either reallocation failed or the
  * preallocated storage is full
  */
-_CBOR_NODISCARD CBOR_EXPORT bool _cbor_map_add_value(cbor_item_t *item,
-                                                     cbor_item_t *value);
+_CBOR_NODISCARD CBOR_EXPORT bool _cbor_map_add_value(cbor_item_t* item,
+                                                     cbor_item_t* value);
 
 /** Is this map definite?
  *
  * @param item A map
  * @return Is this map definite?
  */
-_CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_definite(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_definite(const cbor_item_t* item);
 
 /** Is this map indefinite?
  *
@@ -103,7 +103,7 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_definite(const cbor_item_t *item);
  * @return Is this map indefinite?
  */
 _CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_indefinite(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Get the pairs storage
  *
@@ -111,8 +111,8 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_indefinite(
  * @return Array of #cbor_map_size pairs. Manipulation is possible as long as
  * references remain valid.
  */
-_CBOR_NODISCARD CBOR_EXPORT struct cbor_pair *cbor_map_handle(
-    const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT struct cbor_pair* cbor_map_handle(
+    const cbor_item_t* item);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -19,7 +19,6 @@
 
 size_t cbor_serialize(const cbor_item_t *item, unsigned char *buffer,
                       size_t buffer_size) {
-  // cppcheck-suppress missingReturn
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
       return cbor_serialize_uint(item, buffer, buffer_size);
@@ -37,6 +36,9 @@ size_t cbor_serialize(const cbor_item_t *item, unsigned char *buffer,
       return cbor_serialize_tag(item, buffer, buffer_size);
     case CBOR_TYPE_FLOAT_CTRL:
       return cbor_serialize_float_ctrl(item, buffer, buffer_size);
+    default:
+      _CBOR_UNREACHABLE;
+      return 0;
   }
 }
 
@@ -59,7 +61,6 @@ size_t _cbor_encoded_header_size(uint64_t size) {
 }
 
 size_t cbor_serialized_size(const cbor_item_t *item) {
-  // cppcheck-suppress missingReturn
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
     case CBOR_TYPE_NEGINT:
@@ -73,6 +74,9 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
           return 5;
         case CBOR_INT_64:
           return 9;
+        default:
+          _CBOR_UNREACHABLE;
+          return 0;
       }
     // Note: We do not _cbor_safe_signaling_add zero-length definite strings,
     // they would cause zeroes to propagate. All other items are at least one
@@ -147,7 +151,13 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
           return 5;
         case CBOR_FLOAT_64:
           return 9;
+        default:
+          _CBOR_UNREACHABLE;
+          return 0;
       }
+    default:
+      _CBOR_UNREACHABLE;
+      return 0;
   }
 }
 
@@ -184,6 +194,9 @@ size_t cbor_serialize_uint(const cbor_item_t *item, unsigned char *buffer,
       return cbor_encode_uint32(cbor_get_uint32(item), buffer, buffer_size);
     case CBOR_INT_64:
       return cbor_encode_uint64(cbor_get_uint64(item), buffer, buffer_size);
+    default:
+      _CBOR_UNREACHABLE;
+      return 0;
   }
 }
 
@@ -200,6 +213,9 @@ size_t cbor_serialize_negint(const cbor_item_t *item, unsigned char *buffer,
       return cbor_encode_negint32(cbor_get_uint32(item), buffer, buffer_size);
     case CBOR_INT_64:
       return cbor_encode_negint64(cbor_get_uint64(item), buffer, buffer_size);
+    default:
+      _CBOR_UNREACHABLE;
+      return 0;
   }
 }
 
@@ -364,5 +380,8 @@ size_t cbor_serialize_float_ctrl(const cbor_item_t *item, unsigned char *buffer,
     case CBOR_FLOAT_64:
       return cbor_encode_double(cbor_float_get_float8(item), buffer,
                                 buffer_size);
+    default:
+      _CBOR_UNREACHABLE;
+      return 0;
   }
 }

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -17,7 +17,7 @@
 #include "encoding.h"
 #include "internal/memory_utils.h"
 
-size_t cbor_serialize(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize(const cbor_item_t* item, unsigned char* buffer,
                       size_t buffer_size) {
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
@@ -60,7 +60,7 @@ size_t _cbor_encoded_header_size(uint64_t size) {
     return 9;
 }
 
-size_t cbor_serialized_size(const cbor_item_t *item) {
+size_t cbor_serialized_size(const cbor_item_t* item) {
   switch (cbor_typeof(item)) {
     case CBOR_TYPE_UINT:
     case CBOR_TYPE_NEGINT:
@@ -90,7 +90,7 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
                                         cbor_bytestring_length(item));
       }
       size_t indef_bytestring_size = 2;  // Leading byte + break
-      cbor_item_t **chunks = cbor_bytestring_chunks_handle(item);
+      cbor_item_t** chunks = cbor_bytestring_chunks_handle(item);
       for (size_t i = 0; i < cbor_bytestring_chunk_count(item); i++) {
         indef_bytestring_size = _cbor_safe_signaling_add(
             indef_bytestring_size, cbor_serialized_size(chunks[i]));
@@ -105,7 +105,7 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
         return _cbor_safe_signaling_add(header_size, cbor_string_length(item));
       }
       size_t indef_string_size = 2;  // Leading byte + break
-      cbor_item_t **chunks = cbor_string_chunks_handle(item);
+      cbor_item_t** chunks = cbor_string_chunks_handle(item);
       for (size_t i = 0; i < cbor_string_chunk_count(item); i++) {
         indef_string_size = _cbor_safe_signaling_add(
             indef_string_size, cbor_serialized_size(chunks[i]));
@@ -116,7 +116,7 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
       size_t array_size = cbor_array_is_definite(item)
                               ? _cbor_encoded_header_size(cbor_array_size(item))
                               : 2;  // Leading byte + break
-      cbor_item_t **items = cbor_array_handle(item);
+      cbor_item_t** items = cbor_array_handle(item);
       for (size_t i = 0; i < cbor_array_size(item); i++) {
         array_size = _cbor_safe_signaling_add(array_size,
                                               cbor_serialized_size(items[i]));
@@ -127,7 +127,7 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
       size_t map_size = cbor_map_is_definite(item)
                             ? _cbor_encoded_header_size(cbor_map_size(item))
                             : 2;  // Leading byte + break
-      struct cbor_pair *items = cbor_map_handle(item);
+      struct cbor_pair* items = cbor_map_handle(item);
       for (size_t i = 0; i < cbor_map_size(item); i++) {
         map_size = _cbor_safe_signaling_add(
             map_size,
@@ -161,8 +161,8 @@ size_t cbor_serialized_size(const cbor_item_t *item) {
   }
 }
 
-size_t cbor_serialize_alloc(const cbor_item_t *item, unsigned char **buffer,
-                            size_t *buffer_size) {
+size_t cbor_serialize_alloc(const cbor_item_t* item, unsigned char** buffer,
+                            size_t* buffer_size) {
   *buffer = NULL;
   size_t serialized_size = cbor_serialized_size(item);
   if (serialized_size == 0) {
@@ -181,7 +181,7 @@ size_t cbor_serialize_alloc(const cbor_item_t *item, unsigned char **buffer,
   return written;
 }
 
-size_t cbor_serialize_uint(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_uint(const cbor_item_t* item, unsigned char* buffer,
                            size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_uint(item));
   // cppcheck-suppress missingReturn
@@ -200,7 +200,7 @@ size_t cbor_serialize_uint(const cbor_item_t *item, unsigned char *buffer,
   }
 }
 
-size_t cbor_serialize_negint(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_negint(const cbor_item_t* item, unsigned char* buffer,
                              size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_negint(item));
   // cppcheck-suppress missingReturn
@@ -219,7 +219,7 @@ size_t cbor_serialize_negint(const cbor_item_t *item, unsigned char *buffer,
   }
 }
 
-size_t cbor_serialize_bytestring(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_bytestring(const cbor_item_t* item, unsigned char* buffer,
                                  size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_bytestring(item));
   if (cbor_bytestring_is_definite(item)) {
@@ -236,7 +236,7 @@ size_t cbor_serialize_bytestring(const cbor_item_t *item, unsigned char *buffer,
     size_t written = cbor_encode_indef_bytestring_start(buffer, buffer_size);
     if (written == 0) return 0;
 
-    cbor_item_t **chunks = cbor_bytestring_chunks_handle(item);
+    cbor_item_t** chunks = cbor_bytestring_chunks_handle(item);
     for (size_t i = 0; i < chunk_count; i++) {
       size_t chunk_written = cbor_serialize_bytestring(
           chunks[i], buffer + written, buffer_size - written);
@@ -251,7 +251,7 @@ size_t cbor_serialize_bytestring(const cbor_item_t *item, unsigned char *buffer,
   }
 }
 
-size_t cbor_serialize_string(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_string(const cbor_item_t* item, unsigned char* buffer,
                              size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_string(item));
   if (cbor_string_is_definite(item)) {
@@ -268,7 +268,7 @@ size_t cbor_serialize_string(const cbor_item_t *item, unsigned char *buffer,
     size_t written = cbor_encode_indef_string_start(buffer, buffer_size);
     if (written == 0) return 0;
 
-    cbor_item_t **chunks = cbor_string_chunks_handle(item);
+    cbor_item_t** chunks = cbor_string_chunks_handle(item);
     for (size_t i = 0; i < chunk_count; i++) {
       size_t chunk_written = cbor_serialize_string(chunks[i], buffer + written,
                                                    buffer_size - written);
@@ -283,11 +283,11 @@ size_t cbor_serialize_string(const cbor_item_t *item, unsigned char *buffer,
   }
 }
 
-size_t cbor_serialize_array(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_array(const cbor_item_t* item, unsigned char* buffer,
                             size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_array(item));
   size_t size = cbor_array_size(item), written = 0;
-  cbor_item_t **handle = cbor_array_handle(item);
+  cbor_item_t** handle = cbor_array_handle(item);
   if (cbor_array_is_definite(item)) {
     written = cbor_encode_array_start(size, buffer, buffer_size);
   } else {
@@ -314,11 +314,11 @@ size_t cbor_serialize_array(const cbor_item_t *item, unsigned char *buffer,
   }
 }
 
-size_t cbor_serialize_map(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_map(const cbor_item_t* item, unsigned char* buffer,
                           size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_map(item));
   size_t size = cbor_map_size(item), written = 0;
-  struct cbor_pair *handle = cbor_map_handle(item);
+  struct cbor_pair* handle = cbor_map_handle(item);
 
   if (cbor_map_is_definite(item)) {
     written = cbor_encode_map_start(size, buffer, buffer_size);
@@ -352,7 +352,7 @@ size_t cbor_serialize_map(const cbor_item_t *item, unsigned char *buffer,
   }
 }
 
-size_t cbor_serialize_tag(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_tag(const cbor_item_t* item, unsigned char* buffer,
                           size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_tag(item));
   size_t written = cbor_encode_tag(cbor_tag_value(item), buffer, buffer_size);
@@ -364,7 +364,7 @@ size_t cbor_serialize_tag(const cbor_item_t *item, unsigned char *buffer,
   return written + item_written;
 }
 
-size_t cbor_serialize_float_ctrl(const cbor_item_t *item, unsigned char *buffer,
+size_t cbor_serialize_float_ctrl(const cbor_item_t* item, unsigned char* buffer,
                                  size_t buffer_size) {
   CBOR_ASSERT(cbor_isa_float_ctrl(item));
   // cppcheck-suppress missingReturn

--- a/src/cbor/serialization.h
+++ b/src/cbor/serialization.h
@@ -28,7 +28,7 @@ extern "C" {
  * @param buffer_size Size of the \p buffer
  * @return Length of the result. 0 on failure.
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize(const cbor_item_t *item,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize(const cbor_item_t* item,
                                                   cbor_mutable_data buffer,
                                                   size_t buffer_size);
 
@@ -42,7 +42,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize(const cbor_item_t *item,
  * `size_t`.
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t
-cbor_serialized_size(const cbor_item_t *item);
+cbor_serialized_size(const cbor_item_t* item);
 
 /** Serialize the given item, allocating buffers as needed
  *
@@ -62,9 +62,9 @@ cbor_serialized_size(const cbor_item_t *item);
  * @return Length of the result in bytes
  * @return 0 on memory allocation failure, in which case \p buffer is `NULL`.
  */
-CBOR_EXPORT size_t cbor_serialize_alloc(const cbor_item_t *item,
-                                        unsigned char **buffer,
-                                        size_t *buffer_size);
+CBOR_EXPORT size_t cbor_serialize_alloc(const cbor_item_t* item,
+                                        unsigned char** buffer,
+                                        size_t* buffer_size);
 
 /** Serialize an uint
  *
@@ -74,7 +74,7 @@ CBOR_EXPORT size_t cbor_serialize_alloc(const cbor_item_t *item,
  * @return Length of the result
  * @return 0 if the \p buffer_size doesn't fit the result
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_uint(const cbor_item_t *item,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_uint(const cbor_item_t* item,
                                                        cbor_mutable_data buffer,
                                                        size_t buffer_size);
 
@@ -87,7 +87,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_uint(const cbor_item_t *item,
  * @return 0 if the \p buffer_size doesn't fit the result
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_negint(
-    const cbor_item_t *item, cbor_mutable_data buffer, size_t buffer_size);
+    const cbor_item_t* item, cbor_mutable_data buffer, size_t buffer_size);
 
 /** Serialize a bytestring
  *
@@ -99,7 +99,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_negint(
  * still be modified
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_bytestring(
-    const cbor_item_t *item, cbor_mutable_data buffer, size_t buffer_size);
+    const cbor_item_t* item, cbor_mutable_data buffer, size_t buffer_size);
 
 /** Serialize a string
  *
@@ -111,7 +111,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_bytestring(
  * still be modified
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_string(
-    const cbor_item_t *item, cbor_mutable_data buffer, size_t buffer_size);
+    const cbor_item_t* item, cbor_mutable_data buffer, size_t buffer_size);
 /** Serialize an array
  *
  * @param item An array
@@ -122,7 +122,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_string(
  * still be modified
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_array(
-    const cbor_item_t *item, cbor_mutable_data buffer, size_t buffer_size);
+    const cbor_item_t* item, cbor_mutable_data buffer, size_t buffer_size);
 
 /** Serialize a map
  *
@@ -133,7 +133,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_array(
  * @return 0 if the \p buffer_size doesn't fit the result. The \p buffer may
  * still be modified
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_map(const cbor_item_t *item,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_map(const cbor_item_t* item,
                                                       cbor_mutable_data buffer,
                                                       size_t buffer_size);
 
@@ -146,7 +146,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_map(const cbor_item_t *item,
  * @return 0 if the \p buffer_size doesn't fit the result. The \p buffer may
  * still be modified
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_tag(const cbor_item_t *item,
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_tag(const cbor_item_t* item,
                                                       cbor_mutable_data buffer,
                                                       size_t buffer_size);
 
@@ -159,7 +159,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_tag(const cbor_item_t *item,
  * @return 0 if the \p buffer_size doesn't fit the result
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t cbor_serialize_float_ctrl(
-    const cbor_item_t *item, cbor_mutable_data buffer, size_t buffer_size);
+    const cbor_item_t* item, cbor_mutable_data buffer, size_t buffer_size);
 
 #ifdef __cplusplus
 }

--- a/src/cbor/streaming.c
+++ b/src/cbor/streaming.c
@@ -9,7 +9,7 @@
 #include "internal/loaders.h"
 
 static bool claim_bytes(size_t required, size_t provided,
-                        struct cbor_decoder_result *result) {
+                        struct cbor_decoder_result* result) {
   if (required > (provided - result->read)) {
     result->required = required + result->read;
     result->read = 0;
@@ -42,7 +42,7 @@ static bool claim_bytes(size_t required, size_t provided,
 
 struct cbor_decoder_result cbor_stream_decode(
     cbor_data source, size_t source_size,
-    const struct cbor_callbacks *callbacks, void *context) {
+    const struct cbor_callbacks* callbacks, void* context) {
   // Attempt to claim the initial MTB byte
   struct cbor_decoder_result result = {.status = CBOR_DECODER_FINISHED};
   if (!claim_bytes(1, source_size, &result)) {

--- a/src/cbor/streaming.c
+++ b/src/cbor/streaming.c
@@ -592,9 +592,10 @@ struct cbor_decoder_result cbor_stream_decode(
     case 0xFF:
       /* Break */
       callbacks->indef_break(context);
-      // Never happens, the switch statement is exhaustive on the 1B range; make
-      // compiler happy
+      return result;
     default:
+      // Never happens, the switch statement is exhaustive on the 1B range
+      _CBOR_UNREACHABLE;
       return result;
   }
 }

--- a/src/cbor/strings.c
+++ b/src/cbor/strings.c
@@ -10,8 +10,8 @@
 #include "internal/memory_utils.h"
 #include "internal/unicode.h"
 
-cbor_item_t *cbor_new_definite_string(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_definite_string(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){
       .refcount = 1,
@@ -22,8 +22,8 @@ cbor_item_t *cbor_new_definite_string(void) {
   return item;
 }
 
-cbor_item_t *cbor_new_indefinite_string(void) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_indefinite_string(void) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
   *item = (cbor_item_t){
       .refcount = 1,
@@ -32,7 +32,7 @@ cbor_item_t *cbor_new_indefinite_string(void) {
                                        .length = 0}},
       .data = _cbor_malloc(sizeof(struct cbor_indefinite_string_data))};
   _CBOR_DEPENDENT_NOTNULL(item, item->data);
-  *((struct cbor_indefinite_string_data *)item->data) =
+  *((struct cbor_indefinite_string_data*)item->data) =
       (struct cbor_indefinite_string_data){
           .chunk_count = 0,
           .chunk_capacity = 0,
@@ -41,28 +41,28 @@ cbor_item_t *cbor_new_indefinite_string(void) {
   return item;
 }
 
-cbor_item_t *cbor_build_string(const char *val) {
-  cbor_item_t *item = cbor_new_definite_string();
+cbor_item_t* cbor_build_string(const char* val) {
+  cbor_item_t* item = cbor_new_definite_string();
   _CBOR_NOTNULL(item);
   size_t len = strlen(val);
-  unsigned char *handle = _cbor_malloc(len);
+  unsigned char* handle = _cbor_malloc(len);
   _CBOR_DEPENDENT_NOTNULL(item, handle);
   memcpy(handle, val, len);
   cbor_string_set_handle(item, handle, len);
   return item;
 }
 
-cbor_item_t *cbor_build_stringn(const char *val, size_t length) {
-  cbor_item_t *item = cbor_new_definite_string();
+cbor_item_t* cbor_build_stringn(const char* val, size_t length) {
+  cbor_item_t* item = cbor_new_definite_string();
   _CBOR_NOTNULL(item);
-  unsigned char *handle = _cbor_malloc(length);
+  unsigned char* handle = _cbor_malloc(length);
   _CBOR_DEPENDENT_NOTNULL(item, handle);
   memcpy(handle, val, length);
   cbor_string_set_handle(item, handle, length);
   return item;
 }
 
-void cbor_string_set_handle(cbor_item_t *item,
+void cbor_string_set_handle(cbor_item_t* item,
                             cbor_mutable_data CBOR_RESTRICT_POINTER data,
                             size_t length) {
   CBOR_ASSERT(cbor_isa_string(item));
@@ -80,23 +80,23 @@ void cbor_string_set_handle(cbor_item_t *item,
   }
 }
 
-cbor_item_t **cbor_string_chunks_handle(const cbor_item_t *item) {
+cbor_item_t** cbor_string_chunks_handle(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_string(item));
   CBOR_ASSERT(cbor_string_is_indefinite(item));
-  return ((struct cbor_indefinite_string_data *)item->data)->chunks;
+  return ((struct cbor_indefinite_string_data*)item->data)->chunks;
 }
 
-size_t cbor_string_chunk_count(const cbor_item_t *item) {
+size_t cbor_string_chunk_count(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_string(item));
   CBOR_ASSERT(cbor_string_is_indefinite(item));
-  return ((struct cbor_indefinite_string_data *)item->data)->chunk_count;
+  return ((struct cbor_indefinite_string_data*)item->data)->chunk_count;
 }
 
-bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
+bool cbor_string_add_chunk(cbor_item_t* item, cbor_item_t* chunk) {
   CBOR_ASSERT(cbor_isa_string(item));
   CBOR_ASSERT(cbor_string_is_indefinite(item));
-  struct cbor_indefinite_string_data *data =
-      (struct cbor_indefinite_string_data *)item->data;
+  struct cbor_indefinite_string_data* data =
+      (struct cbor_indefinite_string_data*)item->data;
   if (data->chunk_count == data->chunk_capacity) {
     if (!_cbor_safe_to_multiply(CBOR_BUFFER_GROWTH, data->chunk_capacity)) {
       return false;
@@ -105,8 +105,8 @@ bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
     size_t new_chunk_capacity =
         data->chunk_capacity == 0 ? 1
                                   : CBOR_BUFFER_GROWTH * (data->chunk_capacity);
-    cbor_item_t **new_chunks_data = _cbor_realloc_multiple(
-        data->chunks, sizeof(cbor_item_t *), new_chunk_capacity);
+    cbor_item_t** new_chunks_data = _cbor_realloc_multiple(
+        data->chunks, sizeof(cbor_item_t*), new_chunk_capacity);
 
     if (new_chunks_data == NULL) {
       return false;
@@ -119,26 +119,26 @@ bool cbor_string_add_chunk(cbor_item_t *item, cbor_item_t *chunk) {
   return true;
 }
 
-size_t cbor_string_length(const cbor_item_t *item) {
+size_t cbor_string_length(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_string(item));
   return item->metadata.string_metadata.length;
 }
 
-unsigned char *cbor_string_handle(const cbor_item_t *item) {
+unsigned char* cbor_string_handle(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_string(item));
   return item->data;
 }
 
-size_t cbor_string_codepoint_count(const cbor_item_t *item) {
+size_t cbor_string_codepoint_count(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_string(item));
   return item->metadata.string_metadata.codepoint_count;
 }
 
-bool cbor_string_is_definite(const cbor_item_t *item) {
+bool cbor_string_is_definite(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_string(item));
   return item->metadata.string_metadata.type == _CBOR_METADATA_DEFINITE;
 }
 
-bool cbor_string_is_indefinite(const cbor_item_t *item) {
+bool cbor_string_is_indefinite(const cbor_item_t* item) {
   return !cbor_string_is_definite(item);
 }

--- a/src/cbor/strings.c
+++ b/src/cbor/strings.c
@@ -16,7 +16,9 @@ cbor_item_t *cbor_new_definite_string(void) {
   *item = (cbor_item_t){
       .refcount = 1,
       .type = CBOR_TYPE_STRING,
-      .metadata = {.string_metadata = {_CBOR_METADATA_DEFINITE, 0}}};
+      .metadata = {.string_metadata = {.type = _CBOR_METADATA_DEFINITE,
+                                       .codepoint_count = 0,
+                                       .length = 0}}};
   return item;
 }
 

--- a/src/cbor/strings.h
+++ b/src/cbor/strings.h
@@ -29,7 +29,7 @@ extern "C" {
  * @param item a definite string
  * @return length of the string. Zero if no chunk has been attached yet
  */
-_CBOR_NODISCARD CBOR_EXPORT size_t cbor_string_length(const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT size_t cbor_string_length(const cbor_item_t* item);
 
 /** The number of codepoints in this string
  *
@@ -40,7 +40,7 @@ _CBOR_NODISCARD CBOR_EXPORT size_t cbor_string_length(const cbor_item_t *item);
  * @return The number of codepoints in this string
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t
-cbor_string_codepoint_count(const cbor_item_t *item);
+cbor_string_codepoint_count(const cbor_item_t* item);
 
 /** Is the string definite?
  *
@@ -48,7 +48,7 @@ cbor_string_codepoint_count(const cbor_item_t *item);
  * @return Is the string definite?
  */
 _CBOR_NODISCARD CBOR_EXPORT bool cbor_string_is_definite(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Is the string indefinite?
  *
@@ -56,7 +56,7 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_string_is_definite(
  * @return Is the string indefinite?
  */
 _CBOR_NODISCARD CBOR_EXPORT bool cbor_string_is_indefinite(
-    const cbor_item_t *item);
+    const cbor_item_t* item);
 
 /** Get the handle to the underlying string
  *
@@ -68,7 +68,7 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_string_is_indefinite(
  * @return `NULL` if no data have been assigned yet.
  */
 _CBOR_NODISCARD CBOR_EXPORT cbor_mutable_data
-cbor_string_handle(const cbor_item_t *item);
+cbor_string_handle(const cbor_item_t* item);
 
 /** Set the handle to the underlying string
  *
@@ -87,7 +87,7 @@ cbor_string_handle(const cbor_item_t *item);
  * @param length Length of the data block
  */
 CBOR_EXPORT void cbor_string_set_handle(
-    cbor_item_t *item, cbor_mutable_data CBOR_RESTRICT_POINTER data,
+    cbor_item_t* item, cbor_mutable_data CBOR_RESTRICT_POINTER data,
     size_t length);
 
 /** Get the handle to the array of chunks
@@ -98,8 +98,8 @@ CBOR_EXPORT void cbor_string_set_handle(
  * @param item A indefinite string
  * @return array of #cbor_string_chunk_count definite strings
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t **cbor_string_chunks_handle(
-    const cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t** cbor_string_chunks_handle(
+    const cbor_item_t* item);
 
 /** Get the number of chunks this string consist of
  *
@@ -107,7 +107,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t **cbor_string_chunks_handle(
  * @return The chunk count. 0 for freshly created items.
  */
 _CBOR_NODISCARD CBOR_EXPORT size_t
-cbor_string_chunk_count(const cbor_item_t *item);
+cbor_string_chunk_count(const cbor_item_t* item);
 
 /** Appends a chunk to the string
  *
@@ -122,8 +122,8 @@ cbor_string_chunk_count(const cbor_item_t *item);
  * case, the refcount of @p `chunk` is not increased and the @p `item` is left
  * intact.
  */
-_CBOR_NODISCARD CBOR_EXPORT bool cbor_string_add_chunk(cbor_item_t *item,
-                                                       cbor_item_t *chunk);
+_CBOR_NODISCARD CBOR_EXPORT bool cbor_string_add_chunk(cbor_item_t* item,
+                                                       cbor_item_t* chunk);
 
 /** Creates a new definite string
  *
@@ -133,7 +133,7 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_string_add_chunk(cbor_item_t *item,
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_definite_string(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_definite_string(void);
 
 /** Creates a new indefinite string
  *
@@ -143,7 +143,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_definite_string(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_indefinite_string(void);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_indefinite_string(void);
 
 /** Creates a new string and initializes it
  *
@@ -158,7 +158,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_indefinite_string(void);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_string(const char *val);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_string(const char* val);
 
 /** Creates a new string and initializes it
  *
@@ -173,7 +173,7 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_string(const char *val);
  * initialized to one.
  * @return `NULL` if memory allocation fails
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_stringn(const char *val,
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_stringn(const char* val,
                                                             size_t length);
 
 #ifdef __cplusplus

--- a/src/cbor/tags.c
+++ b/src/cbor/tags.c
@@ -7,8 +7,8 @@
 
 #include "tags.h"
 
-cbor_item_t *cbor_new_tag(uint64_t value) {
-  cbor_item_t *item = _cbor_malloc(sizeof(cbor_item_t));
+cbor_item_t* cbor_new_tag(uint64_t value) {
+  cbor_item_t* item = _cbor_malloc(sizeof(cbor_item_t));
   _CBOR_NOTNULL(item);
 
   *item = (cbor_item_t){
@@ -20,24 +20,24 @@ cbor_item_t *cbor_new_tag(uint64_t value) {
   return item;
 }
 
-cbor_item_t *cbor_tag_item(const cbor_item_t *tag) {
+cbor_item_t* cbor_tag_item(const cbor_item_t* tag) {
   CBOR_ASSERT(cbor_isa_tag(tag));
   return cbor_incref(tag->metadata.tag_metadata.tagged_item);
 }
 
-uint64_t cbor_tag_value(const cbor_item_t *tag) {
+uint64_t cbor_tag_value(const cbor_item_t* tag) {
   CBOR_ASSERT(cbor_isa_tag(tag));
   return tag->metadata.tag_metadata.value;
 }
 
-void cbor_tag_set_item(cbor_item_t *tag, cbor_item_t *tagged_item) {
+void cbor_tag_set_item(cbor_item_t* tag, cbor_item_t* tagged_item) {
   CBOR_ASSERT(cbor_isa_tag(tag));
   cbor_incref(tagged_item);
   tag->metadata.tag_metadata.tagged_item = tagged_item;
 }
 
-cbor_item_t *cbor_build_tag(uint64_t value, cbor_item_t *item) {
-  cbor_item_t *res = cbor_new_tag(value);
+cbor_item_t* cbor_build_tag(uint64_t value, cbor_item_t* item) {
+  cbor_item_t* res = cbor_new_tag(value);
   if (res == NULL) {
     return NULL;
   }

--- a/src/cbor/tags.h
+++ b/src/cbor/tags.h
@@ -28,7 +28,7 @@ extern "C" {
  * and it points to a `NULL` item.
  * @return `NULL` if memory allocation fails.
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_tag(uint64_t value);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_tag(uint64_t value);
 
 /** Get the tagged item (what the tag points to).
  *
@@ -38,14 +38,14 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_new_tag(uint64_t value);
  * Increases the reference count of the underlying item. The returned reference
  * must be released using #cbor_decref.
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_tag_item(const cbor_item_t *tag);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_tag_item(const cbor_item_t* tag);
 
 /** Get the tag value.
  *
  * @param tag A #CBOR_TYPE_TAG tag.
  * @return The tag value (number).
  */
-_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_tag_value(const cbor_item_t *tag);
+_CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_tag_value(const cbor_item_t* tag);
 
 /** Assign a tag to an item.
  *
@@ -57,7 +57,7 @@ _CBOR_NODISCARD CBOR_EXPORT uint64_t cbor_tag_value(const cbor_item_t *tag);
  * reference count change on the previous item.
  * TODO: Should we release the reference automatically?
  */
-CBOR_EXPORT void cbor_tag_set_item(cbor_item_t *tag, cbor_item_t *tagged_item);
+CBOR_EXPORT void cbor_tag_set_item(cbor_item_t* tag, cbor_item_t* tagged_item);
 
 /** Build a new tag.
  *
@@ -68,8 +68,8 @@ CBOR_EXPORT void cbor_tag_set_item(cbor_item_t *tag, cbor_item_t *tagged_item);
  * initialized to one.
  * @return `NULL` if memory allocation fails.
  */
-_CBOR_NODISCARD CBOR_EXPORT cbor_item_t *cbor_build_tag(uint64_t value,
-                                                        cbor_item_t *item);
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_build_tag(uint64_t value,
+                                                        cbor_item_t* item);
 
 #ifdef __cplusplus
 }

--- a/test/array_encoders_test.c
+++ b/test/array_encoders_test.c
@@ -10,27 +10,27 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_array_start(void **_state _CBOR_UNUSED) {
+static void test_embedded_array_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_array_start(1, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x81}), 1);
 }
 
-static void test_array_start(void **_state _CBOR_UNUSED) {
+static void test_array_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_array_start(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x9A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
 }
 
-static void test_indef_array_start(void **_state _CBOR_UNUSED) {
+static void test_indef_array_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_indef_array_start(buffer, 512));
   assert_size_equal(0, cbor_encode_indef_array_start(buffer, 0));
   assert_memory_equal(buffer, ((unsigned char[]){0x9F}), 1);
 }
 
-static void test_indef_array_encoding(void **_state _CBOR_UNUSED) {
-  cbor_item_t *array = cbor_new_indefinite_array();
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+static void test_indef_array_encoding(void** _state _CBOR_UNUSED) {
+  cbor_item_t* array = cbor_new_indefinite_array();
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
   assert_true(cbor_array_push(array, one));
   assert_true(cbor_array_push(array, two));
 

--- a/test/array_encoders_test.c
+++ b/test/array_encoders_test.c
@@ -10,24 +10,24 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_array_start(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_array_start(void **_state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_array_start(1, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x81}), 1);
 }
 
-static void test_array_start(void **_CBOR_UNUSED(_state)) {
+static void test_array_start(void **_state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_array_start(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x9A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
 }
 
-static void test_indef_array_start(void **_CBOR_UNUSED(_state)) {
+static void test_indef_array_start(void **_state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_indef_array_start(buffer, 512));
   assert_size_equal(0, cbor_encode_indef_array_start(buffer, 0));
   assert_memory_equal(buffer, ((unsigned char[]){0x9F}), 1);
 }
 
-static void test_indef_array_encoding(void **_CBOR_UNUSED(_state)) {
+static void test_indef_array_encoding(void **_state _CBOR_UNUSED) {
   cbor_item_t *array = cbor_new_indefinite_array();
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);

--- a/test/array_test.c
+++ b/test/array_test.c
@@ -9,12 +9,12 @@
 #include "cbor.h"
 #include "test_allocator.h"
 
-cbor_item_t *arr;
+cbor_item_t* arr;
 struct cbor_load_result res;
 
 unsigned char data1[] = {0x80, 0xFF};
 
-static void test_empty_array(void **_state _CBOR_UNUSED) {
+static void test_empty_array(void** _state _CBOR_UNUSED) {
   arr = cbor_load(data1, 2, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -27,7 +27,7 @@ static void test_empty_array(void **_state _CBOR_UNUSED) {
 
 unsigned char data2[] = {0x81, 0x01, 0xFF};
 
-static void test_simple_array(void **_state _CBOR_UNUSED) {
+static void test_simple_array(void** _state _CBOR_UNUSED) {
   arr = cbor_load(data2, 3, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -37,10 +37,10 @@ static void test_simple_array(void **_state _CBOR_UNUSED) {
   assert_size_equal(cbor_array_allocated(arr), 1);
   /* Check the values */
   assert_uint8(cbor_array_handle(arr)[0], 1);
-  cbor_item_t *intermediate = cbor_array_get(arr, 0);
+  cbor_item_t* intermediate = cbor_array_get(arr, 0);
   assert_uint8(intermediate, 1);
 
-  cbor_item_t *new_val = cbor_build_uint8(10);
+  cbor_item_t* new_val = cbor_build_uint8(10);
   assert_false(cbor_array_set(arr, 1, new_val));
   assert_false(cbor_array_set(arr, 3, new_val));
   cbor_decref(&new_val);
@@ -53,7 +53,7 @@ static void test_simple_array(void **_state _CBOR_UNUSED) {
 
 unsigned char data3[] = {0x82, 0x01, 0x81, 0x01, 0xFF};
 
-static void test_nested_arrays(void **_state _CBOR_UNUSED) {
+static void test_nested_arrays(void** _state _CBOR_UNUSED) {
   arr = cbor_load(data3, 5, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -63,7 +63,7 @@ static void test_nested_arrays(void **_state _CBOR_UNUSED) {
   /* Check the values */
   assert_uint8(cbor_array_handle(arr)[0], 1);
 
-  cbor_item_t *nested = cbor_array_handle(arr)[1];
+  cbor_item_t* nested = cbor_array_handle(arr)[1];
   assert_true(cbor_isa_array(nested));
   assert_true(cbor_array_size(nested) == 1);
   assert_uint8(cbor_array_handle(nested)[0], 1);
@@ -74,7 +74,7 @@ static void test_nested_arrays(void **_state _CBOR_UNUSED) {
 
 unsigned char test_indef_arrays_data[] = {0x9f, 0x01, 0x02, 0xFF};
 
-static void test_indef_arrays(void **_state _CBOR_UNUSED) {
+static void test_indef_arrays(void** _state _CBOR_UNUSED) {
   arr = cbor_load(test_indef_arrays_data, 4, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -94,7 +94,7 @@ static void test_indef_arrays(void **_state _CBOR_UNUSED) {
 unsigned char test_nested_indef_arrays_data[] = {0x9f, 0x01, 0x9f, 0x02,
                                                  0xFF, 0x03, 0xFF};
 
-static void test_nested_indef_arrays(void **_state _CBOR_UNUSED) {
+static void test_nested_indef_arrays(void** _state _CBOR_UNUSED) {
   arr = cbor_load(test_nested_indef_arrays_data, 7, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -104,7 +104,7 @@ static void test_nested_indef_arrays(void **_state _CBOR_UNUSED) {
   /* Check the values */
   assert_uint8(cbor_array_handle(arr)[0], 1);
 
-  cbor_item_t *nested = cbor_array_handle(arr)[1];
+  cbor_item_t* nested = cbor_array_handle(arr)[1];
   assert_true(cbor_isa_array(nested));
   assert_true(cbor_array_size(nested) == 1);
   assert_uint8(cbor_array_handle(nested)[0], 2);
@@ -113,11 +113,11 @@ static void test_nested_indef_arrays(void **_state _CBOR_UNUSED) {
   assert_null(arr);
 }
 
-static void test_array_replace(void **_state _CBOR_UNUSED) {
-  cbor_item_t *array = cbor_new_definite_array(2);
+static void test_array_replace(void** _state _CBOR_UNUSED) {
+  cbor_item_t* array = cbor_new_definite_array(2);
   assert_size_equal(cbor_array_size(array), 0);
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *three = cbor_build_uint8(3);
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* three = cbor_build_uint8(3);
   assert_size_equal(cbor_refcount(one), 1);
   assert_size_equal(cbor_refcount(three), 1);
 
@@ -147,11 +147,11 @@ static void test_array_replace(void **_state _CBOR_UNUSED) {
   cbor_decref(&array);
 }
 
-static void test_array_push_overflow(void **_state _CBOR_UNUSED) {
-  cbor_item_t *array = cbor_new_indefinite_array();
-  cbor_item_t *one = cbor_build_uint8(1);
-  struct _cbor_array_metadata *metadata =
-      (struct _cbor_array_metadata *)&array->metadata;
+static void test_array_push_overflow(void** _state _CBOR_UNUSED) {
+  cbor_item_t* array = cbor_new_indefinite_array();
+  cbor_item_t* one = cbor_build_uint8(1);
+  struct _cbor_array_metadata* metadata =
+      (struct _cbor_array_metadata*)&array->metadata;
   // Pretend we already have a huge block allocated
   metadata->allocated = SIZE_MAX;
   metadata->end_ptr = SIZE_MAX;
@@ -165,7 +165,7 @@ static void test_array_push_overflow(void **_state _CBOR_UNUSED) {
   cbor_decref(&array);
 }
 
-static void test_array_creation(void **_state _CBOR_UNUSED) {
+static void test_array_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_array(42)); });
   WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_array(42)); }, 2, MALLOC,
                    MALLOC_FAIL);
@@ -173,11 +173,11 @@ static void test_array_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_array()); });
 }
 
-static void test_array_push(void **_state _CBOR_UNUSED) {
+static void test_array_push(void** _state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
-        cbor_item_t *array = cbor_new_indefinite_array();
-        cbor_item_t *string = cbor_build_string("Hello!");
+        cbor_item_t* array = cbor_new_indefinite_array();
+        cbor_item_t* string = cbor_build_string("Hello!");
 
         assert_false(cbor_array_push(array, string));
         assert_size_equal(cbor_array_allocated(array), 0);
@@ -191,10 +191,10 @@ static void test_array_push(void **_state _CBOR_UNUSED) {
 }
 
 static unsigned char simple_indef_array[] = {0x9F, 0x01, 0x02, 0xFF};
-static void test_indef_array_decode(void **_state _CBOR_UNUSED) {
+static void test_indef_array_decode(void** _state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
-        cbor_item_t *array;
+        cbor_item_t* array;
         struct cbor_load_result res;
         array = cbor_load(simple_indef_array, 4, &res);
 

--- a/test/array_test.c
+++ b/test/array_test.c
@@ -14,7 +14,7 @@ struct cbor_load_result res;
 
 unsigned char data1[] = {0x80, 0xFF};
 
-static void test_empty_array(void **_CBOR_UNUSED(_state)) {
+static void test_empty_array(void **_state _CBOR_UNUSED) {
   arr = cbor_load(data1, 2, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -27,7 +27,7 @@ static void test_empty_array(void **_CBOR_UNUSED(_state)) {
 
 unsigned char data2[] = {0x81, 0x01, 0xFF};
 
-static void test_simple_array(void **_CBOR_UNUSED(_state)) {
+static void test_simple_array(void **_state _CBOR_UNUSED) {
   arr = cbor_load(data2, 3, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -53,7 +53,7 @@ static void test_simple_array(void **_CBOR_UNUSED(_state)) {
 
 unsigned char data3[] = {0x82, 0x01, 0x81, 0x01, 0xFF};
 
-static void test_nested_arrays(void **_CBOR_UNUSED(_state)) {
+static void test_nested_arrays(void **_state _CBOR_UNUSED) {
   arr = cbor_load(data3, 5, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -74,7 +74,7 @@ static void test_nested_arrays(void **_CBOR_UNUSED(_state)) {
 
 unsigned char test_indef_arrays_data[] = {0x9f, 0x01, 0x02, 0xFF};
 
-static void test_indef_arrays(void **_CBOR_UNUSED(_state)) {
+static void test_indef_arrays(void **_state _CBOR_UNUSED) {
   arr = cbor_load(test_indef_arrays_data, 4, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -94,7 +94,7 @@ static void test_indef_arrays(void **_CBOR_UNUSED(_state)) {
 unsigned char test_nested_indef_arrays_data[] = {0x9f, 0x01, 0x9f, 0x02,
                                                  0xFF, 0x03, 0xFF};
 
-static void test_nested_indef_arrays(void **_CBOR_UNUSED(_state)) {
+static void test_nested_indef_arrays(void **_state _CBOR_UNUSED) {
   arr = cbor_load(test_nested_indef_arrays_data, 7, &res);
   assert_non_null(arr);
   assert_true(cbor_typeof(arr) == CBOR_TYPE_ARRAY);
@@ -113,7 +113,7 @@ static void test_nested_indef_arrays(void **_CBOR_UNUSED(_state)) {
   assert_null(arr);
 }
 
-static void test_array_replace(void **_CBOR_UNUSED(_state)) {
+static void test_array_replace(void **_state _CBOR_UNUSED) {
   cbor_item_t *array = cbor_new_definite_array(2);
   assert_size_equal(cbor_array_size(array), 0);
   cbor_item_t *one = cbor_build_uint8(1);
@@ -147,7 +147,7 @@ static void test_array_replace(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&array);
 }
 
-static void test_array_push_overflow(void **_CBOR_UNUSED(_state)) {
+static void test_array_push_overflow(void **_state _CBOR_UNUSED) {
   cbor_item_t *array = cbor_new_indefinite_array();
   cbor_item_t *one = cbor_build_uint8(1);
   struct _cbor_array_metadata *metadata =
@@ -165,7 +165,7 @@ static void test_array_push_overflow(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&array);
 }
 
-static void test_array_creation(void **_CBOR_UNUSED(_state)) {
+static void test_array_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_array(42)); });
   WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_array(42)); }, 2, MALLOC,
                    MALLOC_FAIL);
@@ -173,7 +173,7 @@ static void test_array_creation(void **_CBOR_UNUSED(_state)) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_array()); });
 }
 
-static void test_array_push(void **_CBOR_UNUSED(_state)) {
+static void test_array_push(void **_state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
         cbor_item_t *array = cbor_new_indefinite_array();
@@ -191,7 +191,7 @@ static void test_array_push(void **_CBOR_UNUSED(_state)) {
 }
 
 static unsigned char simple_indef_array[] = {0x9F, 0x01, 0x02, 0xFF};
-static void test_indef_array_decode(void **_CBOR_UNUSED(_state)) {
+static void test_indef_array_decode(void **_state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
         cbor_item_t *array;

--- a/test/bad_inputs_test.c
+++ b/test/bad_inputs_test.c
@@ -16,7 +16,7 @@ struct cbor_load_result res;
 
 /* Map start + array with embedded length */
 unsigned char data1[] = {0xA9, 0x85};
-static void test_1(void **_CBOR_UNUSED(_state)) {
+static void test_1(void **_state _CBOR_UNUSED) {
   item = cbor_load(data1, 2, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
@@ -24,7 +24,7 @@ static void test_1(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char data2[] = {0x9D};
-static void test_2(void **_CBOR_UNUSED(_state)) {
+static void test_2(void **_state _CBOR_UNUSED) {
   item = cbor_load(data2, 1, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_MALFORMATED);
@@ -32,7 +32,7 @@ static void test_2(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char data3[] = {0xD6};
-static void test_3(void **_CBOR_UNUSED(_state)) {
+static void test_3(void **_state _CBOR_UNUSED) {
   item = cbor_load(data3, 1, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
@@ -41,7 +41,7 @@ static void test_3(void **_CBOR_UNUSED(_state)) {
 
 #ifdef SANE_MALLOC
 unsigned char data4[] = {0xBA, 0xC1, 0xE8, 0x3E, 0xE7, 0x20, 0xA8};
-static void test_4(void **_CBOR_UNUSED(_state)) {
+static void test_4(void **_state _CBOR_UNUSED) {
   item = cbor_load(data4, 7, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_MEMERROR);
@@ -49,7 +49,7 @@ static void test_4(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char data5[] = {0x9A, 0xDA, 0x3A, 0xB2, 0x7F, 0x29};
-static void test_5(void **_CBOR_UNUSED(_state)) {
+static void test_5(void **_state _CBOR_UNUSED) {
   assert_true(res.error.code == CBOR_ERR_MEMERROR);
   item = cbor_load(data5, 6, &res);
   assert_null(item);
@@ -59,7 +59,7 @@ static void test_5(void **_CBOR_UNUSED(_state)) {
 #endif
 
 unsigned char data6[] = {0x7F, 0x21, 0x4C, 0x02, 0x40};
-static void test_6(void **_CBOR_UNUSED(_state)) {
+static void test_6(void **_state _CBOR_UNUSED) {
   item = cbor_load(data6, 5, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);
@@ -71,7 +71,7 @@ static void test_6(void **_CBOR_UNUSED(_state)) {
  * works with 64b sizes */
 unsigned char data7[] = {0xA2, 0x9B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-static void test_7(void **_CBOR_UNUSED(_state)) {
+static void test_7(void **_state _CBOR_UNUSED) {
   item = cbor_load(data7, 16, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_MEMERROR);
@@ -84,7 +84,7 @@ unsigned char data8[] = {0xA3, 0x64, 0x68, 0x61, 0x6C, 0x66, 0xFF, 0x00,
                          0xFA, 0x7F, 0x7F, 0xFF, 0xFF, 0x6D, 0x73, 0x69,
                          0x6D, 0x70, 0x6C, 0x65, 0x20, 0x76, 0x61, 0x6C,
                          0x75, 0x65, 0x73, 0x83, 0xF5, 0xF4, 0xF6};
-static void test_8(void **_CBOR_UNUSED(_state)) {
+static void test_8(void **_state _CBOR_UNUSED) {
   item = cbor_load(data8, 39, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);
@@ -92,7 +92,7 @@ static void test_8(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char data9[] = {0xBF, 0x05, 0xFF, 0x00, 0x00, 0x00, 0x10, 0x04};
-static void test_9(void **_CBOR_UNUSED(_state)) {
+static void test_9(void **_state _CBOR_UNUSED) {
   item = cbor_load(data9, 8, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);

--- a/test/bad_inputs_test.c
+++ b/test/bad_inputs_test.c
@@ -11,12 +11,12 @@
 /* These tests verify behavior on interesting randomly generated inputs from the
  * fuzzer */
 
-cbor_item_t *item;
+cbor_item_t* item;
 struct cbor_load_result res;
 
 /* Map start + array with embedded length */
 unsigned char data1[] = {0xA9, 0x85};
-static void test_1(void **_state _CBOR_UNUSED) {
+static void test_1(void** _state _CBOR_UNUSED) {
   item = cbor_load(data1, 2, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
@@ -24,7 +24,7 @@ static void test_1(void **_state _CBOR_UNUSED) {
 }
 
 unsigned char data2[] = {0x9D};
-static void test_2(void **_state _CBOR_UNUSED) {
+static void test_2(void** _state _CBOR_UNUSED) {
   item = cbor_load(data2, 1, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_MALFORMATED);
@@ -32,7 +32,7 @@ static void test_2(void **_state _CBOR_UNUSED) {
 }
 
 unsigned char data3[] = {0xD6};
-static void test_3(void **_state _CBOR_UNUSED) {
+static void test_3(void** _state _CBOR_UNUSED) {
   item = cbor_load(data3, 1, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
@@ -41,7 +41,7 @@ static void test_3(void **_state _CBOR_UNUSED) {
 
 #ifdef SANE_MALLOC
 unsigned char data4[] = {0xBA, 0xC1, 0xE8, 0x3E, 0xE7, 0x20, 0xA8};
-static void test_4(void **_state _CBOR_UNUSED) {
+static void test_4(void** _state _CBOR_UNUSED) {
   item = cbor_load(data4, 7, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_MEMERROR);
@@ -49,7 +49,7 @@ static void test_4(void **_state _CBOR_UNUSED) {
 }
 
 unsigned char data5[] = {0x9A, 0xDA, 0x3A, 0xB2, 0x7F, 0x29};
-static void test_5(void **_state _CBOR_UNUSED) {
+static void test_5(void** _state _CBOR_UNUSED) {
   assert_true(res.error.code == CBOR_ERR_MEMERROR);
   item = cbor_load(data5, 6, &res);
   assert_null(item);
@@ -59,7 +59,7 @@ static void test_5(void **_state _CBOR_UNUSED) {
 #endif
 
 unsigned char data6[] = {0x7F, 0x21, 0x4C, 0x02, 0x40};
-static void test_6(void **_state _CBOR_UNUSED) {
+static void test_6(void** _state _CBOR_UNUSED) {
   item = cbor_load(data6, 5, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);
@@ -71,7 +71,7 @@ static void test_6(void **_state _CBOR_UNUSED) {
  * works with 64b sizes */
 unsigned char data7[] = {0xA2, 0x9B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-static void test_7(void **_state _CBOR_UNUSED) {
+static void test_7(void** _state _CBOR_UNUSED) {
   item = cbor_load(data7, 16, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_MEMERROR);
@@ -84,7 +84,7 @@ unsigned char data8[] = {0xA3, 0x64, 0x68, 0x61, 0x6C, 0x66, 0xFF, 0x00,
                          0xFA, 0x7F, 0x7F, 0xFF, 0xFF, 0x6D, 0x73, 0x69,
                          0x6D, 0x70, 0x6C, 0x65, 0x20, 0x76, 0x61, 0x6C,
                          0x75, 0x65, 0x73, 0x83, 0xF5, 0xF4, 0xF6};
-static void test_8(void **_state _CBOR_UNUSED) {
+static void test_8(void** _state _CBOR_UNUSED) {
   item = cbor_load(data8, 39, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);
@@ -92,7 +92,7 @@ static void test_8(void **_state _CBOR_UNUSED) {
 }
 
 unsigned char data9[] = {0xBF, 0x05, 0xFF, 0x00, 0x00, 0x00, 0x10, 0x04};
-static void test_9(void **_state _CBOR_UNUSED) {
+static void test_9(void** _state _CBOR_UNUSED) {
   item = cbor_load(data9, 8, &res);
   assert_null(item);
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);

--- a/test/bytestring_encoders_test.c
+++ b/test/bytestring_encoders_test.c
@@ -11,18 +11,18 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_bytestring_start(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_bytestring_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_bytestring_start(1, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x41}), 1);
 }
 
-static void test_bytestring_start(void **_CBOR_UNUSED(_state)) {
+static void test_bytestring_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_bytestring_start(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x5A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
 }
 
-static void test_indef_bytestring_start(void **_CBOR_UNUSED(_state)) {
+static void test_indef_bytestring_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_indef_bytestring_start(buffer, 0));
   assert_size_equal(1, cbor_encode_indef_bytestring_start(buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x5F}), 1);

--- a/test/bytestring_test.c
+++ b/test/bytestring_test.c
@@ -9,7 +9,7 @@
 #include "cbor.h"
 #include "test_allocator.h"
 
-cbor_item_t *bs;
+cbor_item_t* bs;
 struct cbor_load_result res;
 
 unsigned char data1[] = {0x40, 0xFF};
@@ -133,7 +133,7 @@ unsigned char data8[] = {
     0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD,
     0xFE, 0xFF};
 
-static void test_empty_bs(void **_state _CBOR_UNUSED) {
+static void test_empty_bs(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data1, 2, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -144,7 +144,7 @@ static void test_empty_bs(void **_state _CBOR_UNUSED) {
   assert_null(bs);
 }
 
-static void test_embedded_bs(void **_state _CBOR_UNUSED) {
+static void test_embedded_bs(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data2, 2, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -157,13 +157,13 @@ static void test_embedded_bs(void **_state _CBOR_UNUSED) {
   assert_null(bs);
 }
 
-static void test_notenough_data(void **_state _CBOR_UNUSED) {
+static void test_notenough_data(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data3, 2, &res);
   assert_null(bs);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
 }
 
-static void test_short_bs1(void **_state _CBOR_UNUSED) {
+static void test_short_bs1(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data3, 4, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -176,7 +176,7 @@ static void test_short_bs1(void **_state _CBOR_UNUSED) {
   assert_null(bs);
 }
 
-static void test_short_bs2(void **_state _CBOR_UNUSED) {
+static void test_short_bs2(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data4, 259, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -188,7 +188,7 @@ static void test_short_bs2(void **_state _CBOR_UNUSED) {
   assert_null(bs);
 }
 
-static void test_half_bs(void **_state _CBOR_UNUSED) {
+static void test_half_bs(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data5, 259, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -200,7 +200,7 @@ static void test_half_bs(void **_state _CBOR_UNUSED) {
   assert_null(bs);
 }
 
-static void test_int_bs(void **_state _CBOR_UNUSED) {
+static void test_int_bs(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data6, 261, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -212,7 +212,7 @@ static void test_int_bs(void **_state _CBOR_UNUSED) {
   assert_null(bs);
 }
 
-static void test_long_bs(void **_state _CBOR_UNUSED) {
+static void test_long_bs(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data7, 265, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -226,7 +226,7 @@ static void test_long_bs(void **_state _CBOR_UNUSED) {
 
 unsigned char data9[] = {0x5F, 0xFF};
 
-static void test_zero_indef(void **_state _CBOR_UNUSED) {
+static void test_zero_indef(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data9, 2, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -242,7 +242,7 @@ unsigned char data10[] = {0x5F, 0x58, 0x01, 0xA1, 0xFF, 0xFF};
 
 /*                          start |   bstring     | break| extra */
 
-static void test_short_indef(void **_state _CBOR_UNUSED) {
+static void test_short_indef(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data10, 6, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -265,7 +265,7 @@ unsigned char data11[] = {0x5F, 0x58, 0x01, 0xA1, 0x58, 0x01, 0xA2, 0xFF, 0xFF};
 /*                          start |   bstring     |    bstring     | break|
  * extra */
 
-static void test_two_indef(void **_state _CBOR_UNUSED) {
+static void test_two_indef(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data11, 9, &res);
   assert_non_null(bs);
   assert_size_equal(1, cbor_refcount(bs));
@@ -293,23 +293,23 @@ unsigned char data12[] = {0x5F, 0x58, 0x01};
 
 /*                          start |   bstring - too short */
 
-static void test_missing_indef(void **_state _CBOR_UNUSED) {
+static void test_missing_indef(void** _state _CBOR_UNUSED) {
   bs = cbor_load(data12, 3, &res);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
   assert_null(bs);
 }
 
-static void test_inline_creation(void **_state _CBOR_UNUSED) {
+static void test_inline_creation(void** _state _CBOR_UNUSED) {
   bs = cbor_build_bytestring((cbor_data) "Hello!", 6);
   assert_memory_equal(cbor_bytestring_handle(bs), "Hello!", 6);
   cbor_decref(&bs);
 }
 
-static void test_add_chunk_reallocation_overflow(void **_state _CBOR_UNUSED) {
+static void test_add_chunk_reallocation_overflow(void** _state _CBOR_UNUSED) {
   bs = cbor_new_indefinite_bytestring();
-  cbor_item_t *chunk = cbor_build_bytestring((cbor_data) "Hello!", 6);
-  struct cbor_indefinite_string_data *metadata =
-      (struct cbor_indefinite_string_data *)bs->data;
+  cbor_item_t* chunk = cbor_build_bytestring((cbor_data) "Hello!", 6);
+  struct cbor_indefinite_string_data* metadata =
+      (struct cbor_indefinite_string_data*)bs->data;
   // Pretend we already have many chunks allocated
   metadata->chunk_count = SIZE_MAX;
   metadata->chunk_capacity = SIZE_MAX;
@@ -323,7 +323,7 @@ static void test_add_chunk_reallocation_overflow(void **_state _CBOR_UNUSED) {
   cbor_decref(&bs);
 }
 
-static void test_bytestring_creation(void **_state _CBOR_UNUSED) {
+static void test_bytestring_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_bytestring()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); });
@@ -337,18 +337,18 @@ static void test_bytestring_creation(void **_state _CBOR_UNUSED) {
                    MALLOC_FAIL);
 }
 
-static void test_bytestring_add_chunk(void **_state _CBOR_UNUSED) {
+static void test_bytestring_add_chunk(void** _state _CBOR_UNUSED) {
   unsigned char bytes[] = {0, 0, 0xFF, 0xAB};
   WITH_MOCK_MALLOC(
       {
-        cbor_item_t *bytestring = cbor_new_indefinite_bytestring();
-        cbor_item_t *chunk = cbor_build_bytestring(bytes, 4);
+        cbor_item_t* bytestring = cbor_new_indefinite_bytestring();
+        cbor_item_t* chunk = cbor_build_bytestring(bytes, 4);
 
         assert_false(cbor_bytestring_add_chunk(bytestring, chunk));
 
         assert_size_equal(cbor_bytestring_chunk_count(bytestring), 0);
         assert_size_equal(
-            ((struct cbor_indefinite_string_data *)bytestring->data)
+            ((struct cbor_indefinite_string_data*)bytestring->data)
                 ->chunk_capacity,
             0);
 

--- a/test/bytestring_test.c
+++ b/test/bytestring_test.c
@@ -133,7 +133,7 @@ unsigned char data8[] = {
     0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD,
     0xFE, 0xFF};
 
-static void test_empty_bs(void **_CBOR_UNUSED(_state)) {
+static void test_empty_bs(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data1, 2, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -144,7 +144,7 @@ static void test_empty_bs(void **_CBOR_UNUSED(_state)) {
   assert_null(bs);
 }
 
-static void test_embedded_bs(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_bs(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data2, 2, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -157,13 +157,13 @@ static void test_embedded_bs(void **_CBOR_UNUSED(_state)) {
   assert_null(bs);
 }
 
-static void test_notenough_data(void **_CBOR_UNUSED(_state)) {
+static void test_notenough_data(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data3, 2, &res);
   assert_null(bs);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
 }
 
-static void test_short_bs1(void **_CBOR_UNUSED(_state)) {
+static void test_short_bs1(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data3, 4, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -176,7 +176,7 @@ static void test_short_bs1(void **_CBOR_UNUSED(_state)) {
   assert_null(bs);
 }
 
-static void test_short_bs2(void **_CBOR_UNUSED(_state)) {
+static void test_short_bs2(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data4, 259, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -188,7 +188,7 @@ static void test_short_bs2(void **_CBOR_UNUSED(_state)) {
   assert_null(bs);
 }
 
-static void test_half_bs(void **_CBOR_UNUSED(_state)) {
+static void test_half_bs(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data5, 259, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -200,7 +200,7 @@ static void test_half_bs(void **_CBOR_UNUSED(_state)) {
   assert_null(bs);
 }
 
-static void test_int_bs(void **_CBOR_UNUSED(_state)) {
+static void test_int_bs(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data6, 261, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -212,7 +212,7 @@ static void test_int_bs(void **_CBOR_UNUSED(_state)) {
   assert_null(bs);
 }
 
-static void test_long_bs(void **_CBOR_UNUSED(_state)) {
+static void test_long_bs(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data7, 265, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -226,7 +226,7 @@ static void test_long_bs(void **_CBOR_UNUSED(_state)) {
 
 unsigned char data9[] = {0x5F, 0xFF};
 
-static void test_zero_indef(void **_CBOR_UNUSED(_state)) {
+static void test_zero_indef(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data9, 2, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -242,7 +242,7 @@ unsigned char data10[] = {0x5F, 0x58, 0x01, 0xA1, 0xFF, 0xFF};
 
 /*                          start |   bstring     | break| extra */
 
-static void test_short_indef(void **_CBOR_UNUSED(_state)) {
+static void test_short_indef(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data10, 6, &res);
   assert_non_null(bs);
   assert_true(cbor_typeof(bs) == CBOR_TYPE_BYTESTRING);
@@ -265,7 +265,7 @@ unsigned char data11[] = {0x5F, 0x58, 0x01, 0xA1, 0x58, 0x01, 0xA2, 0xFF, 0xFF};
 /*                          start |   bstring     |    bstring     | break|
  * extra */
 
-static void test_two_indef(void **_CBOR_UNUSED(_state)) {
+static void test_two_indef(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data11, 9, &res);
   assert_non_null(bs);
   assert_size_equal(1, cbor_refcount(bs));
@@ -293,19 +293,19 @@ unsigned char data12[] = {0x5F, 0x58, 0x01};
 
 /*                          start |   bstring - too short */
 
-static void test_missing_indef(void **_CBOR_UNUSED(_state)) {
+static void test_missing_indef(void **_state _CBOR_UNUSED) {
   bs = cbor_load(data12, 3, &res);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
   assert_null(bs);
 }
 
-static void test_inline_creation(void **_CBOR_UNUSED(_state)) {
+static void test_inline_creation(void **_state _CBOR_UNUSED) {
   bs = cbor_build_bytestring((cbor_data) "Hello!", 6);
   assert_memory_equal(cbor_bytestring_handle(bs), "Hello!", 6);
   cbor_decref(&bs);
 }
 
-static void test_add_chunk_reallocation_overflow(void **_CBOR_UNUSED(_state)) {
+static void test_add_chunk_reallocation_overflow(void **_state _CBOR_UNUSED) {
   bs = cbor_new_indefinite_bytestring();
   cbor_item_t *chunk = cbor_build_bytestring((cbor_data) "Hello!", 6);
   struct cbor_indefinite_string_data *metadata =
@@ -323,7 +323,7 @@ static void test_add_chunk_reallocation_overflow(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&bs);
 }
 
-static void test_bytestring_creation(void **_CBOR_UNUSED(_state)) {
+static void test_bytestring_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_bytestring()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_bytestring()); });
@@ -337,7 +337,7 @@ static void test_bytestring_creation(void **_CBOR_UNUSED(_state)) {
                    MALLOC_FAIL);
 }
 
-static void test_bytestring_add_chunk(void **_CBOR_UNUSED(_state)) {
+static void test_bytestring_add_chunk(void **_state _CBOR_UNUSED) {
   unsigned char bytes[] = {0, 0, 0xFF, 0xAB};
   WITH_MOCK_MALLOC(
       {

--- a/test/callbacks_test.c
+++ b/test/callbacks_test.c
@@ -20,7 +20,7 @@ unsigned char data[] = {
     0x88, 0x00, 0x75, 0x9C, 0xF6, 0xF7, 0xF5};
 
 /* Exercise the default callbacks */
-static void test_default_callbacks(void** _CBOR_UNUSED _state) {
+static void test_default_callbacks(void** _state _CBOR_UNUSED) {
   size_t read = 0;
   while (read < 79) {
     struct cbor_decoder_result result =
@@ -31,7 +31,7 @@ static void test_default_callbacks(void** _CBOR_UNUSED _state) {
 
 unsigned char bytestring_data[] = {0x01, 0x02, 0x03};
 static void test_builder_byte_string_callback_append(
-    void** _CBOR_UNUSED _state) {
+    void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -71,7 +71,7 @@ static void test_builder_byte_string_callback_append(
 }
 
 static void test_builder_byte_string_callback_append_alloc_failure(
-    void** _CBOR_UNUSED _state) {
+    void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -103,7 +103,7 @@ static void test_builder_byte_string_callback_append_alloc_failure(
 }
 
 static void test_builder_byte_string_callback_append_item_alloc_failure(
-    void** _CBOR_UNUSED _state) {
+    void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -137,7 +137,7 @@ static void test_builder_byte_string_callback_append_item_alloc_failure(
 }
 
 static void test_builder_byte_string_callback_append_parent_alloc_failure(
-    void** _CBOR_UNUSED _state) {
+    void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -171,7 +171,7 @@ static void test_builder_byte_string_callback_append_parent_alloc_failure(
 }
 
 unsigned char string_data[] = {0x61, 0x62, 0x63};
-static void test_builder_string_callback_append(void** _CBOR_UNUSED _state) {
+static void test_builder_string_callback_append(void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -208,7 +208,7 @@ static void test_builder_string_callback_append(void** _CBOR_UNUSED _state) {
 }
 
 static void test_builder_string_callback_append_alloc_failure(
-    void** _CBOR_UNUSED _state) {
+    void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -239,7 +239,7 @@ static void test_builder_string_callback_append_alloc_failure(
 }
 
 static void test_builder_string_callback_append_item_alloc_failure(
-    void** _CBOR_UNUSED _state) {
+    void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -271,7 +271,7 @@ static void test_builder_string_callback_append_item_alloc_failure(
 }
 
 static void test_builder_string_callback_append_parent_alloc_failure(
-    void** _CBOR_UNUSED _state) {
+    void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -302,7 +302,7 @@ static void test_builder_string_callback_append_parent_alloc_failure(
   _cbor_stack_pop(&stack);
 }
 
-static void test_append_array_failure(void** _CBOR_UNUSED _state) {
+static void test_append_array_failure(void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_definite_array(0), 0));
   stack.top->subitems = 1;
@@ -331,7 +331,7 @@ static void test_append_array_failure(void** _CBOR_UNUSED _state) {
   _cbor_stack_pop(&stack);
 }
 
-static void test_append_map_failure(void** _CBOR_UNUSED _state) {
+static void test_append_map_failure(void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_map(), /*subitems=*/0));
@@ -362,7 +362,7 @@ static void test_append_map_failure(void** _CBOR_UNUSED _state) {
 
 // Size 1 array start, but we get an indef break
 unsigned char invalid_indef_break_data[] = {0x81, 0xFF};
-static void test_invalid_indef_break(void** _CBOR_UNUSED _state) {
+static void test_invalid_indef_break(void** _state _CBOR_UNUSED) {
   struct cbor_load_result res;
   cbor_item_t* item = cbor_load(invalid_indef_break_data, 2, &res);
 
@@ -371,7 +371,7 @@ static void test_invalid_indef_break(void** _CBOR_UNUSED _state) {
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);
 }
 
-static void test_invalid_state_indef_break(void** _CBOR_UNUSED _state) {
+static void test_invalid_state_indef_break(void** _state _CBOR_UNUSED) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_int8(), /*subitems=*/0));
   struct _cbor_decoder_context context = {

--- a/test/callbacks_test.c
+++ b/test/callbacks_test.c
@@ -20,7 +20,7 @@ unsigned char data[] = {
     0x88, 0x00, 0x75, 0x9C, 0xF6, 0xF7, 0xF5};
 
 /* Exercise the default callbacks */
-static void test_default_callbacks(void** _CBOR_UNUSED(_state)) {
+static void test_default_callbacks(void** _CBOR_UNUSED _state) {
   size_t read = 0;
   while (read < 79) {
     struct cbor_decoder_result result =
@@ -31,7 +31,7 @@ static void test_default_callbacks(void** _CBOR_UNUSED(_state)) {
 
 unsigned char bytestring_data[] = {0x01, 0x02, 0x03};
 static void test_builder_byte_string_callback_append(
-    void** _CBOR_UNUSED(_state)) {
+    void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -71,7 +71,7 @@ static void test_builder_byte_string_callback_append(
 }
 
 static void test_builder_byte_string_callback_append_alloc_failure(
-    void** _CBOR_UNUSED(_state)) {
+    void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -103,7 +103,7 @@ static void test_builder_byte_string_callback_append_alloc_failure(
 }
 
 static void test_builder_byte_string_callback_append_item_alloc_failure(
-    void** _CBOR_UNUSED(_state)) {
+    void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -137,7 +137,7 @@ static void test_builder_byte_string_callback_append_item_alloc_failure(
 }
 
 static void test_builder_byte_string_callback_append_parent_alloc_failure(
-    void** _CBOR_UNUSED(_state)) {
+    void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_bytestring(), 0));
@@ -171,7 +171,7 @@ static void test_builder_byte_string_callback_append_parent_alloc_failure(
 }
 
 unsigned char string_data[] = {0x61, 0x62, 0x63};
-static void test_builder_string_callback_append(void** _CBOR_UNUSED(_state)) {
+static void test_builder_string_callback_append(void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -208,7 +208,7 @@ static void test_builder_string_callback_append(void** _CBOR_UNUSED(_state)) {
 }
 
 static void test_builder_string_callback_append_alloc_failure(
-    void** _CBOR_UNUSED(_state)) {
+    void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -239,7 +239,7 @@ static void test_builder_string_callback_append_alloc_failure(
 }
 
 static void test_builder_string_callback_append_item_alloc_failure(
-    void** _CBOR_UNUSED(_state)) {
+    void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -271,7 +271,7 @@ static void test_builder_string_callback_append_item_alloc_failure(
 }
 
 static void test_builder_string_callback_append_parent_alloc_failure(
-    void** _CBOR_UNUSED(_state)) {
+    void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_indefinite_string(), 0));
   struct _cbor_decoder_context context = {
@@ -302,7 +302,7 @@ static void test_builder_string_callback_append_parent_alloc_failure(
   _cbor_stack_pop(&stack);
 }
 
-static void test_append_array_failure(void** _CBOR_UNUSED(_state)) {
+static void test_append_array_failure(void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_definite_array(0), 0));
   stack.top->subitems = 1;
@@ -331,7 +331,7 @@ static void test_append_array_failure(void** _CBOR_UNUSED(_state)) {
   _cbor_stack_pop(&stack);
 }
 
-static void test_append_map_failure(void** _CBOR_UNUSED(_state)) {
+static void test_append_map_failure(void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(
       _cbor_stack_push(&stack, cbor_new_indefinite_map(), /*subitems=*/0));
@@ -362,7 +362,7 @@ static void test_append_map_failure(void** _CBOR_UNUSED(_state)) {
 
 // Size 1 array start, but we get an indef break
 unsigned char invalid_indef_break_data[] = {0x81, 0xFF};
-static void test_invalid_indef_break(void** _CBOR_UNUSED(_state)) {
+static void test_invalid_indef_break(void** _CBOR_UNUSED _state) {
   struct cbor_load_result res;
   cbor_item_t* item = cbor_load(invalid_indef_break_data, 2, &res);
 
@@ -371,7 +371,7 @@ static void test_invalid_indef_break(void** _CBOR_UNUSED(_state)) {
   assert_true(res.error.code == CBOR_ERR_SYNTAXERROR);
 }
 
-static void test_invalid_state_indef_break(void** _CBOR_UNUSED(_state)) {
+static void test_invalid_state_indef_break(void** _CBOR_UNUSED _state) {
   struct _cbor_stack stack = _cbor_stack_init();
   assert_non_null(_cbor_stack_push(&stack, cbor_new_int8(), /*subitems=*/0));
   struct _cbor_decoder_context context = {

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -23,7 +23,7 @@
 
 unsigned char buffer[512];
 
-static void test_serialize_uint8_embed(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_uint8_embed(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int8();
   cbor_set_uint8(item, 0);
   assert_size_equal(1, cbor_serialize(item, buffer, 512));
@@ -32,7 +32,7 @@ static void test_serialize_uint8_embed(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint8(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_uint8(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int8();
   cbor_set_uint8(item, 42);
   assert_size_equal(2, cbor_serialize(item, buffer, 512));
@@ -41,7 +41,7 @@ static void test_serialize_uint8(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint16(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_uint16(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int16();
   cbor_set_uint16(item, 1000);
   assert_size_equal(3, cbor_serialize(item, buffer, 512));
@@ -50,7 +50,7 @@ static void test_serialize_uint16(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint32(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_uint32(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int32();
   cbor_set_uint32(item, 1000000);
   assert_size_equal(5, cbor_serialize(item, buffer, 512));
@@ -60,7 +60,7 @@ static void test_serialize_uint32(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint64(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_uint64(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int64();
   cbor_set_uint64(item, 1000000000000);
   assert_size_equal(9, cbor_serialize(item, buffer, 512));
@@ -72,7 +72,7 @@ static void test_serialize_uint64(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint8_embed(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_negint8_embed(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int8();
   cbor_set_uint8(item, 0);
   cbor_mark_negint(item);
@@ -82,7 +82,7 @@ static void test_serialize_negint8_embed(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint8(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_negint8(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int8();
   cbor_set_uint8(item, 42);
   cbor_mark_negint(item);
@@ -92,7 +92,7 @@ static void test_serialize_negint8(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint16(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_negint16(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int16();
   cbor_set_uint16(item, 1000);
   cbor_mark_negint(item);
@@ -102,7 +102,7 @@ static void test_serialize_negint16(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint32(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_negint32(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int32();
   cbor_set_uint32(item, 1000000);
   cbor_mark_negint(item);
@@ -113,7 +113,7 @@ static void test_serialize_negint32(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint64(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_negint64(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_int64();
   cbor_set_uint64(item, 1000000000000);
   cbor_mark_negint(item);
@@ -126,7 +126,7 @@ static void test_serialize_negint64(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_definite_bytestring(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_definite_bytestring(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_bytestring();
   unsigned char *data = malloc(256);
   cbor_bytestring_set_handle(item, data, 256);
@@ -138,7 +138,7 @@ static void test_serialize_definite_bytestring(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_indefinite_bytestring(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_indefinite_bytestring(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_bytestring();
 
   cbor_item_t *chunk = cbor_new_definite_bytestring();
@@ -158,7 +158,7 @@ static void test_serialize_indefinite_bytestring(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_serialize_bytestring_size_overflow(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_bytestring();
 
   // Fake having a huge chunk of data
@@ -171,7 +171,7 @@ static void test_serialize_bytestring_size_overflow(
   cbor_decref(&item);
 }
 
-static void test_serialize_bytestring_no_space(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_bytestring_no_space(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_bytestring();
   unsigned char *data = malloc(12);
   cbor_bytestring_set_handle(item, data, 12);
@@ -182,7 +182,7 @@ static void test_serialize_bytestring_no_space(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_serialize_indefinite_bytestring_no_space(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_bytestring();
   cbor_item_t *chunk = cbor_new_definite_bytestring();
   unsigned char *data = malloc(256);
@@ -202,7 +202,7 @@ static void test_serialize_indefinite_bytestring_no_space(
   cbor_decref(&item);
 }
 
-static void test_serialize_definite_string(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_definite_string(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_string();
   unsigned char *data = malloc(12);
   strncpy((char *)data, "Hello world!", 12);
@@ -218,7 +218,7 @@ static void test_serialize_definite_string(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_serialize_definite_string_4b_header(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
 #if SIZE_MAX > UINT16_MAX
   cbor_item_t *item = cbor_new_definite_string();
   const size_t size = (size_t)UINT16_MAX + 1;
@@ -231,7 +231,7 @@ static void test_serialize_definite_string_4b_header(
 }
 
 static void test_serialize_definite_string_8b_header(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
 #if SIZE_MAX > UINT32_MAX
   cbor_item_t *item = cbor_new_definite_string();
   const size_t size = (size_t)UINT32_MAX + 1;
@@ -245,7 +245,7 @@ static void test_serialize_definite_string_8b_header(
 #endif
 }
 
-static void test_serialize_indefinite_string(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_indefinite_string(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_string();
   cbor_item_t *chunk = cbor_new_definite_string();
 
@@ -266,7 +266,7 @@ static void test_serialize_indefinite_string(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_string_no_space(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_string_no_space(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_string();
   unsigned char *data = malloc(12);
   memset(data, 0, 12);
@@ -278,7 +278,7 @@ static void test_serialize_string_no_space(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_serialize_indefinite_string_no_space(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_string();
   cbor_item_t *chunk = cbor_new_definite_string();
   unsigned char *data = malloc(256);
@@ -299,7 +299,7 @@ static void test_serialize_indefinite_string_no_space(
   cbor_decref(&item);
 }
 
-static void test_serialize_definite_array(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_definite_array(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_array(2);
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);
@@ -316,7 +316,7 @@ static void test_serialize_definite_array(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&two);
 }
 
-static void test_serialize_array_no_space(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_array_no_space(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_array();
   cbor_item_t *one = cbor_build_uint8(1);
   assert_true(cbor_array_push(item, one));
@@ -335,7 +335,7 @@ static void test_serialize_array_no_space(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&one);
 }
 
-static void test_serialize_indefinite_array(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_indefinite_array(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_array();
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);
@@ -351,7 +351,7 @@ static void test_serialize_indefinite_array(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&two);
 }
 
-static void test_serialize_definite_map(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_definite_map(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_map(2);
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);
@@ -368,7 +368,7 @@ static void test_serialize_definite_map(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&two);
 }
 
-static void test_serialize_indefinite_map(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_indefinite_map(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_map();
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);
@@ -385,7 +385,7 @@ static void test_serialize_indefinite_map(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&two);
 }
 
-static void test_serialize_map_no_space(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_map_no_space(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_map();
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);
@@ -409,7 +409,7 @@ static void test_serialize_map_no_space(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&two);
 }
 
-static void test_serialize_tags(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_tags(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_tag(21);
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_tag_set_item(item, one);
@@ -421,7 +421,7 @@ static void test_serialize_tags(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&one);
 }
 
-static void test_serialize_tags_no_space(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_tags_no_space(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_tag(21);
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_tag_set_item(item, one);
@@ -437,7 +437,7 @@ static void test_serialize_tags_no_space(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&one);
 }
 
-static void test_serialize_half(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_half(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_float2();
   cbor_set_float2(item, NAN);
 
@@ -447,7 +447,7 @@ static void test_serialize_half(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_single(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_single(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_float4();
   cbor_set_float4(item, 100000.0f);
 
@@ -458,7 +458,7 @@ static void test_serialize_single(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_double(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_double(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_float8();
   cbor_set_float8(item, -4.1);
 
@@ -471,7 +471,7 @@ static void test_serialize_double(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_ctrl(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_ctrl(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_undef();
 
   assert_size_equal(1, cbor_serialize(item, buffer, 512));
@@ -480,7 +480,7 @@ static void test_serialize_ctrl(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_serialize_long_ctrl(void **_CBOR_UNUSED(_state)) {
+static void test_serialize_long_ctrl(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_ctrl();
   cbor_set_ctrl(item, 254);
 
@@ -490,7 +490,7 @@ static void test_serialize_long_ctrl(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_auto_serialize(void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_array(4);
   for (size_t i = 0; i < 4; i++) {
     assert_true(cbor_array_push(item, cbor_move(cbor_build_uint64(0))));
@@ -506,7 +506,7 @@ static void test_auto_serialize(void **_CBOR_UNUSED(_state)) {
   _cbor_free(output);
 }
 
-static void test_auto_serialize_no_size(void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize_no_size(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_build_uint8(1);
 
   unsigned char *output;
@@ -517,7 +517,7 @@ static void test_auto_serialize_no_size(void **_CBOR_UNUSED(_state)) {
   _cbor_free(output);
 }
 
-static void test_auto_serialize_too_large(void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize_too_large(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_string();
   cbor_item_t *chunk = cbor_new_definite_string();
   assert_true(cbor_string_add_chunk(item, chunk));
@@ -537,7 +537,7 @@ static void test_auto_serialize_too_large(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_auto_serialize_alloc_fail(void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize_alloc_fail(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_build_uint8(42);
 
   WITH_FAILING_MALLOC({
@@ -552,7 +552,7 @@ static void test_auto_serialize_alloc_fail(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_auto_serialize_zero_len_bytestring(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_build_bytestring((cbor_data) "", 0);
 
   unsigned char *output;
@@ -563,7 +563,7 @@ static void test_auto_serialize_zero_len_bytestring(
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_string(void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize_zero_len_string(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_build_string("");
 
   unsigned char *output;
@@ -575,7 +575,7 @@ static void test_auto_serialize_zero_len_string(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_auto_serialize_zero_len_bytestring_chunk(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_bytestring();
 
   assert_true(cbor_bytestring_add_chunk(
@@ -590,7 +590,7 @@ static void test_auto_serialize_zero_len_bytestring_chunk(
 }
 
 static void test_auto_serialize_zero_len_string_chunk(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_string();
 
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string(""))));
@@ -603,7 +603,7 @@ static void test_auto_serialize_zero_len_string_chunk(
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_array(void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize_zero_len_array(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_array(0);
 
   unsigned char *output;
@@ -615,7 +615,7 @@ static void test_auto_serialize_zero_len_array(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_auto_serialize_zero_len_indef_array(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_array();
 
   unsigned char *output;
@@ -626,7 +626,7 @@ static void test_auto_serialize_zero_len_indef_array(
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_map(void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize_zero_len_map(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_map(0);
 
   unsigned char *output;
@@ -637,8 +637,7 @@ static void test_auto_serialize_zero_len_map(void **_CBOR_UNUSED(_state)) {
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_indef_map(
-    void **_CBOR_UNUSED(_state)) {
+static void test_auto_serialize_zero_len_indef_map(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_map();
 
   unsigned char *output;

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -23,8 +23,8 @@
 
 unsigned char buffer[512];
 
-static void test_serialize_uint8_embed(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int8();
+static void test_serialize_uint8_embed(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int8();
   cbor_set_uint8(item, 0);
   assert_size_equal(1, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, (unsigned char[]){0x00}, 1);
@@ -32,8 +32,8 @@ static void test_serialize_uint8_embed(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint8(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int8();
+static void test_serialize_uint8(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int8();
   cbor_set_uint8(item, 42);
   assert_size_equal(2, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x18, 0x2a}), 2);
@@ -41,8 +41,8 @@ static void test_serialize_uint8(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint16(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int16();
+static void test_serialize_uint16(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int16();
   cbor_set_uint16(item, 1000);
   assert_size_equal(3, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x19, 0x03, 0xE8}), 3);
@@ -50,8 +50,8 @@ static void test_serialize_uint16(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint32(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int32();
+static void test_serialize_uint32(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int32();
   cbor_set_uint32(item, 1000000);
   assert_size_equal(5, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x1A, 0x00, 0x0F, 0x42, 0x40}),
@@ -60,8 +60,8 @@ static void test_serialize_uint32(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_uint64(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int64();
+static void test_serialize_uint64(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int64();
   cbor_set_uint64(item, 1000000000000);
   assert_size_equal(9, cbor_serialize(item, buffer, 512));
   assert_memory_equal(
@@ -72,8 +72,8 @@ static void test_serialize_uint64(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint8_embed(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int8();
+static void test_serialize_negint8_embed(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int8();
   cbor_set_uint8(item, 0);
   cbor_mark_negint(item);
   assert_size_equal(1, cbor_serialize(item, buffer, 512));
@@ -82,8 +82,8 @@ static void test_serialize_negint8_embed(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint8(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int8();
+static void test_serialize_negint8(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int8();
   cbor_set_uint8(item, 42);
   cbor_mark_negint(item);
   assert_size_equal(2, cbor_serialize(item, buffer, 512));
@@ -92,8 +92,8 @@ static void test_serialize_negint8(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint16(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int16();
+static void test_serialize_negint16(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int16();
   cbor_set_uint16(item, 1000);
   cbor_mark_negint(item);
   assert_size_equal(3, cbor_serialize(item, buffer, 512));
@@ -102,8 +102,8 @@ static void test_serialize_negint16(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint32(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int32();
+static void test_serialize_negint32(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int32();
   cbor_set_uint32(item, 1000000);
   cbor_mark_negint(item);
   assert_size_equal(5, cbor_serialize(item, buffer, 512));
@@ -113,8 +113,8 @@ static void test_serialize_negint32(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_negint64(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_int64();
+static void test_serialize_negint64(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_int64();
   cbor_set_uint64(item, 1000000000000);
   cbor_mark_negint(item);
   assert_size_equal(9, cbor_serialize(item, buffer, 512));
@@ -126,9 +126,9 @@ static void test_serialize_negint64(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_definite_bytestring(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_bytestring();
-  unsigned char *data = malloc(256);
+static void test_serialize_definite_bytestring(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_bytestring();
+  unsigned char* data = malloc(256);
   cbor_bytestring_set_handle(item, data, 256);
   memset(data, 0, 256); /* Prevent undefined behavior in comparison */
   assert_size_equal(256 + 3, cbor_serialize(item, buffer, 512));
@@ -138,11 +138,11 @@ static void test_serialize_definite_bytestring(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_indefinite_bytestring(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_bytestring();
+static void test_serialize_indefinite_bytestring(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_bytestring();
 
-  cbor_item_t *chunk = cbor_new_definite_bytestring();
-  unsigned char *data = malloc(256);
+  cbor_item_t* chunk = cbor_new_definite_bytestring();
+  unsigned char* data = malloc(256);
   memset(data, 0, 256); /* Prevent undefined behavior in comparison */
   cbor_bytestring_set_handle(chunk, data, 256);
 
@@ -158,11 +158,11 @@ static void test_serialize_indefinite_bytestring(void **_state _CBOR_UNUSED) {
 }
 
 static void test_serialize_bytestring_size_overflow(
-    void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_bytestring();
+    void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_bytestring();
 
   // Fake having a huge chunk of data
-  unsigned char *data = malloc(1);
+  unsigned char* data = malloc(1);
   cbor_bytestring_set_handle(item, data, SIZE_MAX);
 
   // Would require 1 + 8 + SIZE_MAX bytes, which overflows size_t
@@ -171,9 +171,9 @@ static void test_serialize_bytestring_size_overflow(
   cbor_decref(&item);
 }
 
-static void test_serialize_bytestring_no_space(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_bytestring();
-  unsigned char *data = malloc(12);
+static void test_serialize_bytestring_no_space(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_bytestring();
+  unsigned char* data = malloc(12);
   cbor_bytestring_set_handle(item, data, 12);
 
   assert_size_equal(cbor_serialize(item, buffer, 1), 0);
@@ -182,10 +182,10 @@ static void test_serialize_bytestring_no_space(void **_state _CBOR_UNUSED) {
 }
 
 static void test_serialize_indefinite_bytestring_no_space(
-    void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_bytestring();
-  cbor_item_t *chunk = cbor_new_definite_bytestring();
-  unsigned char *data = malloc(256);
+    void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_bytestring();
+  cbor_item_t* chunk = cbor_new_definite_bytestring();
+  unsigned char* data = malloc(256);
   cbor_bytestring_set_handle(chunk, data, 256);
   assert_true(cbor_bytestring_add_chunk(item, cbor_move(chunk)));
 
@@ -202,10 +202,10 @@ static void test_serialize_indefinite_bytestring_no_space(
   cbor_decref(&item);
 }
 
-static void test_serialize_definite_string(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_string();
-  unsigned char *data = malloc(12);
-  strncpy((char *)data, "Hello world!", 12);
+static void test_serialize_definite_string(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_string();
+  unsigned char* data = malloc(12);
+  strncpy((char*)data, "Hello world!", 12);
   cbor_string_set_handle(item, data, 12);
   assert_size_equal(1 + 12, cbor_serialize(item, buffer, 512));
   assert_memory_equal(
@@ -218,11 +218,11 @@ static void test_serialize_definite_string(void **_state _CBOR_UNUSED) {
 }
 
 static void test_serialize_definite_string_4b_header(
-    void **_state _CBOR_UNUSED) {
+    void** _state _CBOR_UNUSED) {
 #if SIZE_MAX > UINT16_MAX
-  cbor_item_t *item = cbor_new_definite_string();
+  cbor_item_t* item = cbor_new_definite_string();
   const size_t size = (size_t)UINT16_MAX + 1;
-  unsigned char *data = malloc(size);
+  unsigned char* data = malloc(size);
   memset(data, 0, size);
   cbor_string_set_handle(item, data, size);
   assert_size_equal(cbor_serialized_size(item), 1 + 4 + size);
@@ -231,11 +231,11 @@ static void test_serialize_definite_string_4b_header(
 }
 
 static void test_serialize_definite_string_8b_header(
-    void **_state _CBOR_UNUSED) {
+    void** _state _CBOR_UNUSED) {
 #if SIZE_MAX > UINT32_MAX
-  cbor_item_t *item = cbor_new_definite_string();
+  cbor_item_t* item = cbor_new_definite_string();
   const size_t size = (size_t)UINT32_MAX + 1;
-  unsigned char *data = malloc(1);
+  unsigned char* data = malloc(1);
   data[0] = '\0';
   cbor_string_set_handle(item, data, 1);
   // Pretend that we have a big item to avoid the huge malloc
@@ -245,12 +245,12 @@ static void test_serialize_definite_string_8b_header(
 #endif
 }
 
-static void test_serialize_indefinite_string(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_string();
-  cbor_item_t *chunk = cbor_new_definite_string();
+static void test_serialize_indefinite_string(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_string();
+  cbor_item_t* chunk = cbor_new_definite_string();
 
-  unsigned char *data = malloc(12);
-  strncpy((char *)data, "Hello world!", 12);
+  unsigned char* data = malloc(12);
+  strncpy((char*)data, "Hello world!", 12);
   cbor_string_set_handle(chunk, data, 12);
 
   assert_true(cbor_string_add_chunk(item, cbor_move(chunk)));
@@ -266,9 +266,9 @@ static void test_serialize_indefinite_string(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_string_no_space(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_string();
-  unsigned char *data = malloc(12);
+static void test_serialize_string_no_space(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_string();
+  unsigned char* data = malloc(12);
   memset(data, 0, 12);
   cbor_string_set_handle(item, data, 12);
 
@@ -278,10 +278,10 @@ static void test_serialize_string_no_space(void **_state _CBOR_UNUSED) {
 }
 
 static void test_serialize_indefinite_string_no_space(
-    void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_string();
-  cbor_item_t *chunk = cbor_new_definite_string();
-  unsigned char *data = malloc(256);
+    void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_string();
+  cbor_item_t* chunk = cbor_new_definite_string();
+  unsigned char* data = malloc(256);
   memset(data, 0, 256);
   cbor_string_set_handle(chunk, data, 256);
   assert_true(cbor_string_add_chunk(item, cbor_move(chunk)));
@@ -299,10 +299,10 @@ static void test_serialize_indefinite_string_no_space(
   cbor_decref(&item);
 }
 
-static void test_serialize_definite_array(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_array(2);
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+static void test_serialize_definite_array(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_array(2);
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
 
   assert_true(cbor_array_push(item, one));
   assert_true(cbor_array_set(item, 1, two));
@@ -316,9 +316,9 @@ static void test_serialize_definite_array(void **_state _CBOR_UNUSED) {
   cbor_decref(&two);
 }
 
-static void test_serialize_array_no_space(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_array();
-  cbor_item_t *one = cbor_build_uint8(1);
+static void test_serialize_array_no_space(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_array();
+  cbor_item_t* one = cbor_build_uint8(1);
   assert_true(cbor_array_push(item, one));
   assert_size_equal(cbor_serialized_size(item), 3);
 
@@ -335,10 +335,10 @@ static void test_serialize_array_no_space(void **_state _CBOR_UNUSED) {
   cbor_decref(&one);
 }
 
-static void test_serialize_indefinite_array(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_array();
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+static void test_serialize_indefinite_array(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_array();
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
 
   assert_true(cbor_array_push(item, one));
   assert_true(cbor_array_push(item, two));
@@ -351,10 +351,10 @@ static void test_serialize_indefinite_array(void **_state _CBOR_UNUSED) {
   cbor_decref(&two);
 }
 
-static void test_serialize_definite_map(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_map(2);
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+static void test_serialize_definite_map(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_map(2);
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
 
   assert_true(cbor_map_add(item, (struct cbor_pair){.key = one, .value = two}));
   assert_true(cbor_map_add(item, (struct cbor_pair){.key = two, .value = one}));
@@ -368,10 +368,10 @@ static void test_serialize_definite_map(void **_state _CBOR_UNUSED) {
   cbor_decref(&two);
 }
 
-static void test_serialize_indefinite_map(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_map();
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+static void test_serialize_indefinite_map(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_map();
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
 
   assert_true(cbor_map_add(item, (struct cbor_pair){.key = one, .value = two}));
   assert_true(cbor_map_add(item, (struct cbor_pair){.key = two, .value = one}));
@@ -385,10 +385,10 @@ static void test_serialize_indefinite_map(void **_state _CBOR_UNUSED) {
   cbor_decref(&two);
 }
 
-static void test_serialize_map_no_space(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_map();
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+static void test_serialize_map_no_space(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_map();
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
   assert_true(cbor_map_add(item, (struct cbor_pair){.key = one, .value = two}));
   assert_size_equal(cbor_serialized_size(item), 4);
 
@@ -409,9 +409,9 @@ static void test_serialize_map_no_space(void **_state _CBOR_UNUSED) {
   cbor_decref(&two);
 }
 
-static void test_serialize_tags(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_tag(21);
-  cbor_item_t *one = cbor_build_uint8(1);
+static void test_serialize_tags(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_tag(21);
+  cbor_item_t* one = cbor_build_uint8(1);
   cbor_tag_set_item(item, one);
 
   assert_size_equal(2, cbor_serialize(item, buffer, 512));
@@ -421,9 +421,9 @@ static void test_serialize_tags(void **_state _CBOR_UNUSED) {
   cbor_decref(&one);
 }
 
-static void test_serialize_tags_no_space(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_tag(21);
-  cbor_item_t *one = cbor_build_uint8(1);
+static void test_serialize_tags_no_space(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_tag(21);
+  cbor_item_t* one = cbor_build_uint8(1);
   cbor_tag_set_item(item, one);
   assert_size_equal(cbor_serialized_size(item), 2);
 
@@ -437,8 +437,8 @@ static void test_serialize_tags_no_space(void **_state _CBOR_UNUSED) {
   cbor_decref(&one);
 }
 
-static void test_serialize_half(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_float2();
+static void test_serialize_half(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_float2();
   cbor_set_float2(item, NAN);
 
   assert_size_equal(3, cbor_serialize(item, buffer, 512));
@@ -447,8 +447,8 @@ static void test_serialize_half(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_single(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_float4();
+static void test_serialize_single(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_float4();
   cbor_set_float4(item, 100000.0f);
 
   assert_size_equal(5, cbor_serialize(item, buffer, 512));
@@ -458,8 +458,8 @@ static void test_serialize_single(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_double(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_float8();
+static void test_serialize_double(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_float8();
   cbor_set_float8(item, -4.1);
 
   assert_size_equal(9, cbor_serialize(item, buffer, 512));
@@ -471,8 +471,8 @@ static void test_serialize_double(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_ctrl(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_undef();
+static void test_serialize_ctrl(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_undef();
 
   assert_size_equal(1, cbor_serialize(item, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF7}), 1);
@@ -480,8 +480,8 @@ static void test_serialize_ctrl(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_serialize_long_ctrl(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_ctrl();
+static void test_serialize_long_ctrl(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_ctrl();
   cbor_set_ctrl(item, 254);
 
   assert_size_equal(2, cbor_serialize(item, buffer, 512));
@@ -490,13 +490,13 @@ static void test_serialize_long_ctrl(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_auto_serialize(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_array(4);
+static void test_auto_serialize(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_array(4);
   for (size_t i = 0; i < 4; i++) {
     assert_true(cbor_array_push(item, cbor_move(cbor_build_uint64(0))));
   }
 
-  unsigned char *output;
+  unsigned char* output;
   size_t output_size;
   assert_size_equal(cbor_serialize_alloc(item, &output, &output_size), 37);
   assert_size_equal(output_size, 37);
@@ -506,10 +506,10 @@ static void test_auto_serialize(void **_state _CBOR_UNUSED) {
   _cbor_free(output);
 }
 
-static void test_auto_serialize_no_size(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_build_uint8(1);
+static void test_auto_serialize_no_size(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_build_uint8(1);
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 1);
   assert_memory_equal(output, ((unsigned char[]){0x01}), 1);
   assert_size_equal(cbor_serialized_size(item), 1);
@@ -517,16 +517,16 @@ static void test_auto_serialize_no_size(void **_state _CBOR_UNUSED) {
   _cbor_free(output);
 }
 
-static void test_auto_serialize_too_large(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_string();
-  cbor_item_t *chunk = cbor_new_definite_string();
+static void test_auto_serialize_too_large(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_string();
+  cbor_item_t* chunk = cbor_new_definite_string();
   assert_true(cbor_string_add_chunk(item, chunk));
 
   // Pretend the chunk is huge
   chunk->metadata.string_metadata.length = SIZE_MAX;
   assert_true(SIZE_MAX + 2 == 1);
   assert_size_equal(cbor_serialized_size(item), 0);
-  unsigned char *output;
+  unsigned char* output;
   size_t output_size;
   assert_size_equal(cbor_serialize_alloc(item, &output, &output_size), 0);
   assert_size_equal(output_size, 0);
@@ -537,11 +537,11 @@ static void test_auto_serialize_too_large(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_auto_serialize_alloc_fail(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_build_uint8(42);
+static void test_auto_serialize_alloc_fail(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_build_uint8(42);
 
   WITH_FAILING_MALLOC({
-    unsigned char *output;
+    unsigned char* output;
     size_t output_size;
     assert_size_equal(cbor_serialize_alloc(item, &output, &output_size), 0);
     assert_size_equal(output_size, 0);
@@ -552,10 +552,10 @@ static void test_auto_serialize_alloc_fail(void **_state _CBOR_UNUSED) {
 }
 
 static void test_auto_serialize_zero_len_bytestring(
-    void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_build_bytestring((cbor_data) "", 0);
+    void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_build_bytestring((cbor_data) "", 0);
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 1);
   assert_memory_equal(output, ((unsigned char[]){0x40}), 1);
   assert_size_equal(cbor_serialized_size(item), 1);
@@ -563,10 +563,10 @@ static void test_auto_serialize_zero_len_bytestring(
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_string(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_build_string("");
+static void test_auto_serialize_zero_len_string(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_build_string("");
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 1);
   assert_memory_equal(output, ((unsigned char[]){0x60}), 1);
   assert_size_equal(cbor_serialized_size(item), 1);
@@ -575,13 +575,13 @@ static void test_auto_serialize_zero_len_string(void **_state _CBOR_UNUSED) {
 }
 
 static void test_auto_serialize_zero_len_bytestring_chunk(
-    void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_bytestring();
+    void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_bytestring();
 
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "", 0))));
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 3);
   assert_memory_equal(output, ((unsigned char[]){0x5f, 0x40, 0xff}), 3);
   assert_size_equal(cbor_serialized_size(item), 3);
@@ -590,12 +590,12 @@ static void test_auto_serialize_zero_len_bytestring_chunk(
 }
 
 static void test_auto_serialize_zero_len_string_chunk(
-    void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_string();
+    void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_string();
 
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string(""))));
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 3);
   assert_memory_equal(output, ((unsigned char[]){0x7f, 0x60, 0xff}), 3);
   assert_size_equal(cbor_serialized_size(item), 3);
@@ -603,10 +603,10 @@ static void test_auto_serialize_zero_len_string_chunk(
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_array(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_array(0);
+static void test_auto_serialize_zero_len_array(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_array(0);
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 1);
   assert_memory_equal(output, ((unsigned char[]){0x80}), 1);
   assert_size_equal(cbor_serialized_size(item), 1);
@@ -615,10 +615,10 @@ static void test_auto_serialize_zero_len_array(void **_state _CBOR_UNUSED) {
 }
 
 static void test_auto_serialize_zero_len_indef_array(
-    void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_array();
+    void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_array();
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 2);
   assert_memory_equal(output, ((unsigned char[]){0x9f, 0xff}), 2);
   assert_size_equal(cbor_serialized_size(item), 2);
@@ -626,10 +626,10 @@ static void test_auto_serialize_zero_len_indef_array(
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_map(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_map(0);
+static void test_auto_serialize_zero_len_map(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_map(0);
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 1);
   assert_memory_equal(output, ((unsigned char[]){0xa0}), 1);
   assert_size_equal(cbor_serialized_size(item), 1);
@@ -637,10 +637,10 @@ static void test_auto_serialize_zero_len_map(void **_state _CBOR_UNUSED) {
   _cbor_free(output);
 }
 
-static void test_auto_serialize_zero_len_indef_map(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_map();
+static void test_auto_serialize_zero_len_indef_map(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_map();
 
-  unsigned char *output;
+  unsigned char* output;
   assert_size_equal(cbor_serialize_alloc(item, &output, NULL), 2);
   assert_memory_equal(output, ((unsigned char[]){0xbf, 0xff}), 2);
   assert_size_equal(cbor_serialized_size(item), 2);

--- a/test/cbor_stream_decode_test.c
+++ b/test/cbor_stream_decode_test.c
@@ -9,12 +9,12 @@
 #include "cbor.h"
 #include "stream_expectations.h"
 
-static void test_no_data(void **_CBOR_UNUSED(_state)) {
+static void test_no_data(void** _state _CBOR_UNUSED) {
   assert_decoder_result_nedata(1, decode(NULL, 0));
 }
 
 unsigned char embedded_uint8_data[] = {0x00, 0x01, 0x05, 0x17};
-static void test_uint8_embedded_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_uint8_embedded_decoding(void** _state _CBOR_UNUSED) {
   assert_uint8_eq(0);
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(embedded_uint8_data, 1));
@@ -33,7 +33,7 @@ static void test_uint8_embedded_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char uint8_data[] = {0x18, 0x83, 0x18, 0xFF};
-static void test_uint8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_uint8_decoding(void** _state _CBOR_UNUSED) {
   assert_uint8_eq(0x83);
   assert_decoder_result(2, CBOR_DECODER_FINISHED, decode(uint8_data, 2));
 
@@ -44,7 +44,7 @@ static void test_uint8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char uint16_data[] = {0x19, 0x01, 0xf4};
-static void test_uint16_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_uint16_decoding(void** _state _CBOR_UNUSED) {
   assert_uint16_eq(500);
   assert_decoder_result(3, CBOR_DECODER_FINISHED, decode(uint16_data, 3));
 
@@ -52,7 +52,7 @@ static void test_uint16_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char uint32_data[] = {0x1a, 0xa5, 0xf7, 0x02, 0xb3};
-static void test_uint32_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_uint32_decoding(void** _state _CBOR_UNUSED) {
   assert_uint32_eq((uint32_t)2784428723UL);
   assert_decoder_result(5, CBOR_DECODER_FINISHED, decode(uint32_data, 5));
 
@@ -61,7 +61,7 @@ static void test_uint32_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char uint64_data[] = {0x1b, 0xa5, 0xf7, 0x02, 0xb3,
                                0xa5, 0xf7, 0x02, 0xb3};
-static void test_uint64_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_uint64_decoding(void** _state _CBOR_UNUSED) {
   assert_uint64_eq(11959030306112471731ULL);
   assert_decoder_result(9, CBOR_DECODER_FINISHED, decode(uint64_data, 9));
 
@@ -69,7 +69,7 @@ static void test_uint64_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char embedded_negint8_data[] = {0x20, 0x21, 0x25, 0x37};
-static void test_negint8_embedded_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_negint8_embedded_decoding(void** _state _CBOR_UNUSED) {
   assert_negint8_eq(0);
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(embedded_negint8_data, 1));
@@ -88,7 +88,7 @@ static void test_negint8_embedded_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char negint8_data[] = {0x38, 0x83, 0x38, 0xFF};
-static void test_negint8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_negint8_decoding(void** _state _CBOR_UNUSED) {
   assert_negint8_eq(0x83);
   assert_decoder_result(2, CBOR_DECODER_FINISHED, decode(negint8_data, 2));
 
@@ -99,7 +99,7 @@ static void test_negint8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char negint16_data[] = {0x39, 0x01, 0xf4};
-static void test_negint16_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_negint16_decoding(void** _state _CBOR_UNUSED) {
   assert_negint16_eq(500);
   assert_decoder_result(3, CBOR_DECODER_FINISHED, decode(negint16_data, 3));
 
@@ -107,7 +107,7 @@ static void test_negint16_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char negint32_data[] = {0x3a, 0xa5, 0xf7, 0x02, 0xb3};
-static void test_negint32_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_negint32_decoding(void** _state _CBOR_UNUSED) {
   assert_negint32_eq((uint32_t)2784428723UL);
   assert_decoder_result(5, CBOR_DECODER_FINISHED, decode(negint32_data, 5));
 
@@ -116,7 +116,7 @@ static void test_negint32_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char negint64_data[] = {0x3b, 0xa5, 0xf7, 0x02, 0xb3,
                                  0xa5, 0xf7, 0x02, 0xb3};
-static void test_negint64_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_negint64_decoding(void** _state _CBOR_UNUSED) {
   assert_negint64_eq(11959030306112471731ULL);
   assert_decoder_result(9, CBOR_DECODER_FINISHED, decode(negint64_data, 9));
 
@@ -124,7 +124,7 @@ static void test_negint64_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char bstring_embedded_int8_data[] = {0x41, 0xFF};
-static void test_bstring_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_embedded_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_bstring_mem_eq(bstring_embedded_int8_data + 1, 1);
   assert_decoder_result(2, CBOR_DECODER_FINISHED,
                         decode(bstring_embedded_int8_data, 2));
@@ -136,7 +136,7 @@ static void test_bstring_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
 // the second byte of input); the data is never read, so we never run into
 // memory issues despite not allocating and initializing all the data.
 unsigned char bstring_int8_data[] = {0x58, 0x02 /*, [2 bytes] */};
-static void test_bstring_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_bstring_mem_eq(bstring_int8_data + 2, 2);
   assert_decoder_result(4, CBOR_DECODER_FINISHED, decode(bstring_int8_data, 4));
 
@@ -146,7 +146,7 @@ static void test_bstring_int8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char bstring_int8_empty_data[] = {0x58, 0x00};
-static void test_bstring_int8_empty_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_int8_empty_decoding(void** _state _CBOR_UNUSED) {
   assert_bstring_mem_eq(bstring_int8_empty_data + 2, 0);
   assert_decoder_result(2, CBOR_DECODER_FINISHED,
                         decode(bstring_int8_empty_data, 2));
@@ -155,7 +155,7 @@ static void test_bstring_int8_empty_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char bstring_int16_data[] = {0x59, 0x01, 0x5C /*, [348 bytes] */};
-static void test_bstring_int16_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_int16_decoding(void** _state _CBOR_UNUSED) {
   assert_bstring_mem_eq(bstring_int16_data + 3, 348);
   assert_decoder_result(3 + 348, CBOR_DECODER_FINISHED,
                         decode(bstring_int16_data, 3 + 348));
@@ -167,7 +167,7 @@ static void test_bstring_int16_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char bstring_int32_data[] = {0x5A, 0x00, 0x10, 0x10,
                                       0x10 /*, [1052688 bytes] */};
-static void test_bstring_int32_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_int32_decoding(void** _state _CBOR_UNUSED) {
   assert_bstring_mem_eq(bstring_int32_data + 5, 1052688);
   assert_decoder_result(5 + 1052688, CBOR_DECODER_FINISHED,
                         decode(bstring_int32_data, 5 + 1052688));
@@ -181,7 +181,7 @@ static void test_bstring_int32_decoding(void **_CBOR_UNUSED(_state)) {
 unsigned char bstring_int64_data[] = {
     0x5B, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x00, 0x00, 0x00 /*, [4294967296 bytes] */};
-static void test_bstring_int64_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_int64_decoding(void** _state _CBOR_UNUSED) {
   assert_bstring_mem_eq(bstring_int64_data + 9, 4294967296);
   assert_decoder_result(9 + 4294967296, CBOR_DECODER_FINISHED,
                         decode(bstring_int64_data, 9 + 4294967296));
@@ -194,7 +194,7 @@ static void test_bstring_int64_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char bstring_indef_1_data[] = {0x5F, 0x40 /* Empty byte string */,
                                         0xFF};
-static void test_bstring_indef_decoding_1(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_indef_decoding_1(void** _state _CBOR_UNUSED) {
   assert_bstring_indef_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(bstring_indef_1_data, 3));
@@ -209,7 +209,7 @@ static void test_bstring_indef_decoding_1(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char bstring_indef_2_data[] = {0x5F, 0xFF};
-static void test_bstring_indef_decoding_2(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_indef_decoding_2(void** _state _CBOR_UNUSED) {
   assert_bstring_indef_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(bstring_indef_2_data, 2));
@@ -226,7 +226,7 @@ unsigned char bstring_indef_3_data[] = {0x5F,
                                         0x58, 0x01, 0x00,
                                         // Break
                                         0xFF};
-static void test_bstring_indef_decoding_3(void **_CBOR_UNUSED(_state)) {
+static void test_bstring_indef_decoding_3(void** _state _CBOR_UNUSED) {
   assert_bstring_indef_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(bstring_indef_3_data, 6));
@@ -245,7 +245,7 @@ static void test_bstring_indef_decoding_3(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char string_embedded_int8_data[] = {0x61, 0xFF};
-static void test_string_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_string_embedded_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_string_mem_eq(string_embedded_int8_data + 1, 1);
   assert_decoder_result(2, CBOR_DECODER_FINISHED,
                         decode(string_embedded_int8_data, 2));
@@ -257,7 +257,7 @@ static void test_string_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
 // the second byte of input); the data is never read, so we never run into
 // memory issues despite not allocating and initializing all the data.
 unsigned char string_int8_data[] = {0x78, 0x02 /*, [2 bytes] */};
-static void test_string_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_string_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_string_mem_eq(string_int8_data + 2, 2);
   assert_decoder_result(4, CBOR_DECODER_FINISHED, decode(string_int8_data, 4));
 
@@ -267,7 +267,7 @@ static void test_string_int8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char string_int8_empty_data[] = {0x78, 0x00};
-static void test_string_int8_empty_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_string_int8_empty_decoding(void** _state _CBOR_UNUSED) {
   assert_string_mem_eq(string_int8_empty_data + 2, 0);
   assert_decoder_result(2, CBOR_DECODER_FINISHED,
                         decode(string_int8_empty_data, 2));
@@ -276,7 +276,7 @@ static void test_string_int8_empty_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char string_int16_data[] = {0x79, 0x01, 0x5C /*, [348 bytes] */};
-static void test_string_int16_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_string_int16_decoding(void** _state _CBOR_UNUSED) {
   assert_string_mem_eq(string_int16_data + 3, 348);
   assert_decoder_result(3 + 348, CBOR_DECODER_FINISHED,
                         decode(string_int16_data, 3 + 348));
@@ -288,7 +288,7 @@ static void test_string_int16_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char string_int32_data[] = {0x7A, 0x00, 0x10, 0x10,
                                      0x10 /*, [1052688 bytes] */};
-static void test_string_int32_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_string_int32_decoding(void** _state _CBOR_UNUSED) {
   assert_string_mem_eq(string_int32_data + 5, 1052688);
   assert_decoder_result(5 + 1052688, CBOR_DECODER_FINISHED,
                         decode(string_int32_data, 5 + 1052688));
@@ -302,7 +302,7 @@ static void test_string_int32_decoding(void **_CBOR_UNUSED(_state)) {
 unsigned char string_int64_data[] = {
     0x7B, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x00, 0x00, 0x00 /*, [4294967296 bytes] */};
-static void test_string_int64_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_string_int64_decoding(void** _state _CBOR_UNUSED) {
   assert_string_mem_eq(string_int64_data + 9, 4294967296);
   assert_decoder_result(9 + 4294967296, CBOR_DECODER_FINISHED,
                         decode(string_int64_data, 9 + 4294967296));
@@ -314,7 +314,7 @@ static void test_string_int64_decoding(void **_CBOR_UNUSED(_state)) {
 #endif
 
 unsigned char string_indef_1_data[] = {0x7F, 0x60 /* Empty string */, 0xFF};
-static void test_string_indef_decoding_1(void **_CBOR_UNUSED(_state)) {
+static void test_string_indef_decoding_1(void** _state _CBOR_UNUSED) {
   assert_string_indef_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(string_indef_1_data, 3));
@@ -329,7 +329,7 @@ static void test_string_indef_decoding_1(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char string_indef_2_data[] = {0x7F, 0xFF};
-static void test_string_indef_decoding_2(void **_CBOR_UNUSED(_state)) {
+static void test_string_indef_decoding_2(void** _state _CBOR_UNUSED) {
   assert_string_indef_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(string_indef_2_data, 2));
@@ -346,7 +346,7 @@ unsigned char string_indef_3_data[] = {0x7F,
                                        0x78, 0x01, 0x00,
                                        // Break
                                        0xFF};
-static void test_string_indef_decoding_3(void **_CBOR_UNUSED(_state)) {
+static void test_string_indef_decoding_3(void** _state _CBOR_UNUSED) {
   assert_string_indef_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(string_indef_3_data, 6));
@@ -365,14 +365,14 @@ static void test_string_indef_decoding_3(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char array_embedded_int8_data[] = {0x80};
-static void test_array_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_array_embedded_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_array_start(0);
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(array_embedded_int8_data, 1));
 }
 
 unsigned char array_int8_data[] = {0x98, 0x02, 0x00, 0x01};
-static void test_array_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_array_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_array_start(2);
   assert_decoder_result(2, CBOR_DECODER_FINISHED, decode(array_int8_data, 4));
 
@@ -388,7 +388,7 @@ static void test_array_int8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char array_int16_data[] = {0x99, 0x00, 0x02, 0x00, 0x01};
-static void test_array_int16_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_array_int16_decoding(void** _state _CBOR_UNUSED) {
   assert_array_start(2);
   assert_decoder_result(3, CBOR_DECODER_FINISHED, decode(array_int16_data, 5));
 
@@ -404,7 +404,7 @@ static void test_array_int16_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char array_int32_data[] = {0x9A, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01};
-static void test_array_int32_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_array_int32_decoding(void** _state _CBOR_UNUSED) {
   assert_array_start(2);
   assert_decoder_result(5, CBOR_DECODER_FINISHED, decode(array_int32_data, 7));
 
@@ -421,7 +421,7 @@ static void test_array_int32_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char array_int64_data[] = {0x9B, 0x00, 0x00, 0x00, 0x00, 0x00,
                                     0x00, 0x00, 0x02, 0x00, 0x01};
-static void test_array_int64_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_array_int64_decoding(void** _state _CBOR_UNUSED) {
   assert_array_start(2);
   assert_decoder_result(9, CBOR_DECODER_FINISHED, decode(array_int64_data, 11));
 
@@ -437,7 +437,7 @@ static void test_array_int64_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char array_of_arrays_data[] = {0x82, 0x80, 0x80};
-static void test_array_of_arrays_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_array_of_arrays_decoding(void** _state _CBOR_UNUSED) {
   assert_array_start(2);
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(array_of_arrays_data, 3));
@@ -452,7 +452,7 @@ static void test_array_of_arrays_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char indef_array_data_1[] = {0x9F, 0x00, 0x18, 0xFF, 0x9F, 0xFF, 0xFF};
-static void test_indef_array_decoding_1(void **_CBOR_UNUSED(_state)) {
+static void test_indef_array_decoding_1(void** _state _CBOR_UNUSED) {
   assert_indef_array_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(indef_array_data_1, 7));
@@ -479,7 +479,7 @@ static void test_indef_array_decoding_1(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char map_embedded_int8_data[] = {0xa1, 0x01, 0x00};
-static void test_map_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_map_embedded_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_map_start(1);
   assert_decoder_result(1, CBOR_DECODER_FINISHED,
                         decode(map_embedded_int8_data, 3));
@@ -494,7 +494,7 @@ static void test_map_embedded_int8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char map_int8_data[] = {0xB8, 0x01, 0x00, 0x01};
-static void test_map_int8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_map_int8_decoding(void** _state _CBOR_UNUSED) {
   assert_map_start(1);
   assert_decoder_result(2, CBOR_DECODER_FINISHED, decode(map_int8_data, 4));
 
@@ -508,7 +508,7 @@ static void test_map_int8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char map_int16_data[] = {0xB9, 0x00, 0x01, 0x00, 0x01};
-static void test_map_int16_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_map_int16_decoding(void** _state _CBOR_UNUSED) {
   assert_map_start(1);
   assert_decoder_result(3, CBOR_DECODER_FINISHED, decode(map_int16_data, 5));
 
@@ -524,7 +524,7 @@ static void test_map_int16_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char map_int32_data[] = {0xBA, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01};
-static void test_map_int32_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_map_int32_decoding(void** _state _CBOR_UNUSED) {
   assert_map_start(1);
   assert_decoder_result(5, CBOR_DECODER_FINISHED, decode(map_int32_data, 7));
 
@@ -541,7 +541,7 @@ static void test_map_int32_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char map_int64_data[] = {0xBB, 0x00, 0x00, 0x00, 0x00, 0x00,
                                   0x00, 0x00, 0x01, 0x00, 0x01};
-static void test_map_int64_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_map_int64_decoding(void** _state _CBOR_UNUSED) {
   assert_map_start(1);
   assert_decoder_result(9, CBOR_DECODER_FINISHED, decode(map_int64_data, 11));
 
@@ -557,7 +557,7 @@ static void test_map_int64_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char indef_map_data_1[] = {0xBF, 0x00, 0x18, 0xFF, 0xFF};
-static void test_indef_map_decoding_1(void **_CBOR_UNUSED(_state)) {
+static void test_indef_map_decoding_1(void** _state _CBOR_UNUSED) {
   assert_indef_map_start();
   assert_decoder_result(1, CBOR_DECODER_FINISHED, decode(indef_map_data_1, 5));
 
@@ -575,13 +575,13 @@ static void test_indef_map_decoding_1(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char embedded_tag_data[] = {0xC1};
-static void test_embedded_tag_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_tag_decoding(void** _state _CBOR_UNUSED) {
   assert_tag_eq(1);
   assert_decoder_result(1, CBOR_DECODER_FINISHED, decode(embedded_tag_data, 1));
 }
 
 unsigned char int8_tag_data[] = {0xD8, 0xFE};
-static void test_int8_tag_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_int8_tag_decoding(void** _state _CBOR_UNUSED) {
   assert_tag_eq(254);
   assert_decoder_result(2, CBOR_DECODER_FINISHED, decode(int8_tag_data, 2));
 
@@ -589,7 +589,7 @@ static void test_int8_tag_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char int16_tag_data[] = {0xD9, 0xFE, 0xFD};
-static void test_int16_tag_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_int16_tag_decoding(void** _state _CBOR_UNUSED) {
   assert_tag_eq(65277);
   assert_decoder_result(3, CBOR_DECODER_FINISHED, decode(int16_tag_data, 3));
 
@@ -597,7 +597,7 @@ static void test_int16_tag_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char int32_tag_data[] = {0xDA, 0xFE, 0xFD, 0xFC, 0xFB};
-static void test_int32_tag_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_int32_tag_decoding(void** _state _CBOR_UNUSED) {
   assert_tag_eq(4278058235ULL);
   assert_decoder_result(5, CBOR_DECODER_FINISHED, decode(int32_tag_data, 5));
 
@@ -606,7 +606,7 @@ static void test_int32_tag_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char int64_tag_data[] = {0xDB, 0xFE, 0xFD, 0xFC, 0xFB,
                                   0xFA, 0xF9, 0xF8, 0xF7};
-static void test_int64_tag_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_int64_tag_decoding(void** _state _CBOR_UNUSED) {
   assert_tag_eq(18374120213919168759ULL);
   assert_decoder_result(9, CBOR_DECODER_FINISHED, decode(int64_tag_data, 9));
 
@@ -614,12 +614,12 @@ static void test_int64_tag_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char reserved_byte_data[] = {0xDC};
-static void test_reserved_byte_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_reserved_byte_decoding(void** _state _CBOR_UNUSED) {
   assert_decoder_result(0, CBOR_DECODER_ERROR, decode(reserved_byte_data, 1));
 }
 
 unsigned char float2_data[] = {0xF9, 0x7B, 0xFF};
-static void test_float2_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_float2_decoding(void** _state _CBOR_UNUSED) {
   assert_half(65504.0f);
   assert_decoder_result(3, CBOR_DECODER_FINISHED, decode(float2_data, 3));
 
@@ -627,7 +627,7 @@ static void test_float2_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char float4_data[] = {0xFA, 0x47, 0xC3, 0x50, 0x00};
-static void test_float4_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_float4_decoding(void** _state _CBOR_UNUSED) {
   assert_float(100000.0f);
   assert_decoder_result(5, CBOR_DECODER_FINISHED, decode(float4_data, 5));
 
@@ -636,7 +636,7 @@ static void test_float4_decoding(void **_CBOR_UNUSED(_state)) {
 
 unsigned char float8_data[] = {0xFB, 0xC0, 0x10, 0x66, 0x66,
                                0x66, 0x66, 0x66, 0x66};
-static void test_float8_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_float8_decoding(void** _state _CBOR_UNUSED) {
   assert_double(-4.1);
   assert_decoder_result(9, CBOR_DECODER_FINISHED, decode(float8_data, 9));
 
@@ -644,25 +644,25 @@ static void test_float8_decoding(void **_CBOR_UNUSED(_state)) {
 }
 
 unsigned char false_data[] = {0xF4};
-static void test_false_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_false_decoding(void** _state _CBOR_UNUSED) {
   assert_bool(false);
   assert_decoder_result(1, CBOR_DECODER_FINISHED, decode(false_data, 1));
 }
 
 unsigned char true_data[] = {0xF5};
-static void test_true_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_true_decoding(void** _state _CBOR_UNUSED) {
   assert_bool(true);
   assert_decoder_result(1, CBOR_DECODER_FINISHED, decode(true_data, 1));
 }
 
 unsigned char null_data[] = {0xF6};
-static void test_null_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_null_decoding(void** _state _CBOR_UNUSED) {
   assert_nil();
   assert_decoder_result(1, CBOR_DECODER_FINISHED, decode(null_data, 1));
 }
 
 unsigned char undef_data[] = {0xF7};
-static void test_undef_decoding(void **_CBOR_UNUSED(_state)) {
+static void test_undef_decoding(void** _state _CBOR_UNUSED) {
   assert_undef();
   assert_decoder_result(1, CBOR_DECODER_FINISHED, decode(undef_data, 1));
 }

--- a/test/copy_test.c
+++ b/test/copy_test.c
@@ -11,7 +11,7 @@
 
 cbor_item_t *item, *copy, *tmp;
 
-static void test_uints(void **_CBOR_UNUSED(_state)) {
+static void test_uints(void **_state _CBOR_UNUSED) {
   item = cbor_build_uint8(10);
   assert_uint8(copy = cbor_copy(item), 10);
   cbor_decref(&item);
@@ -33,7 +33,7 @@ static void test_uints(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_negints(void **_CBOR_UNUSED(_state)) {
+static void test_negints(void **_state _CBOR_UNUSED) {
   item = cbor_build_negint8(10);
   assert_true(cbor_get_uint8(copy = cbor_copy(item)) == 10);
   cbor_decref(&item);
@@ -55,7 +55,7 @@ static void test_negints(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_def_bytestring(void **_CBOR_UNUSED(_state)) {
+static void test_def_bytestring(void **_state _CBOR_UNUSED) {
   item = cbor_build_bytestring((cbor_data) "abc", 3);
   assert_memory_equal(cbor_bytestring_handle(copy = cbor_copy(item)),
                       cbor_bytestring_handle(item), 3);
@@ -63,7 +63,7 @@ static void test_def_bytestring(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_indef_bytestring(void **_CBOR_UNUSED(_state)) {
+static void test_indef_bytestring(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -78,7 +78,7 @@ static void test_indef_bytestring(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_def_string(void **_CBOR_UNUSED(_state)) {
+static void test_def_string(void **_state _CBOR_UNUSED) {
   item = cbor_build_string("abc");
   assert_memory_equal(cbor_string_handle(copy = cbor_copy(item)),
                       cbor_string_handle(item), 3);
@@ -86,7 +86,7 @@ static void test_def_string(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_indef_string(void **_CBOR_UNUSED(_state)) {
+static void test_indef_string(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
   copy = cbor_copy(item);
@@ -100,7 +100,7 @@ static void test_indef_string(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_def_array(void **_CBOR_UNUSED(_state)) {
+static void test_def_array(void **_state _CBOR_UNUSED) {
   item = cbor_new_definite_array(1);
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -110,7 +110,7 @@ static void test_def_array(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&tmp);
 }
 
-static void test_indef_array(void **_CBOR_UNUSED(_state)) {
+static void test_indef_array(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -120,7 +120,7 @@ static void test_indef_array(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&tmp);
 }
 
-static void test_def_map(void **_CBOR_UNUSED(_state)) {
+static void test_def_map(void **_state _CBOR_UNUSED) {
   item = cbor_new_definite_map(1);
   assert_true(cbor_map_add(item, (struct cbor_pair){
                                      .key = cbor_move(cbor_build_uint8(42)),
@@ -133,7 +133,7 @@ static void test_def_map(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_indef_map(void **_CBOR_UNUSED(_state)) {
+static void test_indef_map(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(cbor_map_add(item, (struct cbor_pair){
                                      .key = cbor_move(cbor_build_uint8(42)),
@@ -146,7 +146,7 @@ static void test_indef_map(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_tag(void **_CBOR_UNUSED(_state)) {
+static void test_tag(void **_state _CBOR_UNUSED) {
   item = cbor_build_tag(10, cbor_move(cbor_build_uint8(42)));
 
   assert_uint8(cbor_move(cbor_tag_item(copy = cbor_copy(item))), 42);
@@ -155,14 +155,14 @@ static void test_tag(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_ctrls(void **_CBOR_UNUSED(_state)) {
+static void test_ctrls(void **_state _CBOR_UNUSED) {
   item = cbor_new_null();
   assert_true(cbor_is_null(copy = cbor_copy(item)));
   cbor_decref(&item);
   cbor_decref(&copy);
 }
 
-static void test_floats(void **_CBOR_UNUSED(_state)) {
+static void test_floats(void **_state _CBOR_UNUSED) {
   item = cbor_build_float2(3.14f);
   assert_true(cbor_float_get_float2(copy = cbor_copy(item)) ==
               cbor_float_get_float2(item));
@@ -182,7 +182,7 @@ static void test_floats(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&copy);
 }
 
-static void test_alloc_failure_simple(void **_CBOR_UNUSED(_state)) {
+static void test_alloc_failure_simple(void **_state _CBOR_UNUSED) {
   item = cbor_build_uint8(10);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
@@ -191,7 +191,7 @@ static void test_alloc_failure_simple(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_bytestring_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_bytestring_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -202,7 +202,7 @@ static void test_bytestring_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_bytestring_chunk_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_bytestring_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -213,7 +213,7 @@ static void test_bytestring_chunk_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_bytestring_chunk_append_failure(void **_CBOR_UNUSED(_state)) {
+static void test_bytestring_chunk_append_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -228,7 +228,7 @@ static void test_bytestring_chunk_append_failure(void **_CBOR_UNUSED(_state)) {
 }
 
 static void test_bytestring_second_chunk_alloc_failure(
-    void **_CBOR_UNUSED(_state)) {
+    void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -245,7 +245,7 @@ static void test_bytestring_second_chunk_alloc_failure(
   cbor_decref(&item);
 }
 
-static void test_string_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_string_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
 
@@ -255,7 +255,7 @@ static void test_string_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_string_chunk_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_string_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
 
@@ -265,7 +265,7 @@ static void test_string_chunk_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_string_chunk_append_failure(void **_CBOR_UNUSED(_state)) {
+static void test_string_chunk_append_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
 
@@ -278,8 +278,7 @@ static void test_string_chunk_append_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_string_second_chunk_alloc_failure(
-    void **_CBOR_UNUSED(_state)) {
+static void test_string_second_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("def"))));
@@ -294,7 +293,7 @@ static void test_string_second_chunk_alloc_failure(
   cbor_decref(&item);
 }
 
-static void test_array_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_array_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -304,7 +303,7 @@ static void test_array_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_array_item_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_array_item_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -317,7 +316,7 @@ static void test_array_item_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_array_push_failure(void **_CBOR_UNUSED(_state)) {
+static void test_array_push_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -330,7 +329,7 @@ static void test_array_push_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_array_second_item_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_array_second_item_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(43))));
@@ -344,7 +343,7 @@ static void test_array_second_item_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_map_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_map_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -356,7 +355,7 @@ static void test_map_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_map_key_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_map_key_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -370,7 +369,7 @@ static void test_map_key_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_map_value_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_map_value_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -384,7 +383,7 @@ static void test_map_value_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_map_add_failure(void **_CBOR_UNUSED(_state)) {
+static void test_map_add_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -398,7 +397,7 @@ static void test_map_add_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_map_second_key_failure(void **_CBOR_UNUSED(_state)) {
+static void test_map_second_key_failure(void **_state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -415,7 +414,7 @@ static void test_map_second_key_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_tag_item_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_tag_item_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
 
   WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
@@ -424,7 +423,7 @@ static void test_tag_item_alloc_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_tag_alloc_failure(void **_CBOR_UNUSED(_state)) {
+static void test_tag_alloc_failure(void **_state _CBOR_UNUSED) {
   item = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
 
   WITH_MOCK_MALLOC({ assert_null(cbor_copy(item)); }, 2,

--- a/test/copy_test.c
+++ b/test/copy_test.c
@@ -11,7 +11,7 @@
 
 cbor_item_t *item, *copy, *tmp;
 
-static void test_uints(void **_state _CBOR_UNUSED) {
+static void test_uints(void** _state _CBOR_UNUSED) {
   item = cbor_build_uint8(10);
   assert_uint8(copy = cbor_copy(item), 10);
   cbor_decref(&item);
@@ -33,7 +33,7 @@ static void test_uints(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_negints(void **_state _CBOR_UNUSED) {
+static void test_negints(void** _state _CBOR_UNUSED) {
   item = cbor_build_negint8(10);
   assert_true(cbor_get_uint8(copy = cbor_copy(item)) == 10);
   cbor_decref(&item);
@@ -55,7 +55,7 @@ static void test_negints(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_def_bytestring(void **_state _CBOR_UNUSED) {
+static void test_def_bytestring(void** _state _CBOR_UNUSED) {
   item = cbor_build_bytestring((cbor_data) "abc", 3);
   assert_memory_equal(cbor_bytestring_handle(copy = cbor_copy(item)),
                       cbor_bytestring_handle(item), 3);
@@ -63,7 +63,7 @@ static void test_def_bytestring(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_indef_bytestring(void **_state _CBOR_UNUSED) {
+static void test_indef_bytestring(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -78,7 +78,7 @@ static void test_indef_bytestring(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_def_string(void **_state _CBOR_UNUSED) {
+static void test_def_string(void** _state _CBOR_UNUSED) {
   item = cbor_build_string("abc");
   assert_memory_equal(cbor_string_handle(copy = cbor_copy(item)),
                       cbor_string_handle(item), 3);
@@ -86,7 +86,7 @@ static void test_def_string(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_indef_string(void **_state _CBOR_UNUSED) {
+static void test_indef_string(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
   copy = cbor_copy(item);
@@ -100,7 +100,7 @@ static void test_indef_string(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_def_array(void **_state _CBOR_UNUSED) {
+static void test_def_array(void** _state _CBOR_UNUSED) {
   item = cbor_new_definite_array(1);
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -110,7 +110,7 @@ static void test_def_array(void **_state _CBOR_UNUSED) {
   cbor_decref(&tmp);
 }
 
-static void test_indef_array(void **_state _CBOR_UNUSED) {
+static void test_indef_array(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -120,7 +120,7 @@ static void test_indef_array(void **_state _CBOR_UNUSED) {
   cbor_decref(&tmp);
 }
 
-static void test_def_map(void **_state _CBOR_UNUSED) {
+static void test_def_map(void** _state _CBOR_UNUSED) {
   item = cbor_new_definite_map(1);
   assert_true(cbor_map_add(item, (struct cbor_pair){
                                      .key = cbor_move(cbor_build_uint8(42)),
@@ -133,7 +133,7 @@ static void test_def_map(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_indef_map(void **_state _CBOR_UNUSED) {
+static void test_indef_map(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(cbor_map_add(item, (struct cbor_pair){
                                      .key = cbor_move(cbor_build_uint8(42)),
@@ -146,7 +146,7 @@ static void test_indef_map(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_tag(void **_state _CBOR_UNUSED) {
+static void test_tag(void** _state _CBOR_UNUSED) {
   item = cbor_build_tag(10, cbor_move(cbor_build_uint8(42)));
 
   assert_uint8(cbor_move(cbor_tag_item(copy = cbor_copy(item))), 42);
@@ -155,14 +155,14 @@ static void test_tag(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_ctrls(void **_state _CBOR_UNUSED) {
+static void test_ctrls(void** _state _CBOR_UNUSED) {
   item = cbor_new_null();
   assert_true(cbor_is_null(copy = cbor_copy(item)));
   cbor_decref(&item);
   cbor_decref(&copy);
 }
 
-static void test_floats(void **_state _CBOR_UNUSED) {
+static void test_floats(void** _state _CBOR_UNUSED) {
   item = cbor_build_float2(3.14f);
   assert_true(cbor_float_get_float2(copy = cbor_copy(item)) ==
               cbor_float_get_float2(item));
@@ -182,7 +182,7 @@ static void test_floats(void **_state _CBOR_UNUSED) {
   cbor_decref(&copy);
 }
 
-static void test_alloc_failure_simple(void **_state _CBOR_UNUSED) {
+static void test_alloc_failure_simple(void** _state _CBOR_UNUSED) {
   item = cbor_build_uint8(10);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
@@ -191,7 +191,7 @@ static void test_alloc_failure_simple(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_bytestring_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_bytestring_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -202,7 +202,7 @@ static void test_bytestring_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_bytestring_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_bytestring_chunk_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -213,7 +213,7 @@ static void test_bytestring_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_bytestring_chunk_append_failure(void **_state _CBOR_UNUSED) {
+static void test_bytestring_chunk_append_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -228,7 +228,7 @@ static void test_bytestring_chunk_append_failure(void **_state _CBOR_UNUSED) {
 }
 
 static void test_bytestring_second_chunk_alloc_failure(
-    void **_state _CBOR_UNUSED) {
+    void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
@@ -245,7 +245,7 @@ static void test_bytestring_second_chunk_alloc_failure(
   cbor_decref(&item);
 }
 
-static void test_string_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_string_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
 
@@ -255,7 +255,7 @@ static void test_string_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_string_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_string_chunk_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
 
@@ -265,7 +265,7 @@ static void test_string_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_string_chunk_append_failure(void **_state _CBOR_UNUSED) {
+static void test_string_chunk_append_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
 
@@ -278,7 +278,7 @@ static void test_string_chunk_append_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_string_second_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_string_second_chunk_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_string();
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("def"))));
@@ -293,7 +293,7 @@ static void test_string_second_chunk_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_array_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_array_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -303,7 +303,7 @@ static void test_array_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_array_item_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_array_item_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -316,7 +316,7 @@ static void test_array_item_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_array_push_failure(void **_state _CBOR_UNUSED) {
+static void test_array_push_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
 
@@ -329,7 +329,7 @@ static void test_array_push_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_array_second_item_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_array_second_item_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(42))));
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(43))));
@@ -343,7 +343,7 @@ static void test_array_second_item_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_map_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_map_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -355,7 +355,7 @@ static void test_map_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_map_key_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_map_key_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -369,7 +369,7 @@ static void test_map_key_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_map_value_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_map_value_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -383,7 +383,7 @@ static void test_map_value_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_map_add_failure(void **_state _CBOR_UNUSED) {
+static void test_map_add_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -397,7 +397,7 @@ static void test_map_add_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_map_second_key_failure(void **_state _CBOR_UNUSED) {
+static void test_map_second_key_failure(void** _state _CBOR_UNUSED) {
   item = cbor_new_indefinite_map();
   assert_true(
       cbor_map_add(item, (struct cbor_pair){cbor_move(cbor_build_uint8(42)),
@@ -414,7 +414,7 @@ static void test_map_second_key_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_tag_item_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_tag_item_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
 
   WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
@@ -423,7 +423,7 @@ static void test_tag_item_alloc_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_tag_alloc_failure(void **_state _CBOR_UNUSED) {
+static void test_tag_alloc_failure(void** _state _CBOR_UNUSED) {
   item = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
 
   WITH_MOCK_MALLOC({ assert_null(cbor_copy(item)); }, 2,

--- a/test/float_ctrl_encoders_test.c
+++ b/test/float_ctrl_encoders_test.c
@@ -11,24 +11,24 @@
 
 unsigned char buffer[512];
 
-static void test_bools(void **_state _CBOR_UNUSED) {
+static void test_bools(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_bool(false, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF4}), 1);
   assert_size_equal(1, cbor_encode_bool(true, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF5}), 1);
 }
 
-static void test_null(void **_state _CBOR_UNUSED) {
+static void test_null(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_null(buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF6}), 1);
 }
 
-static void test_undef(void **_state _CBOR_UNUSED) {
+static void test_undef(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_undef(buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF7}), 1);
 }
 
-static void test_break(void **_state _CBOR_UNUSED) {
+static void test_break(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_break(buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xFF}), 1);
 }
@@ -39,7 +39,7 @@ static void assert_half_float_codec_identity(void) {
   unsigned char secondary_buffer[3];
   struct cbor_load_result res;
   // Load and check data in buffer
-  cbor_item_t *half_float = cbor_load(buffer, 3, &res);
+  cbor_item_t* half_float = cbor_load(buffer, 3, &res);
   assert_size_equal(res.error.code, CBOR_ERR_NONE);
   assert_true(cbor_isa_float_ctrl(half_float));
   assert_true(cbor_is_float(half_float));
@@ -51,7 +51,7 @@ static void assert_half_float_codec_identity(void) {
   cbor_decref(&half_float);
 }
 
-static void test_half(void **_state _CBOR_UNUSED) {
+static void test_half(void** _state _CBOR_UNUSED) {
   assert_size_equal(3, cbor_encode_half(1.5f, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x3E, 0x00}), 3);
   assert_half_float_codec_identity();
@@ -117,7 +117,7 @@ static void test_half(void **_state _CBOR_UNUSED) {
   assert_half_float_codec_identity();
 }
 
-static void test_half_special(void **_state _CBOR_UNUSED) {
+static void test_half_special(void** _state _CBOR_UNUSED) {
   assert_size_equal(3, cbor_encode_half(NAN, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x7E, 0x00}), 3);
   assert_half_float_codec_identity();
@@ -127,7 +127,7 @@ static void test_half_special(void **_state _CBOR_UNUSED) {
   assert_half_float_codec_identity();
 }
 
-static void test_half_infinity(void **_state _CBOR_UNUSED) {
+static void test_half_infinity(void** _state _CBOR_UNUSED) {
   assert_size_equal(3, cbor_encode_half(INFINITY, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x7C, 0x00}), 3);
   assert_half_float_codec_identity();
@@ -137,7 +137,7 @@ static void test_half_infinity(void **_state _CBOR_UNUSED) {
   assert_half_float_codec_identity();
 }
 
-static void test_float(void **_state _CBOR_UNUSED) {
+static void test_float(void** _state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_single(3.4028234663852886e+38, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xFA, 0x7F, 0x7F, 0xFF, 0xFF}),
                       5);
@@ -159,7 +159,7 @@ static void test_float(void **_state _CBOR_UNUSED) {
                       5);
 }
 
-static void test_double(void **_state _CBOR_UNUSED) {
+static void test_double(void** _state _CBOR_UNUSED) {
   assert_size_equal(9, cbor_encode_double(1.0e+300, buffer, 512));
   assert_memory_equal(
       buffer,

--- a/test/float_ctrl_encoders_test.c
+++ b/test/float_ctrl_encoders_test.c
@@ -11,24 +11,24 @@
 
 unsigned char buffer[512];
 
-static void test_bools(void **_CBOR_UNUSED(_state)) {
+static void test_bools(void **_state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_bool(false, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF4}), 1);
   assert_size_equal(1, cbor_encode_bool(true, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF5}), 1);
 }
 
-static void test_null(void **_CBOR_UNUSED(_state)) {
+static void test_null(void **_state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_null(buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF6}), 1);
 }
 
-static void test_undef(void **_CBOR_UNUSED(_state)) {
+static void test_undef(void **_state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_undef(buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF7}), 1);
 }
 
-static void test_break(void **_CBOR_UNUSED(_state)) {
+static void test_break(void **_state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_break(buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xFF}), 1);
 }
@@ -51,7 +51,7 @@ static void assert_half_float_codec_identity(void) {
   cbor_decref(&half_float);
 }
 
-static void test_half(void **_CBOR_UNUSED(_state)) {
+static void test_half(void **_state _CBOR_UNUSED) {
   assert_size_equal(3, cbor_encode_half(1.5f, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x3E, 0x00}), 3);
   assert_half_float_codec_identity();
@@ -117,7 +117,7 @@ static void test_half(void **_CBOR_UNUSED(_state)) {
   assert_half_float_codec_identity();
 }
 
-static void test_half_special(void **_CBOR_UNUSED(_state)) {
+static void test_half_special(void **_state _CBOR_UNUSED) {
   assert_size_equal(3, cbor_encode_half(NAN, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x7E, 0x00}), 3);
   assert_half_float_codec_identity();
@@ -127,7 +127,7 @@ static void test_half_special(void **_CBOR_UNUSED(_state)) {
   assert_half_float_codec_identity();
 }
 
-static void test_half_infinity(void **_CBOR_UNUSED(_state)) {
+static void test_half_infinity(void **_state _CBOR_UNUSED) {
   assert_size_equal(3, cbor_encode_half(INFINITY, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xF9, 0x7C, 0x00}), 3);
   assert_half_float_codec_identity();
@@ -137,7 +137,7 @@ static void test_half_infinity(void **_CBOR_UNUSED(_state)) {
   assert_half_float_codec_identity();
 }
 
-static void test_float(void **_CBOR_UNUSED(_state)) {
+static void test_float(void **_state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_single(3.4028234663852886e+38, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xFA, 0x7F, 0x7F, 0xFF, 0xFF}),
                       5);
@@ -159,7 +159,7 @@ static void test_float(void **_CBOR_UNUSED(_state)) {
                       5);
 }
 
-static void test_double(void **_CBOR_UNUSED(_state)) {
+static void test_double(void **_state _CBOR_UNUSED) {
   assert_size_equal(9, cbor_encode_double(1.0e+300, buffer, 512));
   assert_memory_equal(
       buffer,

--- a/test/float_ctrl_test.c
+++ b/test/float_ctrl_test.c
@@ -24,7 +24,7 @@ static const float eps = 0.00001f;
 
 unsigned char float2_data[] = {0xF9, 0x7B, 0xFF};
 
-static void test_float2(void **_CBOR_UNUSED(_state)) {
+static void test_float2(void **_state _CBOR_UNUSED) {
   float_ctrl = cbor_load(float2_data, 3, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_float(float_ctrl));
@@ -37,7 +37,7 @@ static void test_float2(void **_CBOR_UNUSED(_state)) {
 
 unsigned char float4_data[] = {0xFA, 0x47, 0xC3, 0x50, 0x00};
 
-static void test_float4(void **_CBOR_UNUSED(_state)) {
+static void test_float4(void **_state _CBOR_UNUSED) {
   float_ctrl = cbor_load(float4_data, 5, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_float(float_ctrl));
@@ -51,7 +51,7 @@ static void test_float4(void **_CBOR_UNUSED(_state)) {
 unsigned char float8_data[] = {0xFB, 0x7E, 0x37, 0xE4, 0x3C,
                                0x88, 0x00, 0x75, 0x9C};
 
-static void test_float8(void **_CBOR_UNUSED(_state)) {
+static void test_float8(void **_state _CBOR_UNUSED) {
   float_ctrl = cbor_load(float8_data, 9, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_float(float_ctrl));
@@ -66,7 +66,7 @@ static void test_float8(void **_CBOR_UNUSED(_state)) {
 
 unsigned char null_data[] = {0xF6};
 
-static void test_null(void **_CBOR_UNUSED(_state)) {
+static void test_null(void **_state _CBOR_UNUSED) {
   float_ctrl = cbor_load(null_data, 1, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_null(float_ctrl));
@@ -76,7 +76,7 @@ static void test_null(void **_CBOR_UNUSED(_state)) {
 
 unsigned char undef_data[] = {0xF7};
 
-static void test_undef(void **_CBOR_UNUSED(_state)) {
+static void test_undef(void **_state _CBOR_UNUSED) {
   float_ctrl = cbor_load(undef_data, 1, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_undef(float_ctrl));
@@ -86,7 +86,7 @@ static void test_undef(void **_CBOR_UNUSED(_state)) {
 
 unsigned char bool_data[] = {0xF4, 0xF5};
 
-static void test_bool(void **_CBOR_UNUSED(_state)) {
+static void test_bool(void **_state _CBOR_UNUSED) {
   _CBOR_TEST_DISABLE_ASSERT({
     float_ctrl = cbor_load(bool_data, 1, &res);
     assert_true(cbor_isa_float_ctrl(float_ctrl));
@@ -110,7 +110,7 @@ static void test_bool(void **_CBOR_UNUSED(_state)) {
   });
 }
 
-static void test_float_ctrl_creation(void **_CBOR_UNUSED(_state)) {
+static void test_float_ctrl_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_ctrl()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_float2()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_float4()); });

--- a/test/float_ctrl_test.c
+++ b/test/float_ctrl_test.c
@@ -119,8 +119,8 @@ static void test_float_ctrl_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_undef()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_bool(false)); });
-  WITH_FAILING_MALLOC({ assert_null(cbor_build_float2(3.14)); });
-  WITH_FAILING_MALLOC({ assert_null(cbor_build_float4(3.14)); });
+  WITH_FAILING_MALLOC({ assert_null(cbor_build_float2(3.14f)); });
+  WITH_FAILING_MALLOC({ assert_null(cbor_build_float4(3.14f)); });
   WITH_FAILING_MALLOC({ assert_null(cbor_build_float8(3.14)); });
   WITH_FAILING_MALLOC({ assert_null(cbor_build_ctrl(0xAF)); });
 }

--- a/test/float_ctrl_test.c
+++ b/test/float_ctrl_test.c
@@ -17,14 +17,14 @@
 #include "cbor.h"
 #include "test_allocator.h"
 
-cbor_item_t *float_ctrl;
+cbor_item_t* float_ctrl;
 struct cbor_load_result res;
 
 static const float eps = 0.00001f;
 
 unsigned char float2_data[] = {0xF9, 0x7B, 0xFF};
 
-static void test_float2(void **_state _CBOR_UNUSED) {
+static void test_float2(void** _state _CBOR_UNUSED) {
   float_ctrl = cbor_load(float2_data, 3, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_float(float_ctrl));
@@ -37,7 +37,7 @@ static void test_float2(void **_state _CBOR_UNUSED) {
 
 unsigned char float4_data[] = {0xFA, 0x47, 0xC3, 0x50, 0x00};
 
-static void test_float4(void **_state _CBOR_UNUSED) {
+static void test_float4(void** _state _CBOR_UNUSED) {
   float_ctrl = cbor_load(float4_data, 5, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_float(float_ctrl));
@@ -51,7 +51,7 @@ static void test_float4(void **_state _CBOR_UNUSED) {
 unsigned char float8_data[] = {0xFB, 0x7E, 0x37, 0xE4, 0x3C,
                                0x88, 0x00, 0x75, 0x9C};
 
-static void test_float8(void **_state _CBOR_UNUSED) {
+static void test_float8(void** _state _CBOR_UNUSED) {
   float_ctrl = cbor_load(float8_data, 9, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_float(float_ctrl));
@@ -66,7 +66,7 @@ static void test_float8(void **_state _CBOR_UNUSED) {
 
 unsigned char null_data[] = {0xF6};
 
-static void test_null(void **_state _CBOR_UNUSED) {
+static void test_null(void** _state _CBOR_UNUSED) {
   float_ctrl = cbor_load(null_data, 1, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_null(float_ctrl));
@@ -76,7 +76,7 @@ static void test_null(void **_state _CBOR_UNUSED) {
 
 unsigned char undef_data[] = {0xF7};
 
-static void test_undef(void **_state _CBOR_UNUSED) {
+static void test_undef(void** _state _CBOR_UNUSED) {
   float_ctrl = cbor_load(undef_data, 1, &res);
   assert_true(cbor_isa_float_ctrl(float_ctrl));
   assert_true(cbor_is_undef(float_ctrl));
@@ -86,7 +86,7 @@ static void test_undef(void **_state _CBOR_UNUSED) {
 
 unsigned char bool_data[] = {0xF4, 0xF5};
 
-static void test_bool(void **_state _CBOR_UNUSED) {
+static void test_bool(void** _state _CBOR_UNUSED) {
   _CBOR_TEST_DISABLE_ASSERT({
     float_ctrl = cbor_load(bool_data, 1, &res);
     assert_true(cbor_isa_float_ctrl(float_ctrl));
@@ -110,7 +110,7 @@ static void test_bool(void **_state _CBOR_UNUSED) {
   });
 }
 
-static void test_float_ctrl_creation(void **_state _CBOR_UNUSED) {
+static void test_float_ctrl_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_ctrl()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_float2()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_float4()); });

--- a/test/fuzz_test.c
+++ b/test/fuzz_test.c
@@ -55,7 +55,7 @@ static void run_round(void) {
   free(data);
 }
 
-static void fuzz(void **_CBOR_UNUSED(_state)) {
+static void fuzz(void **_state _CBOR_UNUSED) {
   cbor_set_allocs(mock_malloc, realloc, free);
   printf("Fuzzing %llu rounds of up to %llu bytes with seed %u\n", ROUNDS,
          MAXLEN, seed);

--- a/test/fuzz_test.c
+++ b/test/fuzz_test.c
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef PRINT_FUZZ
-static void printmem(const unsigned char *ptr, size_t length) {
+static void printmem(const unsigned char* ptr, size_t length) {
   for (size_t i = 0; i < length; i++) printf("%02X", ptr[i]);
   printf("\n");
 }
@@ -26,7 +26,7 @@ static void printmem(const unsigned char *ptr, size_t length) {
 
 unsigned seed;
 
-void *mock_malloc(size_t size) {
+void* mock_malloc(size_t size) {
   if (size > (1 << 19))
     return NULL;
   else
@@ -34,11 +34,11 @@ void *mock_malloc(size_t size) {
 }
 
 static void run_round(void) {
-  cbor_item_t *item;
+  cbor_item_t* item;
   struct cbor_load_result res;
 
   size_t length = rand() % MAXLEN + 1;
-  unsigned char *data = malloc(length);
+  unsigned char* data = malloc(length);
   for (size_t i = 0; i < length; i++) {
     data[i] = rand() % 0xFF;
   }
@@ -55,7 +55,7 @@ static void run_round(void) {
   free(data);
 }
 
-static void fuzz(void **_state _CBOR_UNUSED) {
+static void fuzz(void** _state _CBOR_UNUSED) {
   cbor_set_allocs(mock_malloc, realloc, free);
   printf("Fuzzing %llu rounds of up to %llu bytes with seed %u\n", ROUNDS,
          MAXLEN, seed);
@@ -67,7 +67,7 @@ static void fuzz(void **_state _CBOR_UNUSED) {
          (ROUNDS * MAXLEN) / 1024);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   if (argc > 1)
     seed = (unsigned)strtoul(argv[1], NULL, 10);
   else

--- a/test/map_encoders_test.c
+++ b/test/map_encoders_test.c
@@ -10,18 +10,18 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_map_start(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_map_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_map_start(1, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xA1}), 1);
 }
 
-static void test_map_start(void **_CBOR_UNUSED(_state)) {
+static void test_map_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_map_start(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xBA, 0x00, 0x0F, 0x42, 0x40}),
                       5);
 }
 
-static void test_indef_map_start(void **_CBOR_UNUSED(_state)) {
+static void test_indef_map_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_indef_map_start(buffer, 512));
   assert_size_equal(0, cbor_encode_indef_map_start(buffer, 0));
   assert_memory_equal(buffer, ((unsigned char[]){0xBF}), 1);

--- a/test/map_test.c
+++ b/test/map_test.c
@@ -22,7 +22,7 @@ struct cbor_load_result res;
 
 unsigned char empty_map[] = {0xA0};
 
-static void test_empty_map(void **_CBOR_UNUSED(_state)) {
+static void test_empty_map(void **_state _CBOR_UNUSED) {
   map = cbor_load(empty_map, 1, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -37,7 +37,7 @@ static void test_empty_map(void **_CBOR_UNUSED(_state)) {
 unsigned char simple_map[] = {0xA2, 0x01, 0x02, 0x03, 0x04};
 
 /* {1: 2, 3: 4} */
-static void test_simple_map(void **_CBOR_UNUSED(_state)) {
+static void test_simple_map(void **_state _CBOR_UNUSED) {
   map = cbor_load(simple_map, 5, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -57,7 +57,7 @@ static void test_simple_map(void **_CBOR_UNUSED(_state)) {
 unsigned char simple_indef_map[] = {0xBF, 0x01, 0x02, 0x03, 0x04, 0xFF};
 
 /* {_ 1: 2, 3: 4} */
-static void test_indef_simple_map(void **_CBOR_UNUSED(_state)) {
+static void test_indef_simple_map(void **_state _CBOR_UNUSED) {
   map = cbor_load(simple_indef_map, 6, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -84,7 +84,7 @@ unsigned char def_nested_map[] = {
     0x74, 0x69, 0x74, 0x6C, 0x65, 0x70, 0x65, 0x78, 0x61, 0x6D, 0x70, 0x6C,
     0x65, 0x20, 0x67, 0x6C, 0x6F, 0x73, 0x73, 0x61, 0x72, 0x79};
 
-static void test_def_nested_map(void **_CBOR_UNUSED(_state)) {
+static void test_def_nested_map(void **_state _CBOR_UNUSED) {
   map = cbor_load(def_nested_map, 34, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -108,7 +108,7 @@ unsigned char streamed_key_map[] = {0xA1, 0x7F, 0x61, 0x61,
                                     0x61, 0x62, 0xFF, 0xA0};
 
 /* '{ (_"a" "b"): {}}' */
-static void test_streamed_key_map(void **_CBOR_UNUSED(_state)) {
+static void test_streamed_key_map(void **_state _CBOR_UNUSED) {
   map = cbor_load(streamed_key_map, 8, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -130,7 +130,7 @@ unsigned char streamed_kv_map[] = {0xA1, 0x7F, 0x61, 0x61, 0x61, 0x62, 0xFF,
                                    0x7F, 0x61, 0x63, 0x61, 0x64, 0xFF};
 
 /* '{ (_"a" "b"): (_"c", "d")}' */
-static void test_streamed_kv_map(void **_CBOR_UNUSED(_state)) {
+static void test_streamed_kv_map(void **_state _CBOR_UNUSED) {
   map = cbor_load(streamed_kv_map, 13, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -157,7 +157,7 @@ unsigned char streamed_streamed_kv_map[] = {0xBF, 0x7F, 0x61, 0x61, 0x61,
                                             0x61, 0x64, 0xFF, 0xFF};
 
 /* '{_ (_"a" "b"): (_"c", "d")}' */
-static void test_streamed_streamed_kv_map(void **_CBOR_UNUSED(_state)) {
+static void test_streamed_streamed_kv_map(void **_state _CBOR_UNUSED) {
   map = cbor_load(streamed_streamed_kv_map, 14, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -179,7 +179,7 @@ static void test_streamed_streamed_kv_map(void **_CBOR_UNUSED(_state)) {
   assert_null(map);
 }
 
-static void test_map_add_full(void **_CBOR_UNUSED(_state)) {
+static void test_map_add_full(void **_state _CBOR_UNUSED) {
   map = cbor_new_definite_map(0);
   cbor_item_t *one = cbor_build_uint8(1);
   cbor_item_t *two = cbor_build_uint8(2);
@@ -191,7 +191,7 @@ static void test_map_add_full(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&two);
 }
 
-static void test_map_add_too_big_to_realloc(void **_CBOR_UNUSED(_state)) {
+static void test_map_add_too_big_to_realloc(void **_state _CBOR_UNUSED) {
   map = cbor_new_indefinite_map();
   struct _cbor_map_metadata *metadata =
       (struct _cbor_map_metadata *)&map->metadata;
@@ -210,7 +210,7 @@ static void test_map_add_too_big_to_realloc(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&two);
 }
 
-static void test_map_creation(void **_CBOR_UNUSED(_state)) {
+static void test_map_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_map(42)); });
   WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_map(42)); }, 2, MALLOC,
                    MALLOC_FAIL);
@@ -218,7 +218,7 @@ static void test_map_creation(void **_CBOR_UNUSED(_state)) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_map()); });
 }
 
-static void test_map_add(void **_CBOR_UNUSED(_state)) {
+static void test_map_add(void **_state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
         cbor_item_t *map = cbor_new_indefinite_map();
@@ -238,7 +238,7 @@ static void test_map_add(void **_CBOR_UNUSED(_state)) {
 }
 
 static unsigned char test_indef_map[] = {0xBF, 0x01, 0x02, 0x03, 0x04, 0xFF};
-static void test_indef_map_decode(void **_CBOR_UNUSED(_state)) {
+static void test_indef_map_decode(void **_state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
         cbor_item_t *map;

--- a/test/map_test.c
+++ b/test/map_test.c
@@ -17,12 +17,12 @@
 #include "cbor.h"
 #include "test_allocator.h"
 
-cbor_item_t *map;
+cbor_item_t* map;
 struct cbor_load_result res;
 
 unsigned char empty_map[] = {0xA0};
 
-static void test_empty_map(void **_state _CBOR_UNUSED) {
+static void test_empty_map(void** _state _CBOR_UNUSED) {
   map = cbor_load(empty_map, 1, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -37,7 +37,7 @@ static void test_empty_map(void **_state _CBOR_UNUSED) {
 unsigned char simple_map[] = {0xA2, 0x01, 0x02, 0x03, 0x04};
 
 /* {1: 2, 3: 4} */
-static void test_simple_map(void **_state _CBOR_UNUSED) {
+static void test_simple_map(void** _state _CBOR_UNUSED) {
   map = cbor_load(simple_map, 5, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -45,7 +45,7 @@ static void test_simple_map(void **_state _CBOR_UNUSED) {
   assert_true(cbor_map_is_definite(map));
   assert_true(cbor_map_size(map) == 2);
   assert_true(res.read == 5);
-  struct cbor_pair *handle = cbor_map_handle(map);
+  struct cbor_pair* handle = cbor_map_handle(map);
   assert_uint8(handle[0].key, 1);
   assert_uint8(handle[0].value, 2);
   assert_uint8(handle[1].key, 3);
@@ -57,7 +57,7 @@ static void test_simple_map(void **_state _CBOR_UNUSED) {
 unsigned char simple_indef_map[] = {0xBF, 0x01, 0x02, 0x03, 0x04, 0xFF};
 
 /* {_ 1: 2, 3: 4} */
-static void test_indef_simple_map(void **_state _CBOR_UNUSED) {
+static void test_indef_simple_map(void** _state _CBOR_UNUSED) {
   map = cbor_load(simple_indef_map, 6, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -65,7 +65,7 @@ static void test_indef_simple_map(void **_state _CBOR_UNUSED) {
   assert_true(cbor_map_is_indefinite(map));
   assert_true(cbor_map_size(map) == 2);
   assert_true(res.read == 6);
-  struct cbor_pair *handle = cbor_map_handle(map);
+  struct cbor_pair* handle = cbor_map_handle(map);
   assert_uint8(handle[0].key, 1);
   assert_uint8(handle[0].value, 2);
   assert_uint8(handle[1].key, 3);
@@ -84,7 +84,7 @@ unsigned char def_nested_map[] = {
     0x74, 0x69, 0x74, 0x6C, 0x65, 0x70, 0x65, 0x78, 0x61, 0x6D, 0x70, 0x6C,
     0x65, 0x20, 0x67, 0x6C, 0x6F, 0x73, 0x73, 0x61, 0x72, 0x79};
 
-static void test_def_nested_map(void **_state _CBOR_UNUSED) {
+static void test_def_nested_map(void** _state _CBOR_UNUSED) {
   map = cbor_load(def_nested_map, 34, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -92,10 +92,10 @@ static void test_def_nested_map(void **_state _CBOR_UNUSED) {
   assert_true(cbor_map_is_definite(map));
   assert_true(cbor_map_size(map) == 1);
   assert_true(res.read == 34);
-  struct cbor_pair *handle = cbor_map_handle(map);
+  struct cbor_pair* handle = cbor_map_handle(map);
   assert_true(cbor_typeof(handle[0].key) == CBOR_TYPE_STRING);
   assert_true(cbor_typeof(handle[0].value) == CBOR_TYPE_MAP);
-  struct cbor_pair *inner_handle = cbor_map_handle(handle[0].value);
+  struct cbor_pair* inner_handle = cbor_map_handle(handle[0].value);
   assert_true(cbor_typeof(inner_handle[0].key) == CBOR_TYPE_STRING);
   assert_true(cbor_typeof(inner_handle[0].value) == CBOR_TYPE_STRING);
   assert_memory_equal(cbor_string_handle(inner_handle[0].value),
@@ -108,7 +108,7 @@ unsigned char streamed_key_map[] = {0xA1, 0x7F, 0x61, 0x61,
                                     0x61, 0x62, 0xFF, 0xA0};
 
 /* '{ (_"a" "b"): {}}' */
-static void test_streamed_key_map(void **_state _CBOR_UNUSED) {
+static void test_streamed_key_map(void** _state _CBOR_UNUSED) {
   map = cbor_load(streamed_key_map, 8, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -116,7 +116,7 @@ static void test_streamed_key_map(void **_state _CBOR_UNUSED) {
   assert_true(cbor_map_is_definite(map));
   assert_true(cbor_map_size(map) == 1);
   assert_true(res.read == 8);
-  struct cbor_pair *handle = cbor_map_handle(map);
+  struct cbor_pair* handle = cbor_map_handle(map);
   assert_true(cbor_typeof(handle[0].key) == CBOR_TYPE_STRING);
   assert_true(cbor_string_is_indefinite(handle[0].key));
   assert_size_equal(cbor_string_chunk_count(handle[0].key), 2);
@@ -130,7 +130,7 @@ unsigned char streamed_kv_map[] = {0xA1, 0x7F, 0x61, 0x61, 0x61, 0x62, 0xFF,
                                    0x7F, 0x61, 0x63, 0x61, 0x64, 0xFF};
 
 /* '{ (_"a" "b"): (_"c", "d")}' */
-static void test_streamed_kv_map(void **_state _CBOR_UNUSED) {
+static void test_streamed_kv_map(void** _state _CBOR_UNUSED) {
   map = cbor_load(streamed_kv_map, 13, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -138,7 +138,7 @@ static void test_streamed_kv_map(void **_state _CBOR_UNUSED) {
   assert_true(cbor_map_is_definite(map));
   assert_size_equal(cbor_map_size(map), 1);
   assert_size_equal(res.read, 13);
-  struct cbor_pair *handle = cbor_map_handle(map);
+  struct cbor_pair* handle = cbor_map_handle(map);
   assert_true(cbor_typeof(handle[0].key) == CBOR_TYPE_STRING);
   assert_true(cbor_string_is_indefinite(handle[0].key));
   assert_size_equal(cbor_string_chunk_count(handle[0].key), 2);
@@ -157,7 +157,7 @@ unsigned char streamed_streamed_kv_map[] = {0xBF, 0x7F, 0x61, 0x61, 0x61,
                                             0x61, 0x64, 0xFF, 0xFF};
 
 /* '{_ (_"a" "b"): (_"c", "d")}' */
-static void test_streamed_streamed_kv_map(void **_state _CBOR_UNUSED) {
+static void test_streamed_streamed_kv_map(void** _state _CBOR_UNUSED) {
   map = cbor_load(streamed_streamed_kv_map, 14, &res);
   assert_non_null(map);
   assert_true(cbor_typeof(map) == CBOR_TYPE_MAP);
@@ -165,7 +165,7 @@ static void test_streamed_streamed_kv_map(void **_state _CBOR_UNUSED) {
   assert_true(cbor_map_is_indefinite(map));
   assert_size_equal(cbor_map_size(map), 1);
   assert_size_equal(res.read, 14);
-  struct cbor_pair *handle = cbor_map_handle(map);
+  struct cbor_pair* handle = cbor_map_handle(map);
   assert_true(cbor_typeof(handle[0].key) == CBOR_TYPE_STRING);
   assert_true(cbor_string_is_indefinite(handle[0].key));
   assert_size_equal(cbor_string_chunk_count(handle[0].key), 2);
@@ -179,10 +179,10 @@ static void test_streamed_streamed_kv_map(void **_state _CBOR_UNUSED) {
   assert_null(map);
 }
 
-static void test_map_add_full(void **_state _CBOR_UNUSED) {
+static void test_map_add_full(void** _state _CBOR_UNUSED) {
   map = cbor_new_definite_map(0);
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
 
   assert_false(cbor_map_add(map, (struct cbor_pair){.key = one, .value = two}));
 
@@ -191,15 +191,15 @@ static void test_map_add_full(void **_state _CBOR_UNUSED) {
   cbor_decref(&two);
 }
 
-static void test_map_add_too_big_to_realloc(void **_state _CBOR_UNUSED) {
+static void test_map_add_too_big_to_realloc(void** _state _CBOR_UNUSED) {
   map = cbor_new_indefinite_map();
-  struct _cbor_map_metadata *metadata =
-      (struct _cbor_map_metadata *)&map->metadata;
+  struct _cbor_map_metadata* metadata =
+      (struct _cbor_map_metadata*)&map->metadata;
   // Pretend we already have a huge memory block
   metadata->allocated = SIZE_MAX;
   metadata->end_ptr = SIZE_MAX;
-  cbor_item_t *one = cbor_build_uint8(1);
-  cbor_item_t *two = cbor_build_uint8(2);
+  cbor_item_t* one = cbor_build_uint8(1);
+  cbor_item_t* two = cbor_build_uint8(2);
 
   assert_false(cbor_map_add(map, (struct cbor_pair){.key = one, .value = two}));
 
@@ -210,7 +210,7 @@ static void test_map_add_too_big_to_realloc(void **_state _CBOR_UNUSED) {
   cbor_decref(&two);
 }
 
-static void test_map_creation(void **_state _CBOR_UNUSED) {
+static void test_map_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_map(42)); });
   WITH_MOCK_MALLOC({ assert_null(cbor_new_definite_map(42)); }, 2, MALLOC,
                    MALLOC_FAIL);
@@ -218,12 +218,12 @@ static void test_map_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_map()); });
 }
 
-static void test_map_add(void **_state _CBOR_UNUSED) {
+static void test_map_add(void** _state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
-        cbor_item_t *map = cbor_new_indefinite_map();
-        cbor_item_t *key = cbor_build_uint8(0);
-        cbor_item_t *value = cbor_build_bool(true);
+        cbor_item_t* map = cbor_new_indefinite_map();
+        cbor_item_t* key = cbor_build_uint8(0);
+        cbor_item_t* value = cbor_build_bool(true);
 
         assert_false(
             cbor_map_add(map, (struct cbor_pair){.key = key, .value = value}));
@@ -238,10 +238,10 @@ static void test_map_add(void **_state _CBOR_UNUSED) {
 }
 
 static unsigned char test_indef_map[] = {0xBF, 0x01, 0x02, 0x03, 0x04, 0xFF};
-static void test_indef_map_decode(void **_state _CBOR_UNUSED) {
+static void test_indef_map_decode(void** _state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
-        cbor_item_t *map;
+        cbor_item_t* map;
         struct cbor_load_result res;
         map = cbor_load(test_indef_map, 6, &res);
 

--- a/test/memory_utils_test.c
+++ b/test/memory_utils_test.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include "assertions.h"
 
-static void test_safe_multiply(void **_state _CBOR_UNUSED) {
+static void test_safe_multiply(void** _state _CBOR_UNUSED) {
   assert_true(_cbor_safe_to_multiply(1, 1));
   assert_true(_cbor_safe_to_multiply(SIZE_MAX, 0));
   assert_true(_cbor_safe_to_multiply(SIZE_MAX, 1));
@@ -17,7 +17,7 @@ static void test_safe_multiply(void **_state _CBOR_UNUSED) {
   assert_false(_cbor_safe_to_multiply(SIZE_MAX, SIZE_MAX));
 }
 
-static void test_safe_add(void **_state _CBOR_UNUSED) {
+static void test_safe_add(void** _state _CBOR_UNUSED) {
   assert_true(_cbor_safe_to_add(1, 1));
   assert_true(_cbor_safe_to_add(SIZE_MAX - 1, 1));
   assert_true(_cbor_safe_to_add(SIZE_MAX, 0));
@@ -28,7 +28,7 @@ static void test_safe_add(void **_state _CBOR_UNUSED) {
   assert_false(_cbor_safe_to_add(SIZE_MAX - 1, SIZE_MAX - 1));
 }
 
-static void test_safe_signalling_add(void **_state _CBOR_UNUSED) {
+static void test_safe_signalling_add(void** _state _CBOR_UNUSED) {
   assert_size_equal(_cbor_safe_signaling_add(1, 2), 3);
   assert_size_equal(_cbor_safe_signaling_add(0, 1), 0);
   assert_size_equal(_cbor_safe_signaling_add(0, SIZE_MAX), 0);
@@ -36,8 +36,8 @@ static void test_safe_signalling_add(void **_state _CBOR_UNUSED) {
   assert_size_equal(_cbor_safe_signaling_add(1, SIZE_MAX - 1), SIZE_MAX);
 }
 
-static void test_realloc_multiple(void **_state _CBOR_UNUSED) {
-  unsigned char *data = malloc(1);
+static void test_realloc_multiple(void** _state _CBOR_UNUSED) {
+  unsigned char* data = malloc(1);
   data[0] = 0x2a;
 
   data = _cbor_realloc_multiple(data, /*item_size=*/1, /*item_count=*/10);

--- a/test/memory_utils_test.c
+++ b/test/memory_utils_test.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include "assertions.h"
 
-static void test_safe_multiply(void **_CBOR_UNUSED(_state)) {
+static void test_safe_multiply(void **_state _CBOR_UNUSED) {
   assert_true(_cbor_safe_to_multiply(1, 1));
   assert_true(_cbor_safe_to_multiply(SIZE_MAX, 0));
   assert_true(_cbor_safe_to_multiply(SIZE_MAX, 1));
@@ -17,7 +17,7 @@ static void test_safe_multiply(void **_CBOR_UNUSED(_state)) {
   assert_false(_cbor_safe_to_multiply(SIZE_MAX, SIZE_MAX));
 }
 
-static void test_safe_add(void **_CBOR_UNUSED(_state)) {
+static void test_safe_add(void **_state _CBOR_UNUSED) {
   assert_true(_cbor_safe_to_add(1, 1));
   assert_true(_cbor_safe_to_add(SIZE_MAX - 1, 1));
   assert_true(_cbor_safe_to_add(SIZE_MAX, 0));
@@ -28,7 +28,7 @@ static void test_safe_add(void **_CBOR_UNUSED(_state)) {
   assert_false(_cbor_safe_to_add(SIZE_MAX - 1, SIZE_MAX - 1));
 }
 
-static void test_safe_signalling_add(void **_CBOR_UNUSED(_state)) {
+static void test_safe_signalling_add(void **_state _CBOR_UNUSED) {
   assert_size_equal(_cbor_safe_signaling_add(1, 2), 3);
   assert_size_equal(_cbor_safe_signaling_add(0, 1), 0);
   assert_size_equal(_cbor_safe_signaling_add(0, SIZE_MAX), 0);
@@ -36,7 +36,7 @@ static void test_safe_signalling_add(void **_CBOR_UNUSED(_state)) {
   assert_size_equal(_cbor_safe_signaling_add(1, SIZE_MAX - 1), SIZE_MAX);
 }
 
-static void test_realloc_multiple(void **_CBOR_UNUSED(_state)) {
+static void test_realloc_multiple(void **_state _CBOR_UNUSED) {
   unsigned char *data = malloc(1);
   data[0] = 0x2a;
 

--- a/test/negint_encoders_test.c
+++ b/test/negint_encoders_test.c
@@ -10,31 +10,31 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_negint8(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_negint8(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_negint8(14, buffer, 512));
   assert_memory_equal(buffer, (unsigned char[]){0x2E}, 1);
 }
 
-static void test_negint8(void **_CBOR_UNUSED(_state)) {
+static void test_negint8(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_negint8(180, buffer, 1));
   assert_size_equal(2, cbor_encode_negint8(255, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x38, 0xFF}), 2);
 }
 
-static void test_negint16(void **_CBOR_UNUSED(_state)) {
+static void test_negint16(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_negint16(1000, buffer, 2));
   assert_size_equal(3, cbor_encode_negint16(1000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x39, 0x03, 0xE8}), 3);
 }
 
-static void test_negint32(void **_CBOR_UNUSED(_state)) {
+static void test_negint32(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_negint32(1000000, buffer, 4));
   assert_size_equal(5, cbor_encode_negint32(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x3A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
 }
 
-static void test_negint64(void **_CBOR_UNUSED(_state)) {
+static void test_negint64(void** _state _CBOR_UNUSED) {
   assert_size_equal(0,
                     cbor_encode_negint64(18446744073709551615ULL, buffer, 8));
   assert_size_equal(9,
@@ -45,7 +45,7 @@ static void test_negint64(void **_CBOR_UNUSED(_state)) {
       9);
 }
 
-static void test_unspecified(void **_CBOR_UNUSED(_state)) {
+static void test_unspecified(void** _state _CBOR_UNUSED) {
   assert_size_equal(9,
                     cbor_encode_negint(18446744073709551615ULL, buffer, 512));
   assert_memory_equal(

--- a/test/negint_test.c
+++ b/test/negint_test.c
@@ -9,7 +9,7 @@
 #include "cbor.h"
 #include "test_allocator.h"
 
-cbor_item_t *number;
+cbor_item_t* number;
 struct cbor_load_result res;
 
 unsigned char data1[] = {0x22, 0xFF};
@@ -19,7 +19,7 @@ unsigned char data4[] = {0x3a, 0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 unsigned char data5[] = {0x3b, 0xa5, 0xf7, 0x02, 0xb3,
                          0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 
-static void test_very_short_int(void **_state _CBOR_UNUSED) {
+static void test_very_short_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data1, 2, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -33,7 +33,7 @@ static void test_very_short_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_short_int(void **_state _CBOR_UNUSED) {
+static void test_short_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data2, 3, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -47,7 +47,7 @@ static void test_short_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_half_int(void **_state _CBOR_UNUSED) {
+static void test_half_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data3, 5, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_16);
@@ -61,7 +61,7 @@ static void test_half_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_int(void **_state _CBOR_UNUSED) {
+static void test_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data4, 6, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_32);
@@ -75,7 +75,7 @@ static void test_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_long_int(void **_state _CBOR_UNUSED) {
+static void test_long_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data5, 10, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_64);
@@ -89,7 +89,7 @@ static void test_long_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_int_creation(void **_state _CBOR_UNUSED) {
+static void test_int_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int8()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int16()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int32()); });

--- a/test/negint_test.c
+++ b/test/negint_test.c
@@ -19,7 +19,7 @@ unsigned char data4[] = {0x3a, 0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 unsigned char data5[] = {0x3b, 0xa5, 0xf7, 0x02, 0xb3,
                          0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 
-static void test_very_short_int(void **_CBOR_UNUSED(_state)) {
+static void test_very_short_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data1, 2, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -33,7 +33,7 @@ static void test_very_short_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_short_int(void **_CBOR_UNUSED(_state)) {
+static void test_short_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data2, 3, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -47,7 +47,7 @@ static void test_short_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_half_int(void **_CBOR_UNUSED(_state)) {
+static void test_half_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data3, 5, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_16);
@@ -61,7 +61,7 @@ static void test_half_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_int(void **_CBOR_UNUSED(_state)) {
+static void test_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data4, 6, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_32);
@@ -75,7 +75,7 @@ static void test_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_long_int(void **_CBOR_UNUSED(_state)) {
+static void test_long_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data5, 10, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_NEGINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_64);
@@ -89,7 +89,7 @@ static void test_long_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_int_creation(void **_CBOR_UNUSED(_state)) {
+static void test_int_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int8()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int16()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int32()); });

--- a/test/pretty_printer_test.c
+++ b/test/pretty_printer_test.c
@@ -11,17 +11,17 @@
 #include "assertions.h"
 #include "cbor.h"
 
-void assert_describe_result(cbor_item_t *item, char *expected_result) {
+void assert_describe_result(cbor_item_t* item, char* expected_result) {
 #if CBOR_PRETTY_PRINTER
   // We know the expected size based on `expected_result`, but read everything
   // in order to get the full actual output in a useful error message.
   const size_t buffer_size = 512;
-  FILE *outfile = tmpfile();
+  FILE* outfile = tmpfile();
   cbor_describe(item, outfile);
   rewind(outfile);
   // Treat string as null-terminated since cmocka doesn't have asserts
   // for explicit length strings.
-  char *output = malloc(buffer_size);
+  char* output = malloc(buffer_size);
   assert_non_null(output);
   size_t output_size = fread(output, sizeof(char), buffer_size, outfile);
   output[output_size] = '\0';
@@ -32,31 +32,31 @@ void assert_describe_result(cbor_item_t *item, char *expected_result) {
 #endif
 }
 
-static void test_uint(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_build_uint8(42);
+static void test_uint(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_build_uint8(42);
   assert_describe_result(item, "[CBOR_TYPE_UINT] Width: 1B, Value: 42\n");
   cbor_decref(&item);
 }
 
-static void test_negint(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_build_negint16(40);
+static void test_negint(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_build_negint16(40);
   assert_describe_result(item,
                          "[CBOR_TYPE_NEGINT] Width: 2B, Value: -40 - 1\n");
   cbor_decref(&item);
 }
 
-static void test_definite_bytestring(void **_state _CBOR_UNUSED) {
+static void test_definite_bytestring(void** _state _CBOR_UNUSED) {
   unsigned char data[] = {0x01, 0x02, 0x03};
-  cbor_item_t *item = cbor_build_bytestring(data, 3);
+  cbor_item_t* item = cbor_build_bytestring(data, 3);
   assert_describe_result(item,
                          "[CBOR_TYPE_BYTESTRING] Definite, Length: 3B, Data:\n"
                          "    010203\n");
   cbor_decref(&item);
 }
 
-static void test_indefinite_bytestring(void **_state _CBOR_UNUSED) {
+static void test_indefinite_bytestring(void** _state _CBOR_UNUSED) {
   unsigned char data[] = {0x01, 0x02, 0x03};
-  cbor_item_t *item = cbor_new_indefinite_bytestring();
+  cbor_item_t* item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
       item, cbor_move(cbor_build_bytestring(data, 3))));
   assert_true(cbor_bytestring_add_chunk(
@@ -71,9 +71,9 @@ static void test_indefinite_bytestring(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_definite_string(void **_state _CBOR_UNUSED) {
-  char *string = "Hello!";
-  cbor_item_t *item = cbor_build_string(string);
+static void test_definite_string(void** _state _CBOR_UNUSED) {
+  char* string = "Hello!";
+  cbor_item_t* item = cbor_build_string(string);
   assert_describe_result(
       item,
       "[CBOR_TYPE_STRING] Definite, Length: 6B, Codepoints: 6, Data:\n"
@@ -81,9 +81,9 @@ static void test_definite_string(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_indefinite_string(void **_state _CBOR_UNUSED) {
-  char *string = "Hello!";
-  cbor_item_t *item = cbor_new_indefinite_string();
+static void test_indefinite_string(void** _state _CBOR_UNUSED) {
+  char* string = "Hello!";
+  cbor_item_t* item = cbor_new_indefinite_string();
   assert_true(
       cbor_string_add_chunk(item, cbor_move(cbor_build_string(string))));
   assert_true(
@@ -98,10 +98,10 @@ static void test_indefinite_string(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_multibyte_string(void **_state _CBOR_UNUSED) {
+static void test_multibyte_string(void** _state _CBOR_UNUSED) {
   // "Štěstíčko" in UTF-8
-  char *string = "\xc5\xa0t\xc4\x9bst\xc3\xad\xc4\x8dko";
-  cbor_item_t *item = cbor_build_string(string);
+  char* string = "\xc5\xa0t\xc4\x9bst\xc3\xad\xc4\x8dko";
+  cbor_item_t* item = cbor_build_string(string);
   assert_describe_result(
       item,
       "[CBOR_TYPE_STRING] Definite, Length: 13B, Codepoints: 9, Data:\n"
@@ -109,8 +109,8 @@ static void test_multibyte_string(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_definite_array(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_array(2);
+static void test_definite_array(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_array(2);
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(1))));
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(2))));
   assert_describe_result(item,
@@ -120,8 +120,8 @@ static void test_definite_array(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_indefinite_array(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_array();
+static void test_indefinite_array(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(1))));
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(2))));
   assert_describe_result(item,
@@ -131,8 +131,8 @@ static void test_indefinite_array(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_definite_map(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_definite_map(1);
+static void test_definite_map(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_definite_map(1);
   assert_true(cbor_map_add(
       item, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(1)),
                                .value = cbor_move(cbor_build_uint8(2))}));
@@ -144,8 +144,8 @@ static void test_definite_map(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_indefinite_map(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_map();
+static void test_indefinite_map(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_map();
   assert_true(cbor_map_add(
       item, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(1)),
                                .value = cbor_move(cbor_build_uint8(2))}));
@@ -157,16 +157,16 @@ static void test_indefinite_map(void **_state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
-static void test_tag(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_build_tag(42, cbor_move(cbor_build_uint8(1)));
+static void test_tag(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_build_tag(42, cbor_move(cbor_build_uint8(1)));
   assert_describe_result(item,
                          "[CBOR_TYPE_TAG] Value: 42\n"
                          "    [CBOR_TYPE_UINT] Width: 1B, Value: 1\n");
   cbor_decref(&item);
 }
 
-static void test_floats(void **_state _CBOR_UNUSED) {
-  cbor_item_t *item = cbor_new_indefinite_array();
+static void test_floats(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_bool(true))));
   assert_true(
       cbor_array_push(item, cbor_move(cbor_build_ctrl(CBOR_CTRL_UNDEF))));

--- a/test/pretty_printer_test.c
+++ b/test/pretty_printer_test.c
@@ -32,20 +32,20 @@ void assert_describe_result(cbor_item_t *item, char *expected_result) {
 #endif
 }
 
-static void test_uint(void **_CBOR_UNUSED(_state)) {
+static void test_uint(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_build_uint8(42);
   assert_describe_result(item, "[CBOR_TYPE_UINT] Width: 1B, Value: 42\n");
   cbor_decref(&item);
 }
 
-static void test_negint(void **_CBOR_UNUSED(_state)) {
+static void test_negint(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_build_negint16(40);
   assert_describe_result(item,
                          "[CBOR_TYPE_NEGINT] Width: 2B, Value: -40 - 1\n");
   cbor_decref(&item);
 }
 
-static void test_definite_bytestring(void **_CBOR_UNUSED(_state)) {
+static void test_definite_bytestring(void **_state _CBOR_UNUSED) {
   unsigned char data[] = {0x01, 0x02, 0x03};
   cbor_item_t *item = cbor_build_bytestring(data, 3);
   assert_describe_result(item,
@@ -54,7 +54,7 @@ static void test_definite_bytestring(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_indefinite_bytestring(void **_CBOR_UNUSED(_state)) {
+static void test_indefinite_bytestring(void **_state _CBOR_UNUSED) {
   unsigned char data[] = {0x01, 0x02, 0x03};
   cbor_item_t *item = cbor_new_indefinite_bytestring();
   assert_true(cbor_bytestring_add_chunk(
@@ -71,7 +71,7 @@ static void test_indefinite_bytestring(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_definite_string(void **_CBOR_UNUSED(_state)) {
+static void test_definite_string(void **_state _CBOR_UNUSED) {
   char *string = "Hello!";
   cbor_item_t *item = cbor_build_string(string);
   assert_describe_result(
@@ -81,7 +81,7 @@ static void test_definite_string(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_indefinite_string(void **_CBOR_UNUSED(_state)) {
+static void test_indefinite_string(void **_state _CBOR_UNUSED) {
   char *string = "Hello!";
   cbor_item_t *item = cbor_new_indefinite_string();
   assert_true(
@@ -98,7 +98,7 @@ static void test_indefinite_string(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_multibyte_string(void **_CBOR_UNUSED(_state)) {
+static void test_multibyte_string(void **_state _CBOR_UNUSED) {
   // "Štěstíčko" in UTF-8
   char *string = "\xc5\xa0t\xc4\x9bst\xc3\xad\xc4\x8dko";
   cbor_item_t *item = cbor_build_string(string);
@@ -109,7 +109,7 @@ static void test_multibyte_string(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_definite_array(void **_CBOR_UNUSED(_state)) {
+static void test_definite_array(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_array(2);
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(1))));
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(2))));
@@ -120,7 +120,7 @@ static void test_definite_array(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_indefinite_array(void **_CBOR_UNUSED(_state)) {
+static void test_indefinite_array(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(1))));
   assert_true(cbor_array_push(item, cbor_move(cbor_build_uint8(2))));
@@ -131,7 +131,7 @@ static void test_indefinite_array(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_definite_map(void **_CBOR_UNUSED(_state)) {
+static void test_definite_map(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_definite_map(1);
   assert_true(cbor_map_add(
       item, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(1)),
@@ -144,7 +144,7 @@ static void test_definite_map(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_indefinite_map(void **_CBOR_UNUSED(_state)) {
+static void test_indefinite_map(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_map();
   assert_true(cbor_map_add(
       item, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(1)),
@@ -157,7 +157,7 @@ static void test_indefinite_map(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_tag(void **_CBOR_UNUSED(_state)) {
+static void test_tag(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_build_tag(42, cbor_move(cbor_build_uint8(1)));
   assert_describe_result(item,
                          "[CBOR_TYPE_TAG] Value: 42\n"
@@ -165,7 +165,7 @@ static void test_tag(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&item);
 }
 
-static void test_floats(void **_CBOR_UNUSED(_state)) {
+static void test_floats(void **_state _CBOR_UNUSED) {
   cbor_item_t *item = cbor_new_indefinite_array();
   assert_true(cbor_array_push(item, cbor_move(cbor_build_bool(true))));
   assert_true(

--- a/test/stack_over_limit_test.c
+++ b/test/stack_over_limit_test.c
@@ -12,7 +12,7 @@ static size_t generate_overflow_data(unsigned char **overflow_data) {
   return CBOR_MAX_STACK_SIZE + 3;
 }
 
-static void test_stack_over_limit(void **_CBOR_UNUSED(_state)) {
+static void test_stack_over_limit(void **_state _CBOR_UNUSED) {
   unsigned char *overflow_data;
   size_t overflow_data_len;
   struct cbor_load_result res;

--- a/test/stack_over_limit_test.c
+++ b/test/stack_over_limit_test.c
@@ -1,9 +1,9 @@
 #include "assertions.h"
 #include "cbor.h"
 
-static size_t generate_overflow_data(unsigned char **overflow_data) {
+static size_t generate_overflow_data(unsigned char** overflow_data) {
   int i;
-  *overflow_data = (unsigned char *)malloc(CBOR_MAX_STACK_SIZE + 3);
+  *overflow_data = (unsigned char*)malloc(CBOR_MAX_STACK_SIZE + 3);
   for (i = 0; i < CBOR_MAX_STACK_SIZE + 1; i++) {
     (*overflow_data)[i] = 0xC2;  // tag of positive bignum
   }
@@ -12,8 +12,8 @@ static size_t generate_overflow_data(unsigned char **overflow_data) {
   return CBOR_MAX_STACK_SIZE + 3;
 }
 
-static void test_stack_over_limit(void **_state _CBOR_UNUSED) {
-  unsigned char *overflow_data;
+static void test_stack_over_limit(void** _state _CBOR_UNUSED) {
+  unsigned char* overflow_data;
   size_t overflow_data_len;
   struct cbor_load_result res;
   overflow_data_len = generate_overflow_data(&overflow_data);

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -25,7 +25,7 @@ void assert_uint8_eq(uint8_t actual) {
       UINT8_EQ, (union test_expectation_data){.int8 = actual}};
 }
 
-void uint8_callback(void *_CBOR_UNUSED(_context), uint8_t actual) {
+void uint8_callback(void *_CBOR_UNUSED _context, uint8_t actual) {
   assert_true(current().expectation == UINT8_EQ);
   assert_true(current().data.int8 == actual);
   current_expectation++;
@@ -36,7 +36,7 @@ void assert_uint16_eq(uint16_t actual) {
       UINT16_EQ, (union test_expectation_data){.int16 = actual}};
 }
 
-void uint16_callback(void *_CBOR_UNUSED(_context), uint16_t actual) {
+void uint16_callback(void *_CBOR_UNUSED _context, uint16_t actual) {
   assert_true(current().expectation == UINT16_EQ);
   assert_true(current().data.int16 == actual);
   current_expectation++;
@@ -47,7 +47,7 @@ void assert_uint32_eq(uint32_t actual) {
       UINT32_EQ, (union test_expectation_data){.int32 = actual}};
 }
 
-void uint32_callback(void *_CBOR_UNUSED(_context), uint32_t actual) {
+void uint32_callback(void *_CBOR_UNUSED _context, uint32_t actual) {
   assert_true(current().expectation == UINT32_EQ);
   assert_true(current().data.int32 == actual);
   current_expectation++;
@@ -58,7 +58,7 @@ void assert_uint64_eq(uint64_t actual) {
       UINT64_EQ, (union test_expectation_data){.int64 = actual}};
 }
 
-void uint64_callback(void *_CBOR_UNUSED(_context), uint64_t actual) {
+void uint64_callback(void *_CBOR_UNUSED _context, uint64_t actual) {
   assert_true(current().expectation == UINT64_EQ);
   assert_true(current().data.int64 == actual);
   current_expectation++;
@@ -69,7 +69,7 @@ void assert_negint8_eq(uint8_t actual) {
       NEGINT8_EQ, (union test_expectation_data){.int8 = actual}};
 }
 
-void negint8_callback(void *_CBOR_UNUSED(_context), uint8_t actual) {
+void negint8_callback(void *_CBOR_UNUSED _context, uint8_t actual) {
   assert_true(current().expectation == NEGINT8_EQ);
   assert_true(current().data.int8 == actual);
   current_expectation++;
@@ -80,7 +80,7 @@ void assert_negint16_eq(uint16_t actual) {
       NEGINT16_EQ, (union test_expectation_data){.int16 = actual}};
 }
 
-void negint16_callback(void *_CBOR_UNUSED(_context), uint16_t actual) {
+void negint16_callback(void *_CBOR_UNUSED _context, uint16_t actual) {
   assert_true(current().expectation == NEGINT16_EQ);
   assert_true(current().data.int16 == actual);
   current_expectation++;
@@ -91,7 +91,7 @@ void assert_negint32_eq(uint32_t actual) {
       NEGINT32_EQ, (union test_expectation_data){.int32 = actual}};
 }
 
-void negint32_callback(void *_CBOR_UNUSED(_context), uint32_t actual) {
+void negint32_callback(void *_CBOR_UNUSED _context, uint32_t actual) {
   assert_true(current().expectation == NEGINT32_EQ);
   assert_true(current().data.int32 == actual);
   current_expectation++;
@@ -102,7 +102,7 @@ void assert_negint64_eq(uint64_t actual) {
       NEGINT64_EQ, (union test_expectation_data){.int64 = actual}};
 }
 
-void negint64_callback(void *_CBOR_UNUSED(_context), uint64_t actual) {
+void negint64_callback(void *_CBOR_UNUSED _context, uint64_t actual) {
   assert_true(current().expectation == NEGINT64_EQ);
   assert_true(current().data.int64 == actual);
   current_expectation++;
@@ -114,7 +114,7 @@ void assert_bstring_mem_eq(cbor_data address, size_t length) {
       (union test_expectation_data){.string = {address, length}}};
 }
 
-void byte_string_callback(void *_CBOR_UNUSED(_context), cbor_data address,
+void byte_string_callback(void *_CBOR_UNUSED _context, cbor_data address,
                           uint64_t length) {
   assert_true(current().expectation == BSTRING_MEM_EQ);
   assert_true(current().data.string.address == address);
@@ -127,7 +127,7 @@ void assert_bstring_indef_start(void) {
       (struct test_assertion){.expectation = BSTRING_INDEF_START};
 }
 
-void byte_string_start_callback(void *_CBOR_UNUSED(_context)) {
+void byte_string_start_callback(void *_CBOR_UNUSED _context) {
   assert_true(current().expectation == BSTRING_INDEF_START);
   current_expectation++;
 }
@@ -138,7 +138,7 @@ void assert_string_mem_eq(cbor_data address, size_t length) {
       (union test_expectation_data){.string = {address, length}}};
 }
 
-void string_callback(void *_CBOR_UNUSED(_context), cbor_data address,
+void string_callback(void *_CBOR_UNUSED _context, cbor_data address,
                      uint64_t length) {
   assert_true(current().expectation == STRING_MEM_EQ);
   assert_true(current().data.string.address == address);
@@ -151,7 +151,7 @@ void assert_string_indef_start(void) {
       (struct test_assertion){.expectation = STRING_INDEF_START};
 }
 
-void string_start_callback(void *_CBOR_UNUSED(_context)) {
+void string_start_callback(void *_CBOR_UNUSED _context) {
   assert_true(current().expectation == STRING_INDEF_START);
   current_expectation++;
 }
@@ -161,7 +161,7 @@ void assert_indef_break(void) {
       (struct test_assertion){.expectation = INDEF_BREAK};
 }
 
-void indef_break_callback(void *_CBOR_UNUSED(_context)) {
+void indef_break_callback(void *_CBOR_UNUSED _context) {
   assert_true(current().expectation == INDEF_BREAK);
   current_expectation++;
 }
@@ -171,7 +171,7 @@ void assert_array_start(size_t length) {
       (struct test_assertion){ARRAY_START, {.length = length}};
 }
 
-void array_start_callback(void *_CBOR_UNUSED(_context), uint64_t length) {
+void array_start_callback(void *_CBOR_UNUSED _context, uint64_t length) {
   assert_true(current().expectation == ARRAY_START);
   assert_true(current().data.length == length);
   current_expectation++;
@@ -182,7 +182,7 @@ void assert_indef_array_start(void) {
       (struct test_assertion){.expectation = ARRAY_INDEF_START};
 }
 
-void indef_array_start_callback(void *_CBOR_UNUSED(_context)) {
+void indef_array_start_callback(void *_CBOR_UNUSED _context) {
   assert_true(current().expectation == ARRAY_INDEF_START);
   current_expectation++;
 }
@@ -192,7 +192,7 @@ void assert_map_start(size_t length) {
       (struct test_assertion){MAP_START, {.length = length}};
 }
 
-void map_start_callback(void *_CBOR_UNUSED(_context), uint64_t length) {
+void map_start_callback(void *_CBOR_UNUSED _context, uint64_t length) {
   assert_true(current().expectation == MAP_START);
   assert_true(current().data.length == length);
   current_expectation++;
@@ -203,7 +203,7 @@ void assert_indef_map_start(void) {
       (struct test_assertion){.expectation = MAP_INDEF_START};
 }
 
-void indef_map_start_callback(void *_CBOR_UNUSED(_context)) {
+void indef_map_start_callback(void *_CBOR_UNUSED _context) {
   assert_true(current().expectation == MAP_INDEF_START);
   current_expectation++;
 }
@@ -213,7 +213,7 @@ void assert_tag_eq(uint64_t value) {
       (struct test_assertion){TAG_EQ, {.int64 = value}};
 }
 
-void tag_callback(void *_CBOR_UNUSED(_context), uint64_t value) {
+void tag_callback(void *_CBOR_UNUSED _context, uint64_t value) {
   assert_true(current().expectation == TAG_EQ);
   assert_true(current().data.int64 == value);
   current_expectation++;
@@ -224,7 +224,7 @@ void assert_half(float value) {
       (struct test_assertion){HALF_EQ, {.float2 = value}};
 }
 
-void half_callback(void *_CBOR_UNUSED(_context), float actual) {
+void half_callback(void *_CBOR_UNUSED _context, float actual) {
   assert_true(current().expectation == HALF_EQ);
   assert_true(current().data.float2 == actual);
   current_expectation++;
@@ -235,7 +235,7 @@ void assert_float(float value) {
       (struct test_assertion){FLOAT_EQ, {.float4 = value}};
 }
 
-void float_callback(void *_CBOR_UNUSED(_context), float actual) {
+void float_callback(void *_CBOR_UNUSED _context, float actual) {
   assert_true(current().expectation == FLOAT_EQ);
   assert_true(current().data.float4 == actual);
   current_expectation++;
@@ -246,7 +246,7 @@ void assert_double(double value) {
       (struct test_assertion){DOUBLE_EQ, {.float8 = value}};
 }
 
-void double_callback(void *_CBOR_UNUSED(_context), double actual) {
+void double_callback(void *_CBOR_UNUSED _context, double actual) {
   assert_true(current().expectation == DOUBLE_EQ);
   assert_true(current().data.float8 == actual);
   current_expectation++;
@@ -266,18 +266,18 @@ void assert_undef(void) {
       (struct test_assertion){.expectation = UNDEF};
 }
 
-void bool_callback(void *_CBOR_UNUSED(_context), bool actual) {
+void bool_callback(void *_CBOR_UNUSED _context, bool actual) {
   assert_true(current().expectation == BOOL_EQ);
   assert_true(current().data.boolean == actual);
   current_expectation++;
 }
 
-void null_callback(void *_CBOR_UNUSED(_context)) {
+void null_callback(void *_CBOR_UNUSED _context) {
   assert_true(current().expectation == NIL);
   current_expectation++;
 }
 
-void undef_callback(void *_CBOR_UNUSED(_context)) {
+void undef_callback(void *_CBOR_UNUSED _context) {
   assert_true(current().expectation == UNDEF);
   current_expectation++;
 }

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -4,7 +4,7 @@ struct test_assertion assertions_queue[MAX_QUEUE_ITEMS];
 int queue_size = 0;
 int current_expectation = 0;
 
-int clean_up_stream_assertions(void **state) {
+int clean_up_stream_assertions(void** state) {
   if (queue_size != current_expectation) {
     return 1;  // We have not matched all expectations correctly
   }
@@ -25,7 +25,7 @@ void assert_uint8_eq(uint8_t actual) {
       UINT8_EQ, (union test_expectation_data){.int8 = actual}};
 }
 
-void uint8_callback(void *_context _CBOR_UNUSED, uint8_t actual) {
+void uint8_callback(void* _context _CBOR_UNUSED, uint8_t actual) {
   assert_true(current().expectation == UINT8_EQ);
   assert_true(current().data.int8 == actual);
   current_expectation++;
@@ -36,7 +36,7 @@ void assert_uint16_eq(uint16_t actual) {
       UINT16_EQ, (union test_expectation_data){.int16 = actual}};
 }
 
-void uint16_callback(void *_context _CBOR_UNUSED, uint16_t actual) {
+void uint16_callback(void* _context _CBOR_UNUSED, uint16_t actual) {
   assert_true(current().expectation == UINT16_EQ);
   assert_true(current().data.int16 == actual);
   current_expectation++;
@@ -47,7 +47,7 @@ void assert_uint32_eq(uint32_t actual) {
       UINT32_EQ, (union test_expectation_data){.int32 = actual}};
 }
 
-void uint32_callback(void *_context _CBOR_UNUSED, uint32_t actual) {
+void uint32_callback(void* _context _CBOR_UNUSED, uint32_t actual) {
   assert_true(current().expectation == UINT32_EQ);
   assert_true(current().data.int32 == actual);
   current_expectation++;
@@ -58,7 +58,7 @@ void assert_uint64_eq(uint64_t actual) {
       UINT64_EQ, (union test_expectation_data){.int64 = actual}};
 }
 
-void uint64_callback(void *_context _CBOR_UNUSED, uint64_t actual) {
+void uint64_callback(void* _context _CBOR_UNUSED, uint64_t actual) {
   assert_true(current().expectation == UINT64_EQ);
   assert_true(current().data.int64 == actual);
   current_expectation++;
@@ -69,7 +69,7 @@ void assert_negint8_eq(uint8_t actual) {
       NEGINT8_EQ, (union test_expectation_data){.int8 = actual}};
 }
 
-void negint8_callback(void *_context _CBOR_UNUSED, uint8_t actual) {
+void negint8_callback(void* _context _CBOR_UNUSED, uint8_t actual) {
   assert_true(current().expectation == NEGINT8_EQ);
   assert_true(current().data.int8 == actual);
   current_expectation++;
@@ -80,7 +80,7 @@ void assert_negint16_eq(uint16_t actual) {
       NEGINT16_EQ, (union test_expectation_data){.int16 = actual}};
 }
 
-void negint16_callback(void *_context _CBOR_UNUSED, uint16_t actual) {
+void negint16_callback(void* _context _CBOR_UNUSED, uint16_t actual) {
   assert_true(current().expectation == NEGINT16_EQ);
   assert_true(current().data.int16 == actual);
   current_expectation++;
@@ -91,7 +91,7 @@ void assert_negint32_eq(uint32_t actual) {
       NEGINT32_EQ, (union test_expectation_data){.int32 = actual}};
 }
 
-void negint32_callback(void *_context _CBOR_UNUSED, uint32_t actual) {
+void negint32_callback(void* _context _CBOR_UNUSED, uint32_t actual) {
   assert_true(current().expectation == NEGINT32_EQ);
   assert_true(current().data.int32 == actual);
   current_expectation++;
@@ -102,7 +102,7 @@ void assert_negint64_eq(uint64_t actual) {
       NEGINT64_EQ, (union test_expectation_data){.int64 = actual}};
 }
 
-void negint64_callback(void *_context _CBOR_UNUSED, uint64_t actual) {
+void negint64_callback(void* _context _CBOR_UNUSED, uint64_t actual) {
   assert_true(current().expectation == NEGINT64_EQ);
   assert_true(current().data.int64 == actual);
   current_expectation++;
@@ -114,7 +114,7 @@ void assert_bstring_mem_eq(cbor_data address, size_t length) {
       (union test_expectation_data){.string = {address, length}}};
 }
 
-void byte_string_callback(void *_context _CBOR_UNUSED, cbor_data address,
+void byte_string_callback(void* _context _CBOR_UNUSED, cbor_data address,
                           uint64_t length) {
   assert_true(current().expectation == BSTRING_MEM_EQ);
   assert_true(current().data.string.address == address);
@@ -127,7 +127,7 @@ void assert_bstring_indef_start(void) {
       (struct test_assertion){.expectation = BSTRING_INDEF_START};
 }
 
-void byte_string_start_callback(void *_context _CBOR_UNUSED) {
+void byte_string_start_callback(void* _context _CBOR_UNUSED) {
   assert_true(current().expectation == BSTRING_INDEF_START);
   current_expectation++;
 }
@@ -138,7 +138,7 @@ void assert_string_mem_eq(cbor_data address, size_t length) {
       (union test_expectation_data){.string = {address, length}}};
 }
 
-void string_callback(void *_context _CBOR_UNUSED, cbor_data address,
+void string_callback(void* _context _CBOR_UNUSED, cbor_data address,
                      uint64_t length) {
   assert_true(current().expectation == STRING_MEM_EQ);
   assert_true(current().data.string.address == address);
@@ -151,7 +151,7 @@ void assert_string_indef_start(void) {
       (struct test_assertion){.expectation = STRING_INDEF_START};
 }
 
-void string_start_callback(void *_context _CBOR_UNUSED) {
+void string_start_callback(void* _context _CBOR_UNUSED) {
   assert_true(current().expectation == STRING_INDEF_START);
   current_expectation++;
 }
@@ -161,7 +161,7 @@ void assert_indef_break(void) {
       (struct test_assertion){.expectation = INDEF_BREAK};
 }
 
-void indef_break_callback(void *_context _CBOR_UNUSED) {
+void indef_break_callback(void* _context _CBOR_UNUSED) {
   assert_true(current().expectation == INDEF_BREAK);
   current_expectation++;
 }
@@ -171,7 +171,7 @@ void assert_array_start(size_t length) {
       (struct test_assertion){ARRAY_START, {.length = length}};
 }
 
-void array_start_callback(void *_context _CBOR_UNUSED, uint64_t length) {
+void array_start_callback(void* _context _CBOR_UNUSED, uint64_t length) {
   assert_true(current().expectation == ARRAY_START);
   assert_true(current().data.length == length);
   current_expectation++;
@@ -182,7 +182,7 @@ void assert_indef_array_start(void) {
       (struct test_assertion){.expectation = ARRAY_INDEF_START};
 }
 
-void indef_array_start_callback(void *_context _CBOR_UNUSED) {
+void indef_array_start_callback(void* _context _CBOR_UNUSED) {
   assert_true(current().expectation == ARRAY_INDEF_START);
   current_expectation++;
 }
@@ -192,7 +192,7 @@ void assert_map_start(size_t length) {
       (struct test_assertion){MAP_START, {.length = length}};
 }
 
-void map_start_callback(void *_context _CBOR_UNUSED, uint64_t length) {
+void map_start_callback(void* _context _CBOR_UNUSED, uint64_t length) {
   assert_true(current().expectation == MAP_START);
   assert_true(current().data.length == length);
   current_expectation++;
@@ -203,7 +203,7 @@ void assert_indef_map_start(void) {
       (struct test_assertion){.expectation = MAP_INDEF_START};
 }
 
-void indef_map_start_callback(void *_context _CBOR_UNUSED) {
+void indef_map_start_callback(void* _context _CBOR_UNUSED) {
   assert_true(current().expectation == MAP_INDEF_START);
   current_expectation++;
 }
@@ -213,7 +213,7 @@ void assert_tag_eq(uint64_t value) {
       (struct test_assertion){TAG_EQ, {.int64 = value}};
 }
 
-void tag_callback(void *_context _CBOR_UNUSED, uint64_t value) {
+void tag_callback(void* _context _CBOR_UNUSED, uint64_t value) {
   assert_true(current().expectation == TAG_EQ);
   assert_true(current().data.int64 == value);
   current_expectation++;
@@ -224,7 +224,7 @@ void assert_half(float value) {
       (struct test_assertion){HALF_EQ, {.float2 = value}};
 }
 
-void half_callback(void *_context _CBOR_UNUSED, float actual) {
+void half_callback(void* _context _CBOR_UNUSED, float actual) {
   assert_true(current().expectation == HALF_EQ);
   assert_true(current().data.float2 == actual);
   current_expectation++;
@@ -235,7 +235,7 @@ void assert_float(float value) {
       (struct test_assertion){FLOAT_EQ, {.float4 = value}};
 }
 
-void float_callback(void *_context _CBOR_UNUSED, float actual) {
+void float_callback(void* _context _CBOR_UNUSED, float actual) {
   assert_true(current().expectation == FLOAT_EQ);
   assert_true(current().data.float4 == actual);
   current_expectation++;
@@ -246,7 +246,7 @@ void assert_double(double value) {
       (struct test_assertion){DOUBLE_EQ, {.float8 = value}};
 }
 
-void double_callback(void *_context _CBOR_UNUSED, double actual) {
+void double_callback(void* _context _CBOR_UNUSED, double actual) {
   assert_true(current().expectation == DOUBLE_EQ);
   assert_true(current().data.float8 == actual);
   current_expectation++;
@@ -266,18 +266,18 @@ void assert_undef(void) {
       (struct test_assertion){.expectation = UNDEF};
 }
 
-void bool_callback(void *_context _CBOR_UNUSED, bool actual) {
+void bool_callback(void* _context _CBOR_UNUSED, bool actual) {
   assert_true(current().expectation == BOOL_EQ);
   assert_true(current().data.boolean == actual);
   current_expectation++;
 }
 
-void null_callback(void *_context _CBOR_UNUSED) {
+void null_callback(void* _context _CBOR_UNUSED) {
   assert_true(current().expectation == NIL);
   current_expectation++;
 }
 
-void undef_callback(void *_context _CBOR_UNUSED) {
+void undef_callback(void* _context _CBOR_UNUSED) {
   assert_true(current().expectation == UNDEF);
   current_expectation++;
 }

--- a/test/stream_expectations.c
+++ b/test/stream_expectations.c
@@ -25,7 +25,7 @@ void assert_uint8_eq(uint8_t actual) {
       UINT8_EQ, (union test_expectation_data){.int8 = actual}};
 }
 
-void uint8_callback(void *_CBOR_UNUSED _context, uint8_t actual) {
+void uint8_callback(void *_context _CBOR_UNUSED, uint8_t actual) {
   assert_true(current().expectation == UINT8_EQ);
   assert_true(current().data.int8 == actual);
   current_expectation++;
@@ -36,7 +36,7 @@ void assert_uint16_eq(uint16_t actual) {
       UINT16_EQ, (union test_expectation_data){.int16 = actual}};
 }
 
-void uint16_callback(void *_CBOR_UNUSED _context, uint16_t actual) {
+void uint16_callback(void *_context _CBOR_UNUSED, uint16_t actual) {
   assert_true(current().expectation == UINT16_EQ);
   assert_true(current().data.int16 == actual);
   current_expectation++;
@@ -47,7 +47,7 @@ void assert_uint32_eq(uint32_t actual) {
       UINT32_EQ, (union test_expectation_data){.int32 = actual}};
 }
 
-void uint32_callback(void *_CBOR_UNUSED _context, uint32_t actual) {
+void uint32_callback(void *_context _CBOR_UNUSED, uint32_t actual) {
   assert_true(current().expectation == UINT32_EQ);
   assert_true(current().data.int32 == actual);
   current_expectation++;
@@ -58,7 +58,7 @@ void assert_uint64_eq(uint64_t actual) {
       UINT64_EQ, (union test_expectation_data){.int64 = actual}};
 }
 
-void uint64_callback(void *_CBOR_UNUSED _context, uint64_t actual) {
+void uint64_callback(void *_context _CBOR_UNUSED, uint64_t actual) {
   assert_true(current().expectation == UINT64_EQ);
   assert_true(current().data.int64 == actual);
   current_expectation++;
@@ -69,7 +69,7 @@ void assert_negint8_eq(uint8_t actual) {
       NEGINT8_EQ, (union test_expectation_data){.int8 = actual}};
 }
 
-void negint8_callback(void *_CBOR_UNUSED _context, uint8_t actual) {
+void negint8_callback(void *_context _CBOR_UNUSED, uint8_t actual) {
   assert_true(current().expectation == NEGINT8_EQ);
   assert_true(current().data.int8 == actual);
   current_expectation++;
@@ -80,7 +80,7 @@ void assert_negint16_eq(uint16_t actual) {
       NEGINT16_EQ, (union test_expectation_data){.int16 = actual}};
 }
 
-void negint16_callback(void *_CBOR_UNUSED _context, uint16_t actual) {
+void negint16_callback(void *_context _CBOR_UNUSED, uint16_t actual) {
   assert_true(current().expectation == NEGINT16_EQ);
   assert_true(current().data.int16 == actual);
   current_expectation++;
@@ -91,7 +91,7 @@ void assert_negint32_eq(uint32_t actual) {
       NEGINT32_EQ, (union test_expectation_data){.int32 = actual}};
 }
 
-void negint32_callback(void *_CBOR_UNUSED _context, uint32_t actual) {
+void negint32_callback(void *_context _CBOR_UNUSED, uint32_t actual) {
   assert_true(current().expectation == NEGINT32_EQ);
   assert_true(current().data.int32 == actual);
   current_expectation++;
@@ -102,7 +102,7 @@ void assert_negint64_eq(uint64_t actual) {
       NEGINT64_EQ, (union test_expectation_data){.int64 = actual}};
 }
 
-void negint64_callback(void *_CBOR_UNUSED _context, uint64_t actual) {
+void negint64_callback(void *_context _CBOR_UNUSED, uint64_t actual) {
   assert_true(current().expectation == NEGINT64_EQ);
   assert_true(current().data.int64 == actual);
   current_expectation++;
@@ -114,7 +114,7 @@ void assert_bstring_mem_eq(cbor_data address, size_t length) {
       (union test_expectation_data){.string = {address, length}}};
 }
 
-void byte_string_callback(void *_CBOR_UNUSED _context, cbor_data address,
+void byte_string_callback(void *_context _CBOR_UNUSED, cbor_data address,
                           uint64_t length) {
   assert_true(current().expectation == BSTRING_MEM_EQ);
   assert_true(current().data.string.address == address);
@@ -127,7 +127,7 @@ void assert_bstring_indef_start(void) {
       (struct test_assertion){.expectation = BSTRING_INDEF_START};
 }
 
-void byte_string_start_callback(void *_CBOR_UNUSED _context) {
+void byte_string_start_callback(void *_context _CBOR_UNUSED) {
   assert_true(current().expectation == BSTRING_INDEF_START);
   current_expectation++;
 }
@@ -138,7 +138,7 @@ void assert_string_mem_eq(cbor_data address, size_t length) {
       (union test_expectation_data){.string = {address, length}}};
 }
 
-void string_callback(void *_CBOR_UNUSED _context, cbor_data address,
+void string_callback(void *_context _CBOR_UNUSED, cbor_data address,
                      uint64_t length) {
   assert_true(current().expectation == STRING_MEM_EQ);
   assert_true(current().data.string.address == address);
@@ -151,7 +151,7 @@ void assert_string_indef_start(void) {
       (struct test_assertion){.expectation = STRING_INDEF_START};
 }
 
-void string_start_callback(void *_CBOR_UNUSED _context) {
+void string_start_callback(void *_context _CBOR_UNUSED) {
   assert_true(current().expectation == STRING_INDEF_START);
   current_expectation++;
 }
@@ -161,7 +161,7 @@ void assert_indef_break(void) {
       (struct test_assertion){.expectation = INDEF_BREAK};
 }
 
-void indef_break_callback(void *_CBOR_UNUSED _context) {
+void indef_break_callback(void *_context _CBOR_UNUSED) {
   assert_true(current().expectation == INDEF_BREAK);
   current_expectation++;
 }
@@ -171,7 +171,7 @@ void assert_array_start(size_t length) {
       (struct test_assertion){ARRAY_START, {.length = length}};
 }
 
-void array_start_callback(void *_CBOR_UNUSED _context, uint64_t length) {
+void array_start_callback(void *_context _CBOR_UNUSED, uint64_t length) {
   assert_true(current().expectation == ARRAY_START);
   assert_true(current().data.length == length);
   current_expectation++;
@@ -182,7 +182,7 @@ void assert_indef_array_start(void) {
       (struct test_assertion){.expectation = ARRAY_INDEF_START};
 }
 
-void indef_array_start_callback(void *_CBOR_UNUSED _context) {
+void indef_array_start_callback(void *_context _CBOR_UNUSED) {
   assert_true(current().expectation == ARRAY_INDEF_START);
   current_expectation++;
 }
@@ -192,7 +192,7 @@ void assert_map_start(size_t length) {
       (struct test_assertion){MAP_START, {.length = length}};
 }
 
-void map_start_callback(void *_CBOR_UNUSED _context, uint64_t length) {
+void map_start_callback(void *_context _CBOR_UNUSED, uint64_t length) {
   assert_true(current().expectation == MAP_START);
   assert_true(current().data.length == length);
   current_expectation++;
@@ -203,7 +203,7 @@ void assert_indef_map_start(void) {
       (struct test_assertion){.expectation = MAP_INDEF_START};
 }
 
-void indef_map_start_callback(void *_CBOR_UNUSED _context) {
+void indef_map_start_callback(void *_context _CBOR_UNUSED) {
   assert_true(current().expectation == MAP_INDEF_START);
   current_expectation++;
 }
@@ -213,7 +213,7 @@ void assert_tag_eq(uint64_t value) {
       (struct test_assertion){TAG_EQ, {.int64 = value}};
 }
 
-void tag_callback(void *_CBOR_UNUSED _context, uint64_t value) {
+void tag_callback(void *_context _CBOR_UNUSED, uint64_t value) {
   assert_true(current().expectation == TAG_EQ);
   assert_true(current().data.int64 == value);
   current_expectation++;
@@ -224,7 +224,7 @@ void assert_half(float value) {
       (struct test_assertion){HALF_EQ, {.float2 = value}};
 }
 
-void half_callback(void *_CBOR_UNUSED _context, float actual) {
+void half_callback(void *_context _CBOR_UNUSED, float actual) {
   assert_true(current().expectation == HALF_EQ);
   assert_true(current().data.float2 == actual);
   current_expectation++;
@@ -235,7 +235,7 @@ void assert_float(float value) {
       (struct test_assertion){FLOAT_EQ, {.float4 = value}};
 }
 
-void float_callback(void *_CBOR_UNUSED _context, float actual) {
+void float_callback(void *_context _CBOR_UNUSED, float actual) {
   assert_true(current().expectation == FLOAT_EQ);
   assert_true(current().data.float4 == actual);
   current_expectation++;
@@ -246,7 +246,7 @@ void assert_double(double value) {
       (struct test_assertion){DOUBLE_EQ, {.float8 = value}};
 }
 
-void double_callback(void *_CBOR_UNUSED _context, double actual) {
+void double_callback(void *_context _CBOR_UNUSED, double actual) {
   assert_true(current().expectation == DOUBLE_EQ);
   assert_true(current().data.float8 == actual);
   current_expectation++;
@@ -266,18 +266,18 @@ void assert_undef(void) {
       (struct test_assertion){.expectation = UNDEF};
 }
 
-void bool_callback(void *_CBOR_UNUSED _context, bool actual) {
+void bool_callback(void *_context _CBOR_UNUSED, bool actual) {
   assert_true(current().expectation == BOOL_EQ);
   assert_true(current().data.boolean == actual);
   current_expectation++;
 }
 
-void null_callback(void *_CBOR_UNUSED _context) {
+void null_callback(void *_context _CBOR_UNUSED) {
   assert_true(current().expectation == NIL);
   current_expectation++;
 }
 
-void undef_callback(void *_CBOR_UNUSED _context) {
+void undef_callback(void *_context _CBOR_UNUSED) {
   assert_true(current().expectation == UNDEF);
   current_expectation++;
 }

--- a/test/stream_expectations.h
+++ b/test/stream_expectations.h
@@ -78,7 +78,7 @@ struct test_assertion {
 struct cbor_decoder_result decode(cbor_data, size_t);
 
 /* Verify all assertions were applied and clean up */
-int clean_up_stream_assertions(void **);
+int clean_up_stream_assertions(void**);
 
 /* Assertions builders */
 void assert_uint8_eq(uint8_t);
@@ -116,37 +116,37 @@ void assert_undef(void);
 void assert_indef_break(void);
 
 /* Assertions verifying callbacks */
-void uint8_callback(void *, uint8_t);
-void uint16_callback(void *, uint16_t);
-void uint32_callback(void *, uint32_t);
-void uint64_callback(void *, uint64_t);
+void uint8_callback(void*, uint8_t);
+void uint16_callback(void*, uint16_t);
+void uint32_callback(void*, uint32_t);
+void uint64_callback(void*, uint64_t);
 
-void negint8_callback(void *, uint8_t);
-void negint16_callback(void *, uint16_t);
-void negint32_callback(void *, uint32_t);
-void negint64_callback(void *, uint64_t);
+void negint8_callback(void*, uint8_t);
+void negint16_callback(void*, uint16_t);
+void negint32_callback(void*, uint32_t);
+void negint64_callback(void*, uint64_t);
 
-void byte_string_callback(void *, cbor_data, uint64_t);
-void byte_string_start_callback(void *);
+void byte_string_callback(void*, cbor_data, uint64_t);
+void byte_string_start_callback(void*);
 
-void string_callback(void *, cbor_data, uint64_t);
-void string_start_callback(void *);
+void string_callback(void*, cbor_data, uint64_t);
+void string_start_callback(void*);
 
-void array_start_callback(void *, uint64_t);
-void indef_array_start_callback(void *);
+void array_start_callback(void*, uint64_t);
+void indef_array_start_callback(void*);
 
-void map_start_callback(void *, uint64_t);
-void indef_map_start_callback(void *);
+void map_start_callback(void*, uint64_t);
+void indef_map_start_callback(void*);
 
-void tag_callback(void *, uint64_t);
+void tag_callback(void*, uint64_t);
 
-void half_callback(void *, float);
-void float_callback(void *, float);
-void double_callback(void *, double);
-void indef_break_callback(void *);
+void half_callback(void*, float);
+void float_callback(void*, float);
+void double_callback(void*, double);
+void indef_break_callback(void*);
 
-void bool_callback(void *, bool);
-void null_callback(void *);
-void undef_callback(void *);
+void bool_callback(void*, bool);
+void null_callback(void*);
+void undef_callback(void*);
 
 #endif

--- a/test/string_encoders_test.c
+++ b/test/string_encoders_test.c
@@ -10,18 +10,18 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_string_start(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_string_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_string_start(1, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x61}), 1);
 }
 
-static void test_string_start(void **_CBOR_UNUSED(_state)) {
+static void test_string_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_string_start(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x7A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
 }
 
-static void test_indef_string_start(void **_CBOR_UNUSED(_state)) {
+static void test_indef_string_start(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_indef_string_start(buffer, 512));
   assert_size_equal(0, cbor_encode_indef_string_start(buffer, 0));
   assert_memory_equal(buffer, ((unsigned char[]){0x7F}), 1);

--- a/test/string_test.c
+++ b/test/string_test.c
@@ -15,7 +15,7 @@ struct cbor_load_result res;
 
 unsigned char empty_string_data[] = {0x60};
 
-static void test_empty_string(void **_CBOR_UNUSED(_state)) {
+static void test_empty_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(empty_string_data, 1, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -31,7 +31,7 @@ unsigned char short_string_data[] = {0x6C, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20,
                                      0x77, 0x6F, 0x72, 0x6C, 0x64, 0x21};
 
 /*                              0x60 + 12 | Hello world! */
-static void test_short_string(void **_CBOR_UNUSED(_state)) {
+static void test_short_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(short_string_data, 13, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -49,7 +49,7 @@ unsigned char short_multibyte_string_data[] = {
     0xC3, 0x9F, 0x76, 0xC4, 0x9B, 0x74, 0x65, 0x21};
 
 /*                              0x60 + 15 | Čaues ßvěte! */
-static void test_short_multibyte_string(void **_CBOR_UNUSED(_state)) {
+static void test_short_multibyte_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(short_multibyte_string_data, 16, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -78,7 +78,7 @@ unsigned char int8_string_data[] = {
     0x70, 0x6F, 0x73, 0x75, 0x65, 0x72, 0x65, 0x2E};
 
 /*                                          150 | Lorem ....*/
-static void test_int8_string(void **_CBOR_UNUSED(_state)) {
+static void test_int8_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(int8_string_data, 152, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -112,7 +112,7 @@ unsigned char int16_string_data[] = {
 /*                                          150 | Lorem ....*/
 /* This valid but not realistic - length 150 could be encoded in a single
  * uint8_t (but we need to keep the test files reasonably compact) */
-static void test_int16_string(void **_CBOR_UNUSED(_state)) {
+static void test_int16_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(int16_string_data, 153, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -145,7 +145,7 @@ unsigned char int32_string_data[] = {
     0x74, 0x6F, 0x20, 0x70, 0x6F, 0x73, 0x75, 0x65, 0x72, 0x65, 0x2E};
 
 /*                                          150 | Lorem ....*/
-static void test_int32_string(void **_CBOR_UNUSED(_state)) {
+static void test_int32_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(int32_string_data, 155, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -179,7 +179,7 @@ unsigned char int64_string_data[] = {
     0x72, 0x65, 0x2E};
 
 /*                                          150 | Lorem ....*/
-static void test_int64_string(void **_CBOR_UNUSED(_state)) {
+static void test_int64_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(int64_string_data, 159, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -201,7 +201,7 @@ unsigned char short_indef_string_data[] = {0x7F, 0x78, 0x01, 0x65, 0xFF, 0xFF};
 /*                                         start |   string      | break| extra
  */
 
-static void test_short_indef_string(void **_CBOR_UNUSED(_state)) {
+static void test_short_indef_string(void **_state _CBOR_UNUSED) {
   string = cbor_load(short_indef_string_data, 6, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -217,7 +217,7 @@ static void test_short_indef_string(void **_CBOR_UNUSED(_state)) {
   assert_null(string);
 }
 
-static void test_invalid_utf(void **_CBOR_UNUSED(_state)) {
+static void test_invalid_utf(void **_state _CBOR_UNUSED) {
   /* 0x60 + 1 | 0xC5 (invalid unfinished 2B codepoint) */
   unsigned char string_data[] = {0x61, 0xC5};
   string = cbor_load(string_data, 2, &res);
@@ -233,13 +233,13 @@ static void test_invalid_utf(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&string);
 }
 
-static void test_inline_creation(void **_CBOR_UNUSED(_state)) {
+static void test_inline_creation(void **_state _CBOR_UNUSED) {
   string = cbor_build_string("Hello!");
   assert_memory_equal(cbor_string_handle(string), "Hello!", strlen("Hello!"));
   cbor_decref(&string);
 }
 
-static void test_string_creation(void **_CBOR_UNUSED(_state)) {
+static void test_string_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_string()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_string()); });
@@ -255,7 +255,7 @@ static void test_string_creation(void **_CBOR_UNUSED(_state)) {
                    MALLOC_FAIL);
 }
 
-static void test_string_add_chunk(void **_CBOR_UNUSED(_state)) {
+static void test_string_add_chunk(void **_state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
         cbor_item_t *string = cbor_new_indefinite_string();
@@ -273,7 +273,7 @@ static void test_string_add_chunk(void **_CBOR_UNUSED(_state)) {
       5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
-static void test_add_chunk_reallocation_overflow(void **_CBOR_UNUSED(_state)) {
+static void test_add_chunk_reallocation_overflow(void **_state _CBOR_UNUSED) {
   string = cbor_new_indefinite_string();
   cbor_item_t *chunk = cbor_build_string("Hello!");
   struct cbor_indefinite_string_data *metadata =
@@ -291,7 +291,7 @@ static void test_add_chunk_reallocation_overflow(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&string);
 }
 
-static void test_set_handle(void **_CBOR_UNUSED(_state)) {
+static void test_set_handle(void **_state _CBOR_UNUSED) {
   string = cbor_new_definite_string();
   char *test_string = "Hello";
   unsigned char *string_data = malloc(strlen(test_string));
@@ -306,7 +306,7 @@ static void test_set_handle(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&string);
 }
 
-static void test_set_handle_multibyte_codepoint(void **_CBOR_UNUSED(_state)) {
+static void test_set_handle_multibyte_codepoint(void **_state _CBOR_UNUSED) {
   string = cbor_new_definite_string();
   // "Štěstíčko" in UTF-8
   char *test_string = "\xc5\xa0t\xc4\x9bst\xc3\xad\xc4\x8dko";
@@ -322,7 +322,7 @@ static void test_set_handle_multibyte_codepoint(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&string);
 }
 
-static void test_set_handle_invalid_utf(void **_CBOR_UNUSED(_state)) {
+static void test_set_handle_invalid_utf(void **_state _CBOR_UNUSED) {
   string = cbor_new_definite_string();
   // Invalid multi-byte character (missing the second byte).
   char *test_string = "Test: \xc5";

--- a/test/string_test.c
+++ b/test/string_test.c
@@ -10,12 +10,12 @@
 #include "cbor.h"
 #include "test_allocator.h"
 
-cbor_item_t *string;
+cbor_item_t* string;
 struct cbor_load_result res;
 
 unsigned char empty_string_data[] = {0x60};
 
-static void test_empty_string(void **_state _CBOR_UNUSED) {
+static void test_empty_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(empty_string_data, 1, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -31,7 +31,7 @@ unsigned char short_string_data[] = {0x6C, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20,
                                      0x77, 0x6F, 0x72, 0x6C, 0x64, 0x21};
 
 /*                              0x60 + 12 | Hello world! */
-static void test_short_string(void **_state _CBOR_UNUSED) {
+static void test_short_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(short_string_data, 13, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -49,7 +49,7 @@ unsigned char short_multibyte_string_data[] = {
     0xC3, 0x9F, 0x76, 0xC4, 0x9B, 0x74, 0x65, 0x21};
 
 /*                              0x60 + 15 | Čaues ßvěte! */
-static void test_short_multibyte_string(void **_state _CBOR_UNUSED) {
+static void test_short_multibyte_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(short_multibyte_string_data, 16, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -78,7 +78,7 @@ unsigned char int8_string_data[] = {
     0x70, 0x6F, 0x73, 0x75, 0x65, 0x72, 0x65, 0x2E};
 
 /*                                          150 | Lorem ....*/
-static void test_int8_string(void **_state _CBOR_UNUSED) {
+static void test_int8_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(int8_string_data, 152, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -112,7 +112,7 @@ unsigned char int16_string_data[] = {
 /*                                          150 | Lorem ....*/
 /* This valid but not realistic - length 150 could be encoded in a single
  * uint8_t (but we need to keep the test files reasonably compact) */
-static void test_int16_string(void **_state _CBOR_UNUSED) {
+static void test_int16_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(int16_string_data, 153, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -145,7 +145,7 @@ unsigned char int32_string_data[] = {
     0x74, 0x6F, 0x20, 0x70, 0x6F, 0x73, 0x75, 0x65, 0x72, 0x65, 0x2E};
 
 /*                                          150 | Lorem ....*/
-static void test_int32_string(void **_state _CBOR_UNUSED) {
+static void test_int32_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(int32_string_data, 155, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -179,7 +179,7 @@ unsigned char int64_string_data[] = {
     0x72, 0x65, 0x2E};
 
 /*                                          150 | Lorem ....*/
-static void test_int64_string(void **_state _CBOR_UNUSED) {
+static void test_int64_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(int64_string_data, 159, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -201,7 +201,7 @@ unsigned char short_indef_string_data[] = {0x7F, 0x78, 0x01, 0x65, 0xFF, 0xFF};
 /*                                         start |   string      | break| extra
  */
 
-static void test_short_indef_string(void **_state _CBOR_UNUSED) {
+static void test_short_indef_string(void** _state _CBOR_UNUSED) {
   string = cbor_load(short_indef_string_data, 6, &res);
   assert_non_null(string);
   assert_true(cbor_typeof(string) == CBOR_TYPE_STRING);
@@ -217,7 +217,7 @@ static void test_short_indef_string(void **_state _CBOR_UNUSED) {
   assert_null(string);
 }
 
-static void test_invalid_utf(void **_state _CBOR_UNUSED) {
+static void test_invalid_utf(void** _state _CBOR_UNUSED) {
   /* 0x60 + 1 | 0xC5 (invalid unfinished 2B codepoint) */
   unsigned char string_data[] = {0x61, 0xC5};
   string = cbor_load(string_data, 2, &res);
@@ -233,13 +233,13 @@ static void test_invalid_utf(void **_state _CBOR_UNUSED) {
   cbor_decref(&string);
 }
 
-static void test_inline_creation(void **_state _CBOR_UNUSED) {
+static void test_inline_creation(void** _state _CBOR_UNUSED) {
   string = cbor_build_string("Hello!");
   assert_memory_equal(cbor_string_handle(string), "Hello!", strlen("Hello!"));
   cbor_decref(&string);
 }
 
-static void test_string_creation(void **_state _CBOR_UNUSED) {
+static void test_string_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_definite_string()); });
 
   WITH_FAILING_MALLOC({ assert_null(cbor_new_indefinite_string()); });
@@ -255,17 +255,17 @@ static void test_string_creation(void **_state _CBOR_UNUSED) {
                    MALLOC_FAIL);
 }
 
-static void test_string_add_chunk(void **_state _CBOR_UNUSED) {
+static void test_string_add_chunk(void** _state _CBOR_UNUSED) {
   WITH_MOCK_MALLOC(
       {
-        cbor_item_t *string = cbor_new_indefinite_string();
-        cbor_item_t *chunk = cbor_build_string("Hello!");
+        cbor_item_t* string = cbor_new_indefinite_string();
+        cbor_item_t* chunk = cbor_build_string("Hello!");
 
         assert_false(cbor_string_add_chunk(string, chunk));
         assert_size_equal(cbor_string_chunk_count(string), 0);
-        assert_size_equal(((struct cbor_indefinite_string_data *)string->data)
-                              ->chunk_capacity,
-                          0);
+        assert_size_equal(
+            ((struct cbor_indefinite_string_data*)string->data)->chunk_capacity,
+            0);
 
         cbor_decref(&chunk);
         cbor_decref(&string);
@@ -273,11 +273,11 @@ static void test_string_add_chunk(void **_state _CBOR_UNUSED) {
       5, MALLOC, MALLOC, MALLOC, MALLOC, REALLOC_FAIL);
 }
 
-static void test_add_chunk_reallocation_overflow(void **_state _CBOR_UNUSED) {
+static void test_add_chunk_reallocation_overflow(void** _state _CBOR_UNUSED) {
   string = cbor_new_indefinite_string();
-  cbor_item_t *chunk = cbor_build_string("Hello!");
-  struct cbor_indefinite_string_data *metadata =
-      (struct cbor_indefinite_string_data *)string->data;
+  cbor_item_t* chunk = cbor_build_string("Hello!");
+  struct cbor_indefinite_string_data* metadata =
+      (struct cbor_indefinite_string_data*)string->data;
   // Pretend we already have many chunks allocated
   metadata->chunk_count = SIZE_MAX;
   metadata->chunk_capacity = SIZE_MAX;
@@ -291,10 +291,10 @@ static void test_add_chunk_reallocation_overflow(void **_state _CBOR_UNUSED) {
   cbor_decref(&string);
 }
 
-static void test_set_handle(void **_state _CBOR_UNUSED) {
+static void test_set_handle(void** _state _CBOR_UNUSED) {
   string = cbor_new_definite_string();
-  char *test_string = "Hello";
-  unsigned char *string_data = malloc(strlen(test_string));
+  char* test_string = "Hello";
+  unsigned char* string_data = malloc(strlen(test_string));
   memcpy(string_data, test_string, strlen(test_string));
   assert_ptr_not_equal(string_data, NULL);
   cbor_string_set_handle(string, string_data, strlen(test_string));
@@ -306,11 +306,11 @@ static void test_set_handle(void **_state _CBOR_UNUSED) {
   cbor_decref(&string);
 }
 
-static void test_set_handle_multibyte_codepoint(void **_state _CBOR_UNUSED) {
+static void test_set_handle_multibyte_codepoint(void** _state _CBOR_UNUSED) {
   string = cbor_new_definite_string();
   // "Štěstíčko" in UTF-8
-  char *test_string = "\xc5\xa0t\xc4\x9bst\xc3\xad\xc4\x8dko";
-  unsigned char *string_data = malloc(strlen(test_string));
+  char* test_string = "\xc5\xa0t\xc4\x9bst\xc3\xad\xc4\x8dko";
+  unsigned char* string_data = malloc(strlen(test_string));
   memcpy(string_data, test_string, strlen(test_string));
   assert_ptr_not_equal(string_data, NULL);
   cbor_string_set_handle(string, string_data, strlen(test_string));
@@ -322,11 +322,11 @@ static void test_set_handle_multibyte_codepoint(void **_state _CBOR_UNUSED) {
   cbor_decref(&string);
 }
 
-static void test_set_handle_invalid_utf(void **_state _CBOR_UNUSED) {
+static void test_set_handle_invalid_utf(void** _state _CBOR_UNUSED) {
   string = cbor_new_definite_string();
   // Invalid multi-byte character (missing the second byte).
-  char *test_string = "Test: \xc5";
-  unsigned char *string_data = malloc(strlen(test_string));
+  char* test_string = "Test: \xc5";
+  unsigned char* string_data = malloc(strlen(test_string));
   memcpy(string_data, test_string, strlen(test_string));
   assert_ptr_not_equal(string_data, NULL);
   cbor_string_set_handle(string, string_data, strlen(test_string));

--- a/test/tag_encoders_test.c
+++ b/test/tag_encoders_test.c
@@ -10,12 +10,12 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_tag(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_tag(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_tag(1, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xC1}), 1);
 }
 
-static void test_tag(void **_CBOR_UNUSED(_state)) {
+static void test_tag(void** _state _CBOR_UNUSED) {
   assert_size_equal(5, cbor_encode_tag(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0xDA, 0x00, 0x0F, 0x42, 0x40}),
                       5);

--- a/test/tag_test.c
+++ b/test/tag_test.c
@@ -105,7 +105,7 @@ static void test_nested_tag(void **_CBOR_UNUSED(_state)) {
 static void test_all_tag_values_supported(void **_CBOR_UNUSED(_state)) {
   /* Test all items in the protected range of
    * https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml */
-  for (int64_t tag_value = 0; tag_value <= 32767; tag_value++) {
+  for (uint64_t tag_value = 0; tag_value <= 32767; tag_value++) {
     cbor_item_t *tag_item =
         cbor_build_tag(tag_value, cbor_move(cbor_build_uint8(42)));
     unsigned char *serialized_tag;

--- a/test/tag_test.c
+++ b/test/tag_test.c
@@ -9,15 +9,15 @@
 #include "cbor.h"
 #include "test_allocator.h"
 
-cbor_item_t *tag;
+cbor_item_t* tag;
 struct cbor_load_result res;
 
 unsigned char embedded_tag_data[] = {0xC0, 0x00};
 
-static void test_refcounting(void **_state _CBOR_UNUSED) {
+static void test_refcounting(void** _state _CBOR_UNUSED) {
   tag = cbor_load(embedded_tag_data, 2, &res);
   assert_true(cbor_refcount(tag) == 1);
-  cbor_item_t *item = cbor_tag_item(tag);
+  cbor_item_t* item = cbor_tag_item(tag);
   assert_true(cbor_refcount(item) == 2);
   cbor_decref(&tag);
   assert_null(tag);
@@ -27,7 +27,7 @@ static void test_refcounting(void **_state _CBOR_UNUSED) {
 }
 
 /* Tag 0 + uint 0 */
-static void test_embedded_tag(void **_state _CBOR_UNUSED) {
+static void test_embedded_tag(void** _state _CBOR_UNUSED) {
   tag = cbor_load(embedded_tag_data, 2, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 0);
@@ -39,7 +39,7 @@ static void test_embedded_tag(void **_state _CBOR_UNUSED) {
 unsigned char int8_tag_data[] = {0xD8, 0xFF, 0x01};
 
 /* Tag 255 + uint 1 */
-static void test_int8_tag(void **_state _CBOR_UNUSED) {
+static void test_int8_tag(void** _state _CBOR_UNUSED) {
   tag = cbor_load(int8_tag_data, 3, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 255);
@@ -51,7 +51,7 @@ static void test_int8_tag(void **_state _CBOR_UNUSED) {
 unsigned char int16_tag_data[] = {0xD9, 0xFF, 0x00, 0x02};
 
 /* Tag 255 << 8 + uint 2 */
-static void test_int16_tag(void **_state _CBOR_UNUSED) {
+static void test_int16_tag(void** _state _CBOR_UNUSED) {
   tag = cbor_load(int16_tag_data, 4, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 255 << 8);
@@ -63,7 +63,7 @@ static void test_int16_tag(void **_state _CBOR_UNUSED) {
 unsigned char int32_tag_data[] = {0xDA, 0xFF, 0x00, 0x00, 0x00, 0x03};
 
 /* uint 3 */
-static void test_int32_tag(void **_state _CBOR_UNUSED) {
+static void test_int32_tag(void** _state _CBOR_UNUSED) {
   tag = cbor_load(int32_tag_data, 6, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 4278190080ULL);
@@ -76,7 +76,7 @@ unsigned char int64_tag_data[] = {0xDB, 0xFF, 0x00, 0x00, 0x00,
                                   0x00, 0x00, 0x00, 0x00, 0x04};
 
 /* uint 4 */
-static void test_int64_tag(void **_state _CBOR_UNUSED) {
+static void test_int64_tag(void** _state _CBOR_UNUSED) {
   tag = cbor_load(int64_tag_data, 10, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 18374686479671623680ULL);
@@ -88,11 +88,11 @@ static void test_int64_tag(void **_state _CBOR_UNUSED) {
 unsigned char nested_tag_data[] = {0xC0, 0xC1, 0x18, 0x2A};
 
 /* Tag 0, tag 1 + uint 0 */
-static void test_nested_tag(void **_state _CBOR_UNUSED) {
+static void test_nested_tag(void** _state _CBOR_UNUSED) {
   tag = cbor_load(nested_tag_data, 4, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 0);
-  cbor_item_t *nested_tag = cbor_tag_item(tag);
+  cbor_item_t* nested_tag = cbor_tag_item(tag);
   assert_true(cbor_typeof(nested_tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(nested_tag) == 1);
   assert_uint8(cbor_move(cbor_tag_item(nested_tag)), 42);
@@ -102,13 +102,13 @@ static void test_nested_tag(void **_state _CBOR_UNUSED) {
   assert_null(nested_tag);
 }
 
-static void test_all_tag_values_supported(void **_state _CBOR_UNUSED) {
+static void test_all_tag_values_supported(void** _state _CBOR_UNUSED) {
   /* Test all items in the protected range of
    * https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml */
   for (uint64_t tag_value = 0; tag_value <= 32767; tag_value++) {
-    cbor_item_t *tag_item =
+    cbor_item_t* tag_item =
         cbor_build_tag(tag_value, cbor_move(cbor_build_uint8(42)));
-    unsigned char *serialized_tag;
+    unsigned char* serialized_tag;
     size_t serialized_tag_size =
         cbor_serialize_alloc(tag_item, &serialized_tag, NULL);
     assert_true(serialized_tag_size > 0);
@@ -124,7 +124,7 @@ static void test_all_tag_values_supported(void **_state _CBOR_UNUSED) {
   }
 }
 
-static void test_build_tag(void **_state _CBOR_UNUSED) {
+static void test_build_tag(void** _state _CBOR_UNUSED) {
   tag = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
 
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
@@ -134,8 +134,8 @@ static void test_build_tag(void **_state _CBOR_UNUSED) {
   cbor_decref(&tag);
 }
 
-static void test_build_tag_failure(void **_state _CBOR_UNUSED) {
-  cbor_item_t *tagged_item = cbor_build_uint8(42);
+static void test_build_tag_failure(void** _state _CBOR_UNUSED) {
+  cbor_item_t* tagged_item = cbor_build_uint8(42);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_tag(1, tagged_item)); });
   assert_size_equal(cbor_refcount(tagged_item), 1);
@@ -143,7 +143,7 @@ static void test_build_tag_failure(void **_state _CBOR_UNUSED) {
   cbor_decref(&tagged_item);
 }
 
-static void test_tag_creation(void **_state _CBOR_UNUSED) {
+static void test_tag_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_tag(42)); });
 }
 

--- a/test/tag_test.c
+++ b/test/tag_test.c
@@ -14,7 +14,7 @@ struct cbor_load_result res;
 
 unsigned char embedded_tag_data[] = {0xC0, 0x00};
 
-static void test_refcounting(void **_CBOR_UNUSED(_state)) {
+static void test_refcounting(void **_state _CBOR_UNUSED) {
   tag = cbor_load(embedded_tag_data, 2, &res);
   assert_true(cbor_refcount(tag) == 1);
   cbor_item_t *item = cbor_tag_item(tag);
@@ -27,7 +27,7 @@ static void test_refcounting(void **_CBOR_UNUSED(_state)) {
 }
 
 /* Tag 0 + uint 0 */
-static void test_embedded_tag(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_tag(void **_state _CBOR_UNUSED) {
   tag = cbor_load(embedded_tag_data, 2, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 0);
@@ -39,7 +39,7 @@ static void test_embedded_tag(void **_CBOR_UNUSED(_state)) {
 unsigned char int8_tag_data[] = {0xD8, 0xFF, 0x01};
 
 /* Tag 255 + uint 1 */
-static void test_int8_tag(void **_CBOR_UNUSED(_state)) {
+static void test_int8_tag(void **_state _CBOR_UNUSED) {
   tag = cbor_load(int8_tag_data, 3, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 255);
@@ -51,7 +51,7 @@ static void test_int8_tag(void **_CBOR_UNUSED(_state)) {
 unsigned char int16_tag_data[] = {0xD9, 0xFF, 0x00, 0x02};
 
 /* Tag 255 << 8 + uint 2 */
-static void test_int16_tag(void **_CBOR_UNUSED(_state)) {
+static void test_int16_tag(void **_state _CBOR_UNUSED) {
   tag = cbor_load(int16_tag_data, 4, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 255 << 8);
@@ -63,7 +63,7 @@ static void test_int16_tag(void **_CBOR_UNUSED(_state)) {
 unsigned char int32_tag_data[] = {0xDA, 0xFF, 0x00, 0x00, 0x00, 0x03};
 
 /* uint 3 */
-static void test_int32_tag(void **_CBOR_UNUSED(_state)) {
+static void test_int32_tag(void **_state _CBOR_UNUSED) {
   tag = cbor_load(int32_tag_data, 6, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 4278190080ULL);
@@ -76,7 +76,7 @@ unsigned char int64_tag_data[] = {0xDB, 0xFF, 0x00, 0x00, 0x00,
                                   0x00, 0x00, 0x00, 0x00, 0x04};
 
 /* uint 4 */
-static void test_int64_tag(void **_CBOR_UNUSED(_state)) {
+static void test_int64_tag(void **_state _CBOR_UNUSED) {
   tag = cbor_load(int64_tag_data, 10, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 18374686479671623680ULL);
@@ -88,7 +88,7 @@ static void test_int64_tag(void **_CBOR_UNUSED(_state)) {
 unsigned char nested_tag_data[] = {0xC0, 0xC1, 0x18, 0x2A};
 
 /* Tag 0, tag 1 + uint 0 */
-static void test_nested_tag(void **_CBOR_UNUSED(_state)) {
+static void test_nested_tag(void **_state _CBOR_UNUSED) {
   tag = cbor_load(nested_tag_data, 4, &res);
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
   assert_true(cbor_tag_value(tag) == 0);
@@ -102,7 +102,7 @@ static void test_nested_tag(void **_CBOR_UNUSED(_state)) {
   assert_null(nested_tag);
 }
 
-static void test_all_tag_values_supported(void **_CBOR_UNUSED(_state)) {
+static void test_all_tag_values_supported(void **_state _CBOR_UNUSED) {
   /* Test all items in the protected range of
    * https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml */
   for (uint64_t tag_value = 0; tag_value <= 32767; tag_value++) {
@@ -124,7 +124,7 @@ static void test_all_tag_values_supported(void **_CBOR_UNUSED(_state)) {
   }
 }
 
-static void test_build_tag(void **_CBOR_UNUSED(_state)) {
+static void test_build_tag(void **_state _CBOR_UNUSED) {
   tag = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
 
   assert_true(cbor_typeof(tag) == CBOR_TYPE_TAG);
@@ -134,7 +134,7 @@ static void test_build_tag(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&tag);
 }
 
-static void test_build_tag_failure(void **_CBOR_UNUSED(_state)) {
+static void test_build_tag_failure(void **_state _CBOR_UNUSED) {
   cbor_item_t *tagged_item = cbor_build_uint8(42);
 
   WITH_FAILING_MALLOC({ assert_null(cbor_build_tag(1, tagged_item)); });
@@ -143,7 +143,7 @@ static void test_build_tag_failure(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&tagged_item);
 }
 
-static void test_tag_creation(void **_CBOR_UNUSED(_state)) {
+static void test_tag_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_tag(42)); });
 }
 

--- a/test/test_allocator.c
+++ b/test/test_allocator.c
@@ -8,7 +8,7 @@
 int alloc_calls_expected;
 // How many alloc calls we got
 int alloc_calls;
-// Array of booleans indicating whether to return a block or fail with NULL
+// Array of expected call and their behavior (success or failure)
 call_expectation *expectations;
 
 void set_mock_malloc(int calls, ...) {
@@ -59,7 +59,7 @@ error:
   print_error(
       "Unexpected call to malloc(%zu) at position %d of %d; expected %d\n",
       size, alloc_calls, alloc_calls_expected,
-      alloc_calls < alloc_calls_expected ? expectations[alloc_calls] : -1);
+      alloc_calls < alloc_calls_expected ? (int)expectations[alloc_calls] : -1);
   print_backtrace();
   fail();
   return NULL;
@@ -82,7 +82,7 @@ error:
   print_error(
       "Unexpected call to realloc(%zu) at position %d of %d; expected %d\n",
       size, alloc_calls, alloc_calls_expected,
-      alloc_calls < alloc_calls_expected ? expectations[alloc_calls] : -1);
+      alloc_calls < alloc_calls_expected ? (int)expectations[alloc_calls] : -1);
   print_backtrace();
   fail();
   return NULL;

--- a/test/test_allocator.c
+++ b/test/test_allocator.c
@@ -9,7 +9,7 @@ int alloc_calls_expected;
 // How many alloc calls we got
 int alloc_calls;
 // Array of expected call and their behavior (success or failure)
-call_expectation *expectations;
+call_expectation* expectations;
 
 void set_mock_malloc(int calls, ...) {
   va_list args;
@@ -31,9 +31,9 @@ void finalize_mock_malloc(void) {
 
 void print_backtrace(void) {
 #if HAS_EXECINFO
-  void *buffer[128];
+  void* buffer[128];
   int frames = backtrace(buffer, 128);
-  char **symbols = backtrace_symbols(buffer, frames);
+  char** symbols = backtrace_symbols(buffer, frames);
   // Skip this function and the caller
   for (int i = 2; i < frames; ++i) {
     printf("%s\n", symbols[i]);
@@ -42,7 +42,7 @@ void print_backtrace(void) {
 #endif
 }
 
-void *instrumented_malloc(size_t size) {
+void* instrumented_malloc(size_t size) {
   if (alloc_calls >= alloc_calls_expected) {
     goto error;
   }
@@ -65,7 +65,7 @@ error:
   return NULL;
 }
 
-void *instrumented_realloc(void *ptr, size_t size) {
+void* instrumented_realloc(void* ptr, size_t size) {
   if (alloc_calls >= alloc_calls_expected) {
     goto error;
   }

--- a/test/test_allocator.h
+++ b/test/test_allocator.h
@@ -21,9 +21,9 @@ void set_mock_malloc(int calls, ...);
 
 void finalize_mock_malloc(void);
 
-void *instrumented_malloc(size_t size);
+void* instrumented_malloc(size_t size);
 
-void *instrumented_realloc(void *ptr, size_t size);
+void* instrumented_realloc(void* ptr, size_t size);
 
 #define WITH_MOCK_MALLOC(block, malloc_calls, ...)                    \
   do {                                                                \

--- a/test/test_allocator.h
+++ b/test/test_allocator.h
@@ -7,9 +7,13 @@
 // Harness for mocking `malloc` and `realloc`
 
 typedef enum call_expectation {
+  // Call malloc and return a pointer
   MALLOC,
+  // Pretend call malloc, but return NULL (fail)
   MALLOC_FAIL,
+  // Call realloc and return a pointer
   REALLOC,
+  // Pretend call realloc, but return NULL (fail)
   REALLOC_FAIL
 } call_expectation;
 

--- a/test/uint_encoders_test.c
+++ b/test/uint_encoders_test.c
@@ -10,31 +10,31 @@
 
 unsigned char buffer[512];
 
-static void test_embedded_uint8(void **_CBOR_UNUSED(_state)) {
+static void test_embedded_uint8(void** _state _CBOR_UNUSED) {
   assert_size_equal(1, cbor_encode_uint8(14, buffer, 512));
   assert_memory_equal(buffer, (unsigned char[]){0x0E}, 1);
 }
 
-static void test_uint8(void **_CBOR_UNUSED(_state)) {
+static void test_uint8(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_uint8(180, buffer, 1));
   assert_size_equal(2, cbor_encode_uint8(255, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x18, 0xFF}), 2);
 }
 
-static void test_uint16(void **_CBOR_UNUSED(_state)) {
+static void test_uint16(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_uint16(1000, buffer, 2));
   assert_size_equal(3, cbor_encode_uint16(1000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x19, 0x03, 0xE8}), 3);
 }
 
-static void test_uint32(void **_CBOR_UNUSED(_state)) {
+static void test_uint32(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_uint32(1000000, buffer, 4));
   assert_size_equal(5, cbor_encode_uint32(1000000, buffer, 512));
   assert_memory_equal(buffer, ((unsigned char[]){0x1A, 0x00, 0x0F, 0x42, 0x40}),
                       5);
 }
 
-static void test_uint64(void **_CBOR_UNUSED(_state)) {
+static void test_uint64(void** _state _CBOR_UNUSED) {
   assert_size_equal(0, cbor_encode_uint64(18446744073709551615ULL, buffer, 8));
   assert_size_equal(9,
                     cbor_encode_uint64(18446744073709551615ULL, buffer, 512));
@@ -44,7 +44,7 @@ static void test_uint64(void **_CBOR_UNUSED(_state)) {
       9);
 }
 
-static void test_unspecified(void **_CBOR_UNUSED(_state)) {
+static void test_unspecified(void** _state _CBOR_UNUSED) {
   assert_size_equal(9, cbor_encode_uint(18446744073709551615ULL, buffer, 512));
   assert_memory_equal(
       buffer,

--- a/test/uint_test.c
+++ b/test/uint_test.c
@@ -20,7 +20,7 @@ unsigned char data4[] = {0x1a, 0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 unsigned char data5[] = {0x1b, 0xa5, 0xf7, 0x02, 0xb3,
                          0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 
-static void test_very_short_int(void **_CBOR_UNUSED(_state)) {
+static void test_very_short_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data1, 2, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -34,13 +34,13 @@ static void test_very_short_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_incomplete_data(void **_CBOR_UNUSED(_state)) {
+static void test_incomplete_data(void **_state _CBOR_UNUSED) {
   number = cbor_load(data2, 1, &res);
   assert_null(number);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
 }
 
-static void test_short_int(void **_CBOR_UNUSED(_state)) {
+static void test_short_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data2, 3, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -54,7 +54,7 @@ static void test_short_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_half_int(void **_CBOR_UNUSED(_state)) {
+static void test_half_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data3, 5, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_16);
@@ -68,7 +68,7 @@ static void test_half_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_int(void **_CBOR_UNUSED(_state)) {
+static void test_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data4, 6, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_32);
@@ -82,7 +82,7 @@ static void test_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_long_int(void **_CBOR_UNUSED(_state)) {
+static void test_long_int(void **_state _CBOR_UNUSED) {
   number = cbor_load(data5, 10, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_64);
@@ -96,7 +96,7 @@ static void test_long_int(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_refcounting(void **_CBOR_UNUSED(_state)) {
+static void test_refcounting(void **_state _CBOR_UNUSED) {
   number = cbor_load(data5, 10, &res);
   cbor_incref(number);
   assert_true(number->refcount == 2);
@@ -106,13 +106,13 @@ static void test_refcounting(void **_CBOR_UNUSED(_state)) {
   assert_null(number);
 }
 
-static void test_empty_input(void **_CBOR_UNUSED(_state)) {
+static void test_empty_input(void **_state _CBOR_UNUSED) {
   number = cbor_load(data5, 0, &res);
   assert_null(number);
   assert_true(res.error.code == CBOR_ERR_NODATA);
 }
 
-static void test_inline_creation(void **_CBOR_UNUSED(_state)) {
+static void test_inline_creation(void **_state _CBOR_UNUSED) {
   number = cbor_build_uint8(10);
   assert_true(cbor_get_int(number) == 10);
   cbor_decref(&number);
@@ -130,7 +130,7 @@ static void test_inline_creation(void **_CBOR_UNUSED(_state)) {
   cbor_decref(&number);
 }
 
-static void test_int_creation(void **_CBOR_UNUSED(_state)) {
+static void test_int_creation(void **_state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int8()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int16()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int32()); });

--- a/test/uint_test.c
+++ b/test/uint_test.c
@@ -10,7 +10,7 @@
 
 #include "cbor.h"
 
-cbor_item_t *number;
+cbor_item_t* number;
 struct cbor_load_result res;
 
 unsigned char data1[] = {0x02, 0xFF};
@@ -20,7 +20,7 @@ unsigned char data4[] = {0x1a, 0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 unsigned char data5[] = {0x1b, 0xa5, 0xf7, 0x02, 0xb3,
                          0xa5, 0xf7, 0x02, 0xb3, 0xFF};
 
-static void test_very_short_int(void **_state _CBOR_UNUSED) {
+static void test_very_short_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data1, 2, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -34,13 +34,13 @@ static void test_very_short_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_incomplete_data(void **_state _CBOR_UNUSED) {
+static void test_incomplete_data(void** _state _CBOR_UNUSED) {
   number = cbor_load(data2, 1, &res);
   assert_null(number);
   assert_true(res.error.code == CBOR_ERR_NOTENOUGHDATA);
 }
 
-static void test_short_int(void **_state _CBOR_UNUSED) {
+static void test_short_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data2, 3, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_8);
@@ -54,7 +54,7 @@ static void test_short_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_half_int(void **_state _CBOR_UNUSED) {
+static void test_half_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data3, 5, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_16);
@@ -68,7 +68,7 @@ static void test_half_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_int(void **_state _CBOR_UNUSED) {
+static void test_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data4, 6, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_32);
@@ -82,7 +82,7 @@ static void test_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_long_int(void **_state _CBOR_UNUSED) {
+static void test_long_int(void** _state _CBOR_UNUSED) {
   number = cbor_load(data5, 10, &res);
   assert_true(cbor_typeof(number) == CBOR_TYPE_UINT);
   assert_true(cbor_int_get_width(number) == CBOR_INT_64);
@@ -96,7 +96,7 @@ static void test_long_int(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_refcounting(void **_state _CBOR_UNUSED) {
+static void test_refcounting(void** _state _CBOR_UNUSED) {
   number = cbor_load(data5, 10, &res);
   cbor_incref(number);
   assert_true(number->refcount == 2);
@@ -106,13 +106,13 @@ static void test_refcounting(void **_state _CBOR_UNUSED) {
   assert_null(number);
 }
 
-static void test_empty_input(void **_state _CBOR_UNUSED) {
+static void test_empty_input(void** _state _CBOR_UNUSED) {
   number = cbor_load(data5, 0, &res);
   assert_null(number);
   assert_true(res.error.code == CBOR_ERR_NODATA);
 }
 
-static void test_inline_creation(void **_state _CBOR_UNUSED) {
+static void test_inline_creation(void** _state _CBOR_UNUSED) {
   number = cbor_build_uint8(10);
   assert_true(cbor_get_int(number) == 10);
   cbor_decref(&number);
@@ -130,7 +130,7 @@ static void test_inline_creation(void **_state _CBOR_UNUSED) {
   cbor_decref(&number);
 }
 
-static void test_int_creation(void **_state _CBOR_UNUSED) {
+static void test_int_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int8()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int16()); });
   WITH_FAILING_MALLOC({ assert_null(cbor_new_int32()); });

--- a/test/unicode_test.c
+++ b/test/unicode_test.c
@@ -13,7 +13,7 @@ struct _cbor_unicode_status status;
 unsigned char missing_bytes_data[] = {0xC4, 0x8C};
 
 /* Capital accented C */
-static void test_missing_bytes(void **_CBOR_UNUSED(_state)) {
+static void test_missing_bytes(void** _state _CBOR_UNUSED) {
   assert_true(_cbor_unicode_codepoint_count(missing_bytes_data, 1, &status) ==
               0);
   assert_true(status.status == _CBOR_UNICODE_BADCP);
@@ -28,7 +28,7 @@ static void test_missing_bytes(void **_CBOR_UNUSED(_state)) {
 unsigned char invalid_sequence_data[] = {0x65, 0xC4, 0x00};
 
 /* e, invalid seq */
-static void test_invalid_sequence(void **_CBOR_UNUSED(_state)) {
+static void test_invalid_sequence(void** _state _CBOR_UNUSED) {
   assert_true(
       _cbor_unicode_codepoint_count(invalid_sequence_data, 3, &status) == 0);
   assert_true(status.status == _CBOR_UNICODE_BADCP);


### PR DESCRIPTION
These were missed since it turns out we need all of "-pedantic -Wall -Wextra" to get gcc to talk