### PR TITLE
Enable examples in Windows CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
       - run: cd cmocka && git checkout tags/cmocka-1.1.5 
       - run: /c/Program\ Files/Cmake/bin/cmake -S cmocka -B cmocka_build
       - run: /c/Program\ Files/Cmake/bin/cmake --build cmocka_build
-      - run: /c/Program\ Files/Cmake/bin/cmake -S . -B libcbor_build -DWITH_TESTS=ON -DCMOCKA_INCLUDE_DIR=cmocka/include -DCMOCKA_LIBRARIES=$(pwd)/cmocka_build/src/Debug/cmocka.lib
+      - run: /c/Program\ Files/Cmake/bin/cmake -S . -B libcbor_build -DWITH_TESTS=ON -DWITH_EXAMPLES=ON -DCMOCKA_INCLUDE_DIR=cmocka/include -DCMOCKA_LIBRARIES=$(pwd)/cmocka_build/src/Debug/cmocka.lib
       - run: /c/Program\ Files/Cmake/bin/cmake --build libcbor_build
       - run: >
           export PATH="$(pwd)/cmocka_build/src/Debug/:$PATH" &&


### PR DESCRIPTION
## Summary
- Add `-DWITH_EXAMPLES=ON` to the Windows MSVC CI job so that Windows-specific build issues in examples are caught

## Test plan
- [ ] Windows CI (build-and-test-win) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)