### PR TITLE
Fix integer overflow in cbor_copy_definite() chunk accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Next
 
 - [Only generate CMake coverage build targets when explicitly enabled](https://github.com/PJK/libcbor/issues/383)
 - Fix CMake feature macro names and ensure `_CBOR_NODISCARD` is defined with `[[nodiscard]]`
+- [Fix integer overflow in `cbor_copy_definite()` when accumulating indefinite bytestring/string chunk lengths](https://github.com/PJK/libcbor/pull/387)
 
 0.13.0 (2025-08-30)
 ---------------------


### PR DESCRIPTION
## Summary

- Fix integer overflow when summing chunk lengths in `cbor_copy_definite()` for indefinite bytestrings and strings
- Crafted chunks with lengths summing past `SIZE_MAX` would silently wrap around, causing a small `_cbor_malloc` followed by heap buffer overflow in `memcpy`
- Use existing `_cbor_safe_to_add()` to detect overflow and return `NULL`

## Test plan

- [x] Added `test_definite_indef_bytestring_chunk_length_overflow` — verifies `cbor_copy_definite()` returns NULL when bytestring chunk lengths would overflow
- [x] Added `test_definite_indef_string_chunk_length_overflow` — same for strings
- [x] All 26 existing test binaries pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)