### PR TITLE
Fix Windows CI build failure and improve build speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,9 +218,9 @@ jobs:
       - run: git clone https://git.cryptomilk.org/projects/cmocka.git
       - run: cd cmocka && git checkout tags/cmocka-1.1.5 
       - run: /c/Program\ Files/Cmake/bin/cmake -S cmocka -B cmocka_build
-      - run: /c/Program\ Files/Cmake/bin/cmake --build cmocka_build
+      - run: /c/Program\ Files/Cmake/bin/cmake --build cmocka_build --parallel
       - run: /c/Program\ Files/Cmake/bin/cmake -S . -B libcbor_build -DWITH_TESTS=ON -DWITH_EXAMPLES=ON -DCMOCKA_INCLUDE_DIR=cmocka/include -DCMOCKA_LIBRARIES=$(pwd)/cmocka_build/src/Debug/cmocka.lib
-      - run: /c/Program\ Files/Cmake/bin/cmake --build libcbor_build
+      - run: /c/Program\ Files/Cmake/bin/cmake --build libcbor_build --parallel
       - run: >
           export PATH="$(pwd)/cmocka_build/src/Debug/:$PATH" &&
           /c/Program\ Files/Cmake/bin/ctest.exe --test-dir libcbor_build -C Debug --output-on-failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Next
   - The option has been a no-op since 0.10.0. If your build passes `-DCBOR_CUSTOM_ALLOC=ON`, remove it.
 - [Modernize CMake build: use `project(VERSION ...)`, replace `add_definitions()` with target-scoped `target_compile_definitions()`, remove redundant `include_directories()`](https://github.com/PJK/libcbor/pull/402)
 - [Replace global `CMAKE_C_FLAGS` mutations with target-scoped `target_compile_options()` via an INTERFACE library, and simplify LTO configuration](https://github.com/PJK/libcbor/pull/403)
+- [Fix Windows CI: propagate `_CRT_SECURE_NO_WARNINGS` to examples/tests, restrict LTO to Release builds, parallelize Windows CI build](https://github.com/PJK/libcbor/pull/XXX)
 
 0.13.0 (2025-08-30)
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Next
   - The option has been a no-op since 0.10.0. If your build passes `-DCBOR_CUSTOM_ALLOC=ON`, remove it.
 - [Modernize CMake build: use `project(VERSION ...)`, replace `add_definitions()` with target-scoped `target_compile_definitions()`, remove redundant `include_directories()`](https://github.com/PJK/libcbor/pull/402)
 - [Replace global `CMAKE_C_FLAGS` mutations with target-scoped `target_compile_options()` via an INTERFACE library, and simplify LTO configuration](https://github.com/PJK/libcbor/pull/403)
-- [Fix Windows CI: propagate `_CRT_SECURE_NO_WARNINGS` to examples/tests, restrict LTO to Release builds, parallelize Windows CI build](https://github.com/PJK/libcbor/pull/XXX)
+- [Fix Windows CI: propagate `_CRT_SECURE_NO_WARNINGS` to examples/tests, restrict LTO to Release builds, parallelize Windows CI build](https://github.com/PJK/libcbor/pull/404)
 
 0.13.0 (2025-08-30)
 ---------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ endif()
 if(MSVC)
   target_compile_options(cbor_project_options INTERFACE
     $<$<CONFIG:Debug>:/sdl>)
+  target_compile_definitions(cbor_project_options INTERFACE
+    _CRT_SECURE_NO_WARNINGS)
 else()
   target_compile_options(cbor_project_options INTERFACE
     $<$<CONFIG:Debug>:-O0 -Wall -Wextra -g -ggdb>
@@ -159,14 +161,14 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.9.0")
   check_ipo_supported(RESULT LTO_SUPPORTED)
 endif()
 
-if(LTO_SUPPORTED AND NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+if(LTO_SUPPORTED AND NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
 endif()
 
 if(LTO_SUPPORTED)
   message(
     STATUS
-    "LTO is supported and CMAKE_INTERPROCEDURAL_OPTIMIZATION=${CMAKE_INTERPROCEDURAL_OPTIMIZATION}"
+    "LTO is supported and CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=${CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE}"
   )
 else()
   message(STATUS "LTO is not supported")


### PR DESCRIPTION
## Summary

- **Fix build failure**: Add `_CRT_SECURE_NO_WARNINGS` to the `cbor_project_options` INTERFACE library so examples and tests don't fail with MSVC C4996 errors when `/sdl` is active (`sscanf`, `freopen`, `fopen` usages in examples)
- **Restrict LTO to Release only**: Use `CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE` instead of `CMAKE_INTERPROCEDURAL_OPTIMIZATION` to avoid unnecessary LTCG overhead in Debug builds
- **Parallelize Windows CI**: Add `--parallel` to `cmake --build` commands

## Context

The Windows CI failure was introduced in #402 when `add_definitions(-D_CRT_SECURE_NO_WARNINGS)` (global) was replaced with `target_compile_definitions(cbor PRIVATE _CRT_SECURE_NO_WARNINGS)` (library-only). The `/sdl` flag from `cbor_project_options` turns C4996 deprecation warnings into errors for example targets that use standard CRT functions.

## Test plan

- [ ] Windows CI (`build-and-test-win`) passes
- [ ] Linux/macOS CI passes (no LTO in Debug, LTO in Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)