### PR TITLE
Fix critical documentation errors

### DIFF
--- a/doc/source/api/streaming_encoding.rst
+++ b/doc/source/api/streaming_encoding.rst
@@ -7,7 +7,7 @@ exposes a low-level encoding API to encode CBOR objects on the fly. Unlike
 strings, etc.) instead of :type:`cbor_item_t`. The client is responsible for
 constructing the compound types correctly (e.g. terminating arrays).
 
-Streaming encoding is typically used to create an streaming (indefinite length) CBOR :doc:`strings <type_2_byte_strings>`, :doc:`byte strings <type_3_strings>`, :doc:`arrays <type_4_arrays>`, and :doc:`maps <type_5_maps>`. Complete example: `examples/streaming_array.c <https://github.com/PJK/libcbor/blob/master/examples/streaming_array.c>`_
+Streaming encoding is typically used to create a streaming (indefinite length) CBOR :doc:`byte strings <type_2_byte_strings>`, :doc:`strings <type_3_strings>`, :doc:`arrays <type_4_arrays>`, and :doc:`maps <type_5_maps>`. Complete example: `examples/streaming_array.c <https://github.com/PJK/libcbor/blob/master/examples/streaming_array.c>`_
 
 .. doxygenfunction:: cbor_encode_uint8
 

--- a/doc/source/api/type_0_1_integers.rst
+++ b/doc/source/api/type_0_1_integers.rst
@@ -24,7 +24,7 @@ Number of allocations               One per lifetime
 Storage requirements                ``sizeof(cbor_item_t) + sizeof(uint*_t)``
 ==================================  =========================================
 
-**Note:** once a positive integer has been created, its width *cannot* be changed.
+**Note:** once a negative integer has been created, its width *cannot* be changed.
 
 Type 0 & 1
 -------------
@@ -44,7 +44,7 @@ An integer item is created with one of the four widths. Because integers' `stora
 
         cbor_item_t * item = cbor_new_int8();
         cbor_mark_negint(item);
-        cbor_set_uint8(0);
+        cbor_set_uint8(item, 0);
 
     will produce an item with the logical value of :math:`-1`. There is, however, an upside to this as well: There is only one representation of zero.
 

--- a/doc/source/api/type_2_byte_strings.rst
+++ b/doc/source/api/type_2_byte_strings.rst
@@ -7,7 +7,7 @@ In case a byte string is indefinite, it is encoded as a series of definite byte 
 
 ::
 
-    0xf5	    Start indefinite byte string
+    0x5f	    Start indefinite byte string
 	0x41	    Byte string (1B long)
 	    0x00
 	0x41	    Byte string (1B long)

--- a/doc/source/api/type_4_arrays.rst
+++ b/doc/source/api/type_4_arrays.rst
@@ -29,7 +29,7 @@ Examples
 
 ::
 
-    0x9f        Start array, 1B length follows
+    0x98        Start definite array, 1B length follows
     0x20        Unsigned integer 32
         ...        32 items follow
 

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -29,7 +29,7 @@ Building & installing libcbor
 
 Prerequisites:
  - C99 compiler
- - CMake_ 2.8 or newer (might also be called ``cmakesetup``, ``cmake-gui`` or ``ccmake`` depending on the installed version and system)
+ - CMake_ 3.5 or newer (might also be called ``cmakesetup``, ``cmake-gui`` or ``ccmake`` depending on the installed version and system)
  - C build system CMake can target (make, Apple Xcode, MinGW, ...)
 
 .. _CMake: http://cmake.org/

--- a/src/cbor/callbacks.h
+++ b/src/cbor/callbacks.h
@@ -67,9 +67,9 @@ struct cbor_callbacks {
   /** Negative int */
   cbor_int8_callback negint8;
 
-  /** Definite byte string */
-  cbor_simple_callback byte_string_start;
   /** Indefinite byte string start */
+  cbor_simple_callback byte_string_start;
+  /** Definite byte string */
   cbor_string_callback byte_string;
 
   /** Definite string */
@@ -77,14 +77,14 @@ struct cbor_callbacks {
   /** Indefinite string start */
   cbor_simple_callback string_start;
 
-  /** Definite array */
+  /** Indefinite array start */
   cbor_simple_callback indef_array_start;
-  /** Indefinite array */
+  /** Definite array */
   cbor_collection_callback array_start;
 
-  /** Definite map */
+  /** Indefinite map start */
   cbor_simple_callback indef_map_start;
-  /** Indefinite map */
+  /** Definite map */
   cbor_collection_callback map_start;
 
   /** Tags */


### PR DESCRIPTION
## Summary
- Fix swapped Doxygen comments in `callbacks.h`: definite/indefinite labels were reversed for byte strings, arrays, and maps. Since `streaming_decoding.rst` auto-generates from these via `doxygenstruct`, the streaming API docs showed wrong descriptions.
- Fix CBOR encoding example in byte strings docs: `0xf5` (boolean true) -> `0x5f` (indefinite byte string start)
- Fix CBOR encoding example in arrays docs: `0x9f` (indefinite array) described as definite -> `0x98` (definite array, 1B length)
- Fix missing `item` argument in `cbor_set_uint8` code example (wouldn't compile)
- Fix "positive integer" -> "negative integer" in Type 1 section (copy-paste error)
- Fix CMake minimum version: 2.8 -> 3.5 (actual requirement since PR #355)
- Fix swapped cross-references in streaming encoding docs (strings linked to byte strings page and vice versa)

## Test plan
- [x] All 26 tests pass
- [x] Visual review of all changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)