### PR TITLE
Revert "oss-fuzz: Add unit testing build to oss-fuzz build script"

### DIFF
--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -21,7 +21,6 @@ cd oss_fuzz_build
 cmake -D CMAKE_BUILD_TYPE=Debug \
       -D CMAKE_INSTALL_PREFIX="$WORK" \
       -D SANITIZE=OFF \
-      -D WITH_TESTS=ON \
       -D CMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
       ..
 make "-j$(nproc)"


### PR DESCRIPTION
Reverts PJK/libcbor#380

Breaks the build because tests need cmocka: https://github.com/PJK/libcbor/actions/runs/20520843620/job/58955806446?pr=381 -- @arthurscchan could you PTAL?
