### PR TITLE
Fix Bazel build for Bazel 9 compatibility

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_import")
+
 genrule(
     name = "cbor_cmake",
     srcs = glob(["**"]),

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,1 +1,3 @@
 module(name = "libcbor")
+
+bazel_dep(name = "rules_cc", version = "0.2.14")

--- a/examples/bazel/MODULE.bazel
+++ b/examples/bazel/MODULE.bazel
@@ -3,8 +3,8 @@ module(
     version = "0.1.0",
 )
 
-bazel_dep(name = "rules_cc", version = "0.1.1")
-bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "googletest", version = "1.17.0")
 
 bazel_dep(name = "libcbor")
 local_path_override(

--- a/examples/bazel/src/BUILD
+++ b/examples/bazel/src/BUILD
@@ -1,5 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 cc_library(
     name = "hello_lib",

--- a/examples/bazel/third_party/libcbor/BUILD
+++ b/examples/bazel/third_party/libcbor/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 cc_library(
     name = "config",
     hdrs = [


### PR DESCRIPTION
Bazel 9 removed native CC rules (cc_library, cc_binary, cc_test, cc_import) from builtins. Add explicit load() statements and bump stale dependency versions (rules_cc 0.2.14, googletest 1.17.0).

## Description

What changes and why

## Checklist

- [ ] I have read followed [CONTRIBUTING.md](https://github.com/PJK/libcbor/blob/master/CONTRIBUTING.md)
	- [ ] I have added tests
	- [ ] I have updated the documentation
	- [ ] I have updated the CHANGELOG
- [ ] Are there any breaking changes?
	- [ ] If yes: I have marked them in the CHANGELOG ([example](https://github.com/PJK/libcbor/blob/87e2d48a127968d39f158cbfc2b79d6285bd039d/CHANGELOG.md?plain=1#L16))
- [ ] Does this PR introduce any platform specific code?
- [ ] Security: Does this PR potentially affect security?
- [ ] Performance: Does this PR potentially affect performance?
