### PR TITLE
CI: Bump FreeBSD to 13.5 and 14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,12 +14,12 @@ freebsd_task:
     - ctest -VV
     matrix:
     # From gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images
-    - name: freebsd-13-4
+    - name: freebsd-13-5
       freebsd_instance:
-        image_family: freebsd-13-4
-    - name: freebsd-14-2
+        image_family: freebsd-13-5
+    - name: freebsd-14-3
       freebsd_instance:
-        image_family: freebsd-14-2
+        image_family: freebsd-14-3
     - name: freebsd-15-0-snap
       freebsd_instance:
         image_family: freebsd-15-0-snap


### PR DESCRIPTION
These are the current supported releases for 13.x and 14.x.

## Description

Bump FreeBSD to 13.5 and 14.3

## Checklist

- [x] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
