### PR TITLE
Fix typos and style issues in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ libcbor is most prominently used in:
 - [QEMU](https://wiki.qemu.org/ChangeLog/9.2)
 - [ITK](https://docs.itk.org/projects/wasm/en/latest/introduction/parts.html)
 
-It found its way into many open source an proprietary projects. If you run among others [OpenSSH](https://www.matbra.com/2020/02/17/using-fido2-with-ssh.html), [Microsoft PowerShell](https://github.com/PowerShell/libcbor), [SteamOS](https://github.com/randombk/steamos-teardown/blob/5a37d977fae55d9c41eaf1d07528fa965740bb26/docs/packages.md?plain=1#L461), or [MySQL](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html) -- you might be indirectly running libcbor too.
+It found its way into many open source and proprietary projects. If you run among others [OpenSSH](https://www.matbra.com/2020/02/17/using-fido2-with-ssh.html), [Microsoft PowerShell](https://github.com/PowerShell/libcbor), [SteamOS](https://github.com/randombk/steamos-teardown/blob/5a37d977fae55d9c41eaf1d07528fa965740bb26/docs/packages.md?plain=1#L461), or [MySQL](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html) -- you might be indirectly running libcbor too.
 
 Also, thank you for the shout out in <https://github.com/oz123/awesome-c?tab=readme-ov-file#others>!
 
@@ -67,7 +67,7 @@ sudo apt-get install libcbor-dev
 yum install libcbor-devel
 ```
 
-### Include git repository using using CMake
+### Include git repository using CMake
 
 See e.g. <https://github.com/inclavare-containers/librats/blob/master/cmake/LibCBOR.cmake>.
 

--- a/doc/source/api/decoding.rst
+++ b/doc/source/api/decoding.rst
@@ -33,7 +33,7 @@ The following diagram illustrates the relationship among different parts of libc
     │                                                                                              │
     └──────────────────────────────────────────────────────────────────────────────────────────────┘
 
-                  (PSD = Provided Data Structures, CDS = Custom Data Structures)
+                  (PDS = Provided Data Structures, CDS = Custom Data Structures)
 
 This section will deal with the API that is labeled as the "Default driver" in the diagram. That is, routines that
 decode complete libcbor data items

--- a/doc/source/api/item_reference_counting.rst
+++ b/doc/source/api/item_reference_counting.rst
@@ -8,7 +8,7 @@ If you have specific requirements, you should consider rolling your own driver f
 Using custom allocator
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-*libcbor* gives you with the ability to provide your own implementations of ``malloc``, ``realloc``, and ``free``. 
+*libcbor* gives you the ability to provide your own implementations of ``malloc``, ``realloc``, and ``free``. 
 This can be useful if you are using a custom allocator throughout your application, 
 or if you want to implement custom policies (e.g. tighter restrictions on the amount of allocated memory).
 

--- a/doc/source/api/type_5_maps.rst
+++ b/doc/source/api/type_5_maps.rst
@@ -5,7 +5,7 @@ CBOR maps are the plain old associative maps similar JSON objects or Python dict
 
 Definite maps have a fixed size which is stored in the header, whereas indefinite maps do not and are terminated by a special "break" byte instead.
 
-Map are explicitly created or decoded as definite or indefinite and will be encoded using the corresponding wire representation, regardless of whether the actual size is known at the time of encoding.
+Maps are explicitly created or decoded as definite or indefinite and will be encoded using the corresponding wire representation, regardless of whether the actual size is known at the time of encoding.
 
 .. note::
 

--- a/doc/source/api/type_6_tags.rst
+++ b/doc/source/api/type_6_tags.rst
@@ -1,7 +1,7 @@
 Type 6 – Semantic tags 
 =============================
 
-Tag are additional metadata that can be used to extend or specialize the meaning or interpretation of the other data items.
+Tags are additional metadata that can be used to extend or specialize the meaning or interpretation of the other data items.
 
 For example, one might tag an array of numbers to communicate that it should be interpreted as a vector.
 

--- a/doc/source/api/type_7_floats_ctrls.rst
+++ b/doc/source/api/type_7_floats_ctrls.rst
@@ -65,11 +65,11 @@ Manipulating existing items
 Half floats
 ~~~~~~~~~~~~
 CBOR supports two `bytes wide ("half-precision") <https://en.wikipedia.org/wiki/Half-precision_floating-point_format>`_
-floats which are not supported by the C language. *libcbor* represents them using `float <https://en.cppreference.com/w/c/language/type>` values throughout the API. Encoding will be performed by :func:`cbor_encode_half`, which will handle any values that cannot be represented as a half-float.
+floats which are not supported by the C language. *libcbor* represents them using `float <https://en.cppreference.com/w/c/language/type>`_ values throughout the API. Encoding will be performed by :func:`cbor_encode_half`, which will handle any values that cannot be represented as a half-float.
 
 Signaling NaNs
 ~~~~~~~~~~~~~~~~
 
-`Signaling NaNs <https://en.wikipedia.org/wiki/NaN#Signaling_NaN)>`_ are always encoded as a standard, "quiet" NaN.
+`Signaling NaNs <https://en.wikipedia.org/wiki/NaN#Signaling_NaN>`_ are always encoded as a standard, "quiet" NaN.
 
 The reason for this simplification is that standard C does not offer a way to handle the signaling payload without assumptions about the host architecture. See https://github.com/PJK/libcbor/issues/336 for more context.

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -30,7 +30,7 @@ Anything the standard allows, libcbor can do.
 **Why?** Because conformance and interoperability is the point of defining
 standards. Clients expect the support to be feature-complete and
 there is no significant complexity reduction that can be achieved by slightly
-cutting corners, which means that the incremental cost of full [CBOR standard](https://www.rfc-editor.org/info/std94) support is
+cutting corners, which means that the incremental cost of full `CBOR standard <https://www.rfc-editor.org/info/std94>`_ support is
 comparatively small over "almost-conformance" seen in many alternatives.
 
 

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -154,7 +154,7 @@ libcbor is known to successfully work on ARM Android devices. Cross-compilation 
 Linking with libcbor
 ---------------------
 
-If you include and linker paths include the directories to which libcbor has been installed, compiling programs that uses libcbor requires
+If your include and linker paths include the directories to which libcbor has been installed, compiling programs that uses libcbor requires
 no extra considerations.
 
 You can verify that everything has been set up properly by creating a file with the following contents
@@ -208,7 +208,7 @@ location by checking the installation log. If you used make, it will look someth
     -- Installing: /usr/local/include/cbor/encoding.h
     ...
 
-Make sure that ``CMAKE_INSTALL_PREFIX`` (if you provided it) was correct. Including the path path during compilation should suffice, e.g.:
+Make sure that ``CMAKE_INSTALL_PREFIX`` (if you provided it) was correct. Including the path during compilation should suffice, e.g.:
 
 .. code-block:: bash
 

--- a/doc/source/internal.rst
+++ b/doc/source/internal.rst
@@ -112,7 +112,7 @@ Generally speaking, data items consist of three parts:
 
     .. member:: struct _cbor_int_metadata int_metadata
 
-        Used both by both :doc:`api/type_0_1_integers`
+        Used by both :doc:`api/type_0_1_integers`
 
     .. member:: struct _cbor_bytestring_metadata bytestring_metadata
     .. member:: struct _cbor_string_metadata string_metadata
@@ -124,5 +124,5 @@ Generally speaking, data items consist of three parts:
 Decoding
 ---------
 
-As outlined in :doc:`api`, there decoding is based on the streaming decoder Essentially, the decoder is a custom set of callbacks for the streaming decoder.
+As outlined in :doc:`api`, the decoding is based on the streaming decoder. Essentially, the decoder is a custom set of callbacks for the streaming decoder.
 

--- a/doc/source/standard_conformance.rst
+++ b/doc/source/standard_conformance.rst
@@ -11,7 +11,7 @@ There is no explicit limitation of indefinite length byte strings. [#]_ *libcbor
 
 "Half-precision" IEEE 754 floats
 ---------------------------------
-As of C99 and even C11, there is no standard implementation for 2 bytes floats. *libcbor* packs them as a `float <https://en.cppreference.com/w/c/language/type>`. When encoding, *libcbor* selects the appropriate wire representation based on metadata and the actual value. This applies both to canonical and normal mode.
+As of C99 and even C11, there is no standard implementation for 2 bytes floats. *libcbor* packs them as a `float <https://en.cppreference.com/w/c/language/type>`_. When encoding, *libcbor* selects the appropriate wire representation based on metadata and the actual value. This applies both to canonical and normal mode.
 
 For more information on half-float serialization, please refer to the section on :ref:`api_type_7_floats_ctrls_half_floats`.
 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -8,7 +8,7 @@ Where to start
 --------------
 
 - Skim through the Crash course section below.
-- Examples of of how to read, write, manipulate, and translate data to and from JSON using *libcbor* are in the `examples directory <https://github.com/PJK/libcbor/tree/master/examples>`_.
+- Examples of how to read, write, manipulate, and translate data to and from JSON using *libcbor* are in the `examples directory <https://github.com/PJK/libcbor/tree/master/examples>`_.
 - The :doc:`API documentation <api>` is a complete reference of *libcbor*.
 
 


### PR DESCRIPTION
## Summary
Fixes 14 typos, grammar issues, and broken links across 11 files:

- **getting_started.rst**: "If you include" -> "If your include"; "the path path" -> "the path"
- **tutorial.rst**: "Examples of of" -> "Examples of"
- **decoding.rst**: Legend abbreviation "PSD" -> "PDS" to match diagram
- **item_reference_counting.rst**: "gives you with" -> "gives you"
- **internal.rst**: "there decoding" -> "the decoding"; "Used both by both" -> "Used by both"
- **type_5_maps.rst**: "Map are" -> "Maps are"
- **type_6_tags.rst**: "Tag are" -> "Tags are"
- **type_7_floats_ctrls.rst**: Fix missing `_` in RST link for `float`; remove extra `)` in Signaling NaN URL
- **standard_conformance.rst**: Fix missing `_` in RST link for `float`
- **development.rst**: Convert Markdown link to RST syntax
- **README.md**: "an proprietary" -> "and proprietary"; "using using" -> "using"

## Test plan
- [x] All 26 tests pass
- [x] Visual review of all changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)