### PR TITLE
Address potential unsigned underflow in streaming decoder claim_bytes()

### DIFF
--- a/src/cbor/streaming.c
+++ b/src/cbor/streaming.c
@@ -8,8 +8,14 @@
 #include "streaming.h"
 #include "internal/loaders.h"
 
+// Increment the number of bytes read in the `result` by `required` if there are
+// enough bytes `provided` and return true, or set the `result` to an error
+// state and return false.
+//
 static bool claim_bytes(size_t required, size_t provided,
                         struct cbor_decoder_result* result) {
+  // Safe from underflow: read is only incremented on successful claims
+  CBOR_ASSERT(result->read <= provided);
   if (required > (provided - result->read)) {
     result->required = required + result->read;
     result->read = 0;


### PR DESCRIPTION
## Summary

- `claim_bytes()` in `streaming.c` computes `provided - result->read` as `size_t`, which would underflow if `result->read > provided`
- In practice this can't happen because `result->read` is only incremented on successful claims, but the invariant was implicit
- Add an assertion and comment documenting why the subtraction is safe

## Test plan

- [x] All 26 test binaries pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)