### PR TITLE
Fix sizeof in test allocator mock

### DIFF
--- a/test/test_allocator.c
+++ b/test/test_allocator.c
@@ -16,7 +16,7 @@ void set_mock_malloc(int calls, ...) {
   va_start(args, calls);
   alloc_calls_expected = calls;
   alloc_calls = 0;
-  expectations = calloc(calls, sizeof(expectations));
+  expectations = calloc(calls, sizeof(*expectations));
   for (int i = 0; i < calls; i++) {
     // Promotable types, baby
     expectations[i] = va_arg(args, call_expectation);


### PR DESCRIPTION
## Summary
- Fix `sizeof(expectations)` (pointer size) to `sizeof(*expectations)` (element size) in `test/test_allocator.c`
- In practice this over-allocates on 64-bit (pointer > enum) so no runtime issue, but the intent is wrong

## Test plan
- [x] All 26 tests pass (this is the foundation of all allocation-failure tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)