### PR TITLE
Smaller documentation fixes and updates

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -10,7 +10,7 @@ The data API is centered around :type:`cbor_item_t`, a generic handle for any CB
 
 The single most important thing to keep in mind is: :type:`cbor_item_t` **is an opaque type and should only be manipulated using the appropriate functions!** Think of it as an object.
 
-The *libcbor* API closely follows the semantics outlined by `CBOR standard <https://tools.ietf.org/html/rfc7049>`_. This part of the documentation provides a short overview of the CBOR constructs, as well as a general introduction to the *libcbor* API. Remaining reference can be found in the following files structured by data types.
+The *libcbor* API closely follows the semantics outlined by `CBOR standard <https://www.rfc-editor.org/rfc/rfc8949.html>`_. This part of the documentation provides a short overview of the CBOR constructs, as well as a general introduction to the *libcbor* API. Remaining reference can be found in the following files structured by data types.
 
 The API is designed to allow both very tight control & flexibility and general convenience with sane defaults. [#]_ For example, client with very specific requirements (constrained environment, custom application protocol built on top of CBOR, etc.) may choose to take full control (and responsibility) of memory and data structures management by interacting directly with the decoder. Other clients might want to take control of specific aspects (streamed collections, hash maps storage), but leave other responsibilities to *libcbor*. More general clients might prefer to be abstracted away from all aforementioned details and only be presented complete data structures.
 

--- a/doc/source/api/type_0_1_integers.rst
+++ b/doc/source/api/type_0_1_integers.rst
@@ -55,10 +55,15 @@ Building new items
 .. doxygenfunction:: cbor_build_uint16
 .. doxygenfunction:: cbor_build_uint32
 .. doxygenfunction:: cbor_build_uint64
+.. doxygenfunction:: cbor_build_negint8
+.. doxygenfunction:: cbor_build_negint16
+.. doxygenfunction:: cbor_build_negint32
+.. doxygenfunction:: cbor_build_negint64
 
 
 Retrieving values
 ------------------------
+.. doxygenfunction:: cbor_get_int
 .. doxygenfunction:: cbor_get_uint8
 .. doxygenfunction:: cbor_get_uint16
 .. doxygenfunction:: cbor_get_uint32

--- a/doc/source/api/type_3_strings.rst
+++ b/doc/source/api/type_3_strings.rst
@@ -22,6 +22,7 @@ Getting metadata
 ~~~~~~~~~~~~~~~~~
 
 .. doxygenfunction:: cbor_string_length
+.. doxygenfunction:: cbor_string_codepoint_count
 .. doxygenfunction:: cbor_string_is_definite
 .. doxygenfunction:: cbor_string_is_indefinite
 .. doxygenfunction:: cbor_string_chunk_count
@@ -42,6 +43,7 @@ Creating new items
 Building items
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. doxygenfunction:: cbor_build_string
+.. doxygenfunction:: cbor_build_stringn
 
 
 Manipulating existing items

--- a/doc/source/api/type_6_tags.rst
+++ b/doc/source/api/type_6_tags.rst
@@ -15,11 +15,11 @@ applied to.
 ==================================  ======================================================
 Corresponding :type:`cbor_type`     ``CBOR_TYPE_TAG``
 Number of allocations               One plus any manipulations with the data
-                                    reallocations relative  to chunk count
 Storage requirements                ``sizeof(cbor_item_t) + the tagged item``
 ==================================  ======================================================
 
 .. doxygenfunction:: cbor_new_tag
+.. doxygenfunction:: cbor_build_tag
 .. doxygenfunction:: cbor_tag_item
 .. doxygenfunction:: cbor_tag_value
 .. doxygenfunction:: cbor_tag_set_item

--- a/doc/source/internal.rst
+++ b/doc/source/internal.rst
@@ -51,7 +51,7 @@ Combining these two principles in practice turns out to be quite difficult. Inde
 
 Coding style
 -------------
-This code loosely follows the `Linux kernel coding style <https://www.kernel.org/doc/Documentation/CodingStyle>`_. Tabs are tabs, and they are 4 characters wide.
+This code uses a Google-based clang-format style with 2-space indentation and an 80-column limit. Run ``bash clang-format.sh`` before committing.
 
 
 Memory layout


### PR DESCRIPTION
## Summary
- Update outdated RFC 7049 reference to RFC 8949 in `api.rst`
- Fix coding style description in `internal.rst`: was "Linux kernel style, 4-char tabs", actual is Google-based clang-format with 2-space indent
- Add missing API docs for `cbor_get_int`, `cbor_build_negint8/16/32/64` in integers page
- Add missing API docs for `cbor_string_codepoint_count`, `cbor_build_stringn` in strings page
- Add missing API docs for `cbor_build_tag` in tags page
- Remove leftover "reallocations relative to chunk count" text from tags page (tags don't have chunks)

## Test plan
- [x] All 26 tests pass
- [x] Visual review of all changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)