### PR TITLE
Return NULL from cbor_tag_item() when no item is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Next
 - [Add bounds check in `cbor_array_get()` to return NULL on out-of-bounds access](https://github.com/PJK/libcbor/pull/388)
 - BREAKING: [`cbor_tag_set_item` now releases the reference to the previous tagged item](https://github.com/PJK/libcbor/pull/391)
   - Previously, replacing the tagged item would leak the old item's reference. If you were manually releasing the old item before calling `cbor_tag_set_item`, you should remove the extra `cbor_decref`.
+- Potentially BREAKING: [`cbor_tag_item` now returns NULL if the tag has no item set](https://github.com/PJK/libcbor/pull/392)
+  - Previously, this would be undefined behavior (NULL pointer dereference), so no valid clients should be affected.
 
 0.13.0 (2025-08-30)
 ---------------------

--- a/src/cbor/tags.c
+++ b/src/cbor/tags.c
@@ -22,6 +22,9 @@ cbor_item_t* cbor_new_tag(uint64_t value) {
 
 cbor_item_t* cbor_tag_item(const cbor_item_t* tag) {
   CBOR_ASSERT(cbor_isa_tag(tag));
+  if (tag->metadata.tag_metadata.tagged_item == NULL) {
+    return NULL;
+  }
   return cbor_incref(tag->metadata.tag_metadata.tagged_item);
 }
 

--- a/src/cbor/tags.h
+++ b/src/cbor/tags.h
@@ -33,10 +33,11 @@ _CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_new_tag(uint64_t value);
 /** Get the tagged item (what the tag points to).
  *
  * @param tag A #CBOR_TYPE_TAG tag.
- * @return Reference to the tagged item.
+ * @return Reference to the tagged item, which may be `NULL` if no item has
+ * been set yet.
  *
- * Increases the reference count of the underlying item. The returned reference
- * must be released using #cbor_decref.
+ * If non-NULL, increases the reference count of the underlying item. The
+ * returned reference must be released using #cbor_decref.
  */
 _CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_tag_item(const cbor_item_t* tag);
 

--- a/test/tag_test.c
+++ b/test/tag_test.c
@@ -163,6 +163,12 @@ static void test_set_item_replaces_previous(void** _state _CBOR_UNUSED) {
   cbor_decref(&tag);
 }
 
+static void test_tag_item_null(void** _state _CBOR_UNUSED) {
+  tag = cbor_new_tag(0);
+  assert_null(cbor_tag_item(tag));
+  cbor_decref(&tag);
+}
+
 static void test_tag_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_tag(42)); });
 }
@@ -180,6 +186,7 @@ int main(void) {
       cmocka_unit_test(test_build_tag),
       cmocka_unit_test(test_build_tag_failure),
       cmocka_unit_test(test_set_item_replaces_previous),
+      cmocka_unit_test(test_tag_item_null),
       cmocka_unit_test(test_tag_creation),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary

- `cbor_tag_item()` previously passed NULL to `cbor_incref()` when called on a tag with no item set (e.g. freshly created via `cbor_new_tag()`), causing undefined behavior (NULL pointer dereference)
- Now returns NULL instead, propagating the absence of a tagged item to the caller
- Updated documentation to reflect that NULL is a valid return value

## Potentially breaking change

Previously, calling `cbor_tag_item()` on an uninitialized tag was undefined behavior (NULL dereference), so no valid clients should be affected.

## Test plan

- [x] Added `test_tag_item_null` verifying NULL is returned for a freshly created tag
- [x] All 26 test binaries pass
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)