### PR TITLE
Fix undefined behavior in NaN encoding shift

### DIFF
--- a/src/cbor/encoding.c
+++ b/src/cbor/encoding.c
@@ -183,7 +183,8 @@ size_t cbor_encode_single(float value, unsigned char* buffer,
   // way to extract it without assumptions about the internal float
   // representation.
   if (isnan(value)) {
-    return _cbor_encode_uint32(0x7FC0 << 16, buffer, buffer_size, 0xE0);
+    return _cbor_encode_uint32((uint32_t)0x7FC0 << 16, buffer, buffer_size,
+                               0xE0);
   }
   // TODO: Broken on systems that do not use IEEE 754
   return _cbor_encode_uint32(


### PR DESCRIPTION
## Summary

- `0x7FC0 << 16` in `cbor_encode_single()` overflows signed `int` on systems with 32-bit `int`, which is undefined behavior per the C standard
- Cast to `uint32_t` before shifting to make it well-defined
- The `cbor_encode_double()` case (`(uint64_t)0x7FF8 << 48`) was already correctly cast

## Test plan

- [x] All 26 test binaries pass (existing NaN encoding tests cover this path)
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)