### PR TITLE
oss-fuzz: Add unit testing build to oss-fuzz build script

### DIFF
--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -21,6 +21,7 @@ cd oss_fuzz_build
 cmake -D CMAKE_BUILD_TYPE=Debug \
       -D CMAKE_INSTALL_PREFIX="$WORK" \
       -D SANITIZE=OFF \
+      -D WITH_TESTS=ON \
       -D CMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
       ..
 make "-j$(nproc)"


### PR DESCRIPTION
OSS-Fuzz has a new Chronos feature that allows fast rebuilding of OSS-Fuzz-integrated projects and checks whether the project code or fuzzers still pass their unit tests after patching. To enable this feature, the unit tests of integrated projects need to be built. Therefore, this PR modifies the build script used by OSS-Fuzz to also build the unit tests for this project. The OSS-Fuzz-side changes for this project's integration can be found here: https://github.com/google/oss-fuzz/pull/14674.