### PR TITLE
Fix macOS CI: set resource_class and bump Xcode to 16.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,8 @@ jobs:
 
   build-and-test-osx:
     macos:
-      xcode: 16.0.0
+      xcode: 16.4.0
+    resource_class: m4pro.medium
     steps:
       - checkout
       - run: bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,4 +304,4 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: [master]
+              only: [master, fix-macos-ci]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,4 +304,4 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: [master, fix-macos-ci]
+              only: [master]


### PR DESCRIPTION
## Summary

- Set `resource_class: m4pro.medium` explicitly (required since CircleCI changed the default)
- Bump Xcode from 16.0.0 to 16.4.0 (latest stable on m4pro)

## Context

The `build-and-test-osx` job on master is failing with:
> Job was rejected because resource class m4pro.medium, image xcode:16.0.0 is not a valid resource class

CircleCI now [requires explicit resource_class for macOS jobs](https://circleci.com/changelog/free-plan-default-macos-resource-class-changes-to-m4pro-medium-on-november/). M1/M2 resource classes reach end of life on February 16, 2026.

## Test plan

- [ ] `build-and-test-osx` passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)