### PR TITLE
Add a doc for the reference count in cbor_array_set().

### DIFF
--- a/src/cbor/arrays.h
+++ b/src/cbor/arrays.h
@@ -49,7 +49,8 @@ CBOR_EXPORT cbor_item_t* cbor_array_get(const cbor_item_t* item, size_t index);
  * returned. Creating arrays with holes is not possible.
  *
  * @param item An array
- * @param value The item to assign
+ * @param value The item to assign. Its reference count will be increased by
+ * one.
  * @param index The index (zero-based)
  * @return `true` on success, `false` on allocation failure.
  */


### PR DESCRIPTION
## Description

Add a documentation for the reference count in cbor_array_set().

Because cbor_array_set() calls cbor_array_push() or cbor_array_replace(), the reference count increases.

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
