### PR TITLE
cmake: fix macro names for nodiscard/unreachable feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Next
 ---------------------
 
 - [Only generate CMake coverage build targets when explicitly enabled](https://github.com/PJK/libcbor/issues/383)
+- Fix CMake feature macro names and ensure `_CBOR_NODISCARD` is defined with `[[nodiscard]]`
 
 0.13.0 (2025-08-30)
 ---------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ check_c_source_compiles("
 
 if(HAS_NODISCARD_ATTRIBUTE)
   message(STATUS "[[nodiscard]] is supported.")
-  add_definitions(-D_CBOR_HAS_NODISCARD_ATTRIBUTE)
+  add_definitions(-DCBOR_HAS_NODISCARD_ATTRIBUTE)
   # Assume that if we have [[nodiscard]], we have some C23 support. May fail.
   if(NOT DEFINED CMAKE_C_STANDARD)
     message(STATUS "Switching to C23-like mode. To prevent this, pass -DCMAKE_C_STANDARD explicitly.")
@@ -163,7 +163,7 @@ check_c_source_compiles("
 "  HAS_BUILTIN_UNREACHABLE)
 
 if(HAS_BUILTIN_UNREACHABLE)
-  add_definitions(-D_CBOR_HAS_BUILTIN_UNREACHABLE)
+  add_definitions(-DCBOR_HAS_BUILTIN_UNREACHABLE)
 endif()
 
 # CMake >= 3.9.0 enables LTO for GCC and Clang with INTERPROCEDURAL_OPTIMIZATION

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -93,7 +93,9 @@ extern bool _cbor_enable_assert;
 #define _CBOR_UNUSED __attribute__((__unused__))
 // Fall back to __attribute__((warn_unused_result)) if we don't have
 // [[nodiscard]]
-#ifndef CBOR_HAS_NODISCARD_ATTRIBUTE
+#ifdef CBOR_HAS_NODISCARD_ATTRIBUTE
+#define _CBOR_NODISCARD CBOR_NODISCARD
+#else
 #define _CBOR_NODISCARD __attribute__((warn_unused_result))
 #endif
 #elif defined(_MSC_VER)


### PR DESCRIPTION
## Description

Fix CMake feature flag macro names to match the header checks.
CMake defined `_CBOR_HAS_*` while headers check `CBOR_HAS_*`, so the
feature flags for `[[nodiscard]]` and `__builtin_unreachable()` never
took effect. This aligns the definitions.

## Checklist

- [X] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [X] ~~I have added tests~~
	- [X] ~~I have updated the documentation~~
	- [X] I have updated the CHANGELOG
- [X] ~~Are there any breaking changes?~~
	- [X] ~~If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))~~
- [X] ~~Does this PR introduce any platform specific code?~~
- [X] ~~Security: Does this PR potentially affect security?~~
- [X] ~~Performance: Does this PR potentially affect performance?~~
