### PR TITLE
Fix bugs and cleanup in example code

### DIFF
--- a/examples/cbor_sequence.c
+++ b/examples/cbor_sequence.c
@@ -21,8 +21,8 @@ void write_cbor_sequence(const char* filename) {
   cbor_item_t* int_item = cbor_build_uint32(42);
   cbor_item_t* string_item = cbor_build_string("Hello, CBOR!");
   cbor_item_t* array_item = cbor_new_definite_array(2);
-  assert(cbor_array_push(array_item, cbor_build_uint8(1)));
-  assert(cbor_array_push(array_item, cbor_build_uint8(2)));
+  assert(cbor_array_push(array_item, cbor_move(cbor_build_uint8(1))));
+  assert(cbor_array_push(array_item, cbor_move(cbor_build_uint8(2))));
 
   // Serialize and write items to the file
   unsigned char* buffer;

--- a/examples/cjson2cbor.c
+++ b/examples/cjson2cbor.c
@@ -141,5 +141,7 @@ int main(int argc, char* argv[]) {
   free(buffer);
   fflush(stdout);
   cJSON_Delete(json);
+  free(json_buffer);
   cbor_decref(&cbor);
+  fclose(f);
 }

--- a/examples/readfile.c
+++ b/examples/readfile.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "cbor.h"
 
 void usage(void) {

--- a/examples/sort.c
+++ b/examples/sort.c
@@ -39,4 +39,5 @@ int main(void) {
 
   cbor_describe(array, stdout);
   fflush(stdout);
+  cbor_decref(&array);
 }

--- a/examples/streaming_array.c
+++ b/examples/streaming_array.c
@@ -5,6 +5,7 @@
  * it under the terms of the MIT license. See LICENSE for details.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include "cbor.h"
 
@@ -31,7 +32,7 @@ void flush(size_t bytes) {
 int main(int argc, char* argv[]) {
   if (argc != 2) usage();
   size_t n;
-  scanf(argv[1], "%zu", &n);
+  sscanf(argv[1], "%zu", &n);
   out = freopen(NULL, "wb", stdout);
   if (!out) exit(1);
 

--- a/examples/streaming_parser.c
+++ b/examples/streaming_parser.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "cbor.h"
 


### PR DESCRIPTION
## Summary
- **Bug**: Fix `scanf` -> `sscanf` in `streaming_array.c` — the command-line argument was never actually parsed
- **Bug**: Fix memory leak in `cbor_sequence.c` — missing `cbor_move` on `cbor_array_push` calls
- **Cleanup**: Add missing `#include <stdio.h>` in `streaming_array.c`
- **Cleanup**: Add missing `#include <stdlib.h>` in `readfile.c` and `streaming_parser.c`
- **Cleanup**: Free `json_buffer` and close file handle in `cjson2cbor.c`
- **Cleanup**: Add missing `cbor_decref` for array in `sort.c`

## Test plan
- [x] All examples compile
- [x] All 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)