### PR TITLE
Add cbor_structurally_equal for encoding-level item comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Next
 - [Modernize CMake build: use `project(VERSION ...)`, replace `add_definitions()` with target-scoped `target_compile_definitions()`, remove redundant `include_directories()`](https://github.com/PJK/libcbor/pull/402)
 - [Replace global `CMAKE_C_FLAGS` mutations with target-scoped `target_compile_options()` via an INTERFACE library, and simplify LTO configuration](https://github.com/PJK/libcbor/pull/403)
 - [Fix Windows CI: propagate `_CRT_SECURE_NO_WARNINGS` to examples/tests, restrict LTO to Release builds, parallelize Windows CI build](https://github.com/PJK/libcbor/pull/404)
+- [Add `cbor_structurally_equal` for encoding-level item comparison](https://github.com/PJK/libcbor/pull/408)
+  - Compares two items structurally: encoding width, definite-vs-indefinite length, chunk boundaries, and map entry order all count
+  - Runs in O(n) time in the encoded byte size with no additional allocations
+  - See also: #96
 
 0.13.0 (2025-08-30)
 ---------------------

--- a/doc/source/api/item_types.rst
+++ b/doc/source/api/item_types.rst
@@ -39,3 +39,33 @@ These functions provide information about the item type from a more high-level p
 .. doxygenfunction:: cbor_is_bool
 .. doxygenfunction:: cbor_is_null
 .. doxygenfunction:: cbor_is_undef
+
+
+Comparing items
+------------------------
+
+.. doxygenfunction:: cbor_structurally_equal
+
+.. note::
+
+   ``cbor_structurally_equal`` implements **structural** equality: every
+   aspect of the encoding is significant, including integer width, float
+   width, definite-vs-indefinite length, chunk boundaries, and map entry
+   order.  This is intentionally stricter than the data-model equality
+   defined by :rfc:`8949`.
+
+   Key differences from data-model equality:
+
+   * ``cbor_build_uint8(1)`` and ``cbor_build_uint16(1)`` are **not**
+     structurally equal, even though both represent the integer ``1``.
+   * Two maps with the same key-value pairs but in a different encoded
+     order are **not** structurally equal. (:rfc:`8949` §5.6.1 defines
+     maps as unordered sets of key-value pairs at the data-model level.)
+   * Two indefinite-length byte strings that carry the same bytes split
+     across different chunk boundaries are **not** structurally equal.
+   * Floating-point NaN values with different bit patterns are **not**
+     structurally equal.
+
+   If you need data-model equality (e.g. ``uint8(1) == uint64(1)``),
+   you must implement it on top of this library using the value
+   accessors (``cbor_get_uint64``, etc.).

--- a/doc/source/api/item_types.rst
+++ b/doc/source/api/item_types.rst
@@ -69,3 +69,8 @@ Comparing items
    If you need data-model equality (e.g. ``uint8(1) == uint64(1)``),
    you must implement it on top of this library using the value
    accessors (``cbor_get_uint64``, etc.).
+
+   **Complexity**: because structural equality short-circuits on the first
+   mismatch and otherwise visits each byte of data exactly once, the
+   runtime is *O(n)* in the encoded byte size of the items being compared.
+   No additional memory is allocated.

--- a/src/cbor/common.c
+++ b/src/cbor/common.c
@@ -165,3 +165,129 @@ cbor_item_t* cbor_move(cbor_item_t* item) {
   item->refcount--;
   return item;
 }
+
+bool cbor_structurally_equal(const cbor_item_t* item1,
+                             const cbor_item_t* item2) {
+  CBOR_ASSERT(item1 != NULL);
+  CBOR_ASSERT(item2 != NULL);
+  if (item1->type != item2->type) return false;
+
+  switch (item1->type) {
+    case CBOR_TYPE_UINT:
+    case CBOR_TYPE_NEGINT: {
+      /* Encoding width (CBOR_INT_8/16/32/64) is part of structural identity */
+      if (cbor_int_get_width(item1) != cbor_int_get_width(item2)) return false;
+      /* Compare the raw data bytes that back the integer value */
+      static const size_t int_widths[] = {1, 2, 4, 8};
+      return memcmp(item1->data, item2->data,
+                    int_widths[cbor_int_get_width(item1)]) == 0;
+    }
+
+    case CBOR_TYPE_BYTESTRING: {
+      /* Definite vs. indefinite encoding is structurally distinct */
+      if (cbor_bytestring_is_definite(item1) !=
+          cbor_bytestring_is_definite(item2))
+        return false;
+      if (cbor_bytestring_is_definite(item1)) {
+        if (cbor_bytestring_length(item1) != cbor_bytestring_length(item2))
+          return false;
+        return memcmp(item1->data, item2->data,
+                      cbor_bytestring_length(item1)) == 0;
+      } else {
+        /* Indefinite: chunk count and each chunk must match structurally */
+        size_t count = cbor_bytestring_chunk_count(item1);
+        if (count != cbor_bytestring_chunk_count(item2)) return false;
+        cbor_item_t** c1 = cbor_bytestring_chunks_handle(item1);
+        cbor_item_t** c2 = cbor_bytestring_chunks_handle(item2);
+        for (size_t i = 0; i < count; i++)
+          if (!cbor_structurally_equal(c1[i], c2[i])) return false;
+        return true;
+      }
+    }
+
+    case CBOR_TYPE_STRING: {
+      /* Definite vs. indefinite encoding is structurally distinct */
+      if (cbor_string_is_definite(item1) != cbor_string_is_definite(item2))
+        return false;
+      if (cbor_string_is_definite(item1)) {
+        if (cbor_string_length(item1) != cbor_string_length(item2))
+          return false;
+        return memcmp(item1->data, item2->data, cbor_string_length(item1)) == 0;
+      } else {
+        /* Indefinite: chunk boundaries are part of the structure */
+        size_t count = cbor_string_chunk_count(item1);
+        if (count != cbor_string_chunk_count(item2)) return false;
+        cbor_item_t** c1 = cbor_string_chunks_handle(item1);
+        cbor_item_t** c2 = cbor_string_chunks_handle(item2);
+        for (size_t i = 0; i < count; i++)
+          if (!cbor_structurally_equal(c1[i], c2[i])) return false;
+        return true;
+      }
+    }
+
+    case CBOR_TYPE_ARRAY: {
+      /* Definite vs. indefinite encoding is structurally distinct */
+      if (cbor_array_is_definite(item1) != cbor_array_is_definite(item2))
+        return false;
+      size_t size = cbor_array_size(item1);
+      if (size != cbor_array_size(item2)) return false;
+      cbor_item_t** h1 = cbor_array_handle(item1);
+      cbor_item_t** h2 = cbor_array_handle(item2);
+      for (size_t i = 0; i < size; i++)
+        if (!cbor_structurally_equal(h1[i], h2[i])) return false;
+      return true;
+    }
+
+    case CBOR_TYPE_MAP: {
+      /* Definite vs. indefinite encoding is structurally distinct */
+      if (cbor_map_is_definite(item1) != cbor_map_is_definite(item2))
+        return false;
+      size_t size = cbor_map_size(item1);
+      if (size != cbor_map_size(item2)) return false;
+      /*
+       * Structural equality for maps is positional: pair at index i in item1
+       * must match pair at index i in item2 (both key and value). This reflects
+       * the encoded byte order. Use cbor_map_handle to avoid refcount churn.
+       */
+      struct cbor_pair* p1 = cbor_map_handle(item1);
+      struct cbor_pair* p2 = cbor_map_handle(item2);
+      for (size_t i = 0; i < size; i++)
+        if (!cbor_structurally_equal(p1[i].key, p2[i].key) ||
+            !cbor_structurally_equal(p1[i].value, p2[i].value))
+          return false;
+      return true;
+    }
+
+    case CBOR_TYPE_TAG: {
+      if (cbor_tag_value(item1) != cbor_tag_value(item2)) return false;
+      /* Access the tagged item directly to avoid refcount churn */
+      cbor_item_t* t1 = item1->metadata.tag_metadata.tagged_item;
+      cbor_item_t* t2 = item2->metadata.tag_metadata.tagged_item;
+      if (t1 == NULL && t2 == NULL) return true;
+      if (t1 == NULL || t2 == NULL) return false;
+      return cbor_structurally_equal(t1, t2);
+    }
+
+    case CBOR_TYPE_FLOAT_CTRL: {
+      /* Encoding width (CBOR_FLOAT_0/16/32/64) is part of structural identity
+       */
+      if (cbor_float_get_width(item1) != cbor_float_get_width(item2))
+        return false;
+      if (cbor_float_ctrl_is_ctrl(item1)) {
+        /* Simple/ctrl values: compare control byte */
+        return cbor_ctrl_value(item1) == cbor_ctrl_value(item2);
+      } else {
+        /*
+         * Floats: bitwise comparison of the stored representation. This treats
+         * distinct NaN payloads as distinct values, consistent with structural
+         * equality. Widths CBOR_FLOAT_16 and CBOR_FLOAT_32 are both backed by
+         * 4 bytes (C float); CBOR_FLOAT_64 is backed by 8 bytes (C double).
+         */
+        size_t sz = (cbor_float_get_width(item1) == CBOR_FLOAT_64) ? 8 : 4;
+        return memcmp(item1->data, item2->data, sz) == 0;
+      }
+    }
+  }
+  /* Unreachable: all enum values are handled above */
+  return false; /* LCOV_EXCL_LINE */
+}

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -391,6 +391,9 @@ CBOR_EXPORT cbor_item_t* cbor_move(cbor_item_t* item);
  * - **Tag number**: tags with different tag numbers are *not* structurally
  * equal.
  *
+ * Runs in time linear in the encoded byte size of the items and performs no
+ * additional memory allocations.
+ *
  * \rst
  * .. note::
  *   This function implements *structural* equality, not the data-model equality

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "cbor/cbor_export.h"
 #include "cbor/configuration.h"
@@ -359,6 +360,56 @@ CBOR_EXPORT size_t cbor_refcount(const cbor_item_t* item);
  */
 _CBOR_NODISCARD
 CBOR_EXPORT cbor_item_t* cbor_move(cbor_item_t* item);
+
+/** Compares two items for structural (encoding-level) equality
+ *
+ * Two items are structurally equal when they would produce identical bytes
+ * if serialized by a correct CBOR encoder that preserves the in-memory
+ * representation. Every aspect of the encoding counts:
+ *
+ * - **Major type**: `CBOR_TYPE_UINT` and `CBOR_TYPE_NEGINT` are distinct even
+ *   if the argument bytes happen to be the same.
+ * - **Integer encoding width**: `cbor_build_uint8(1)` and
+ * `cbor_build_uint16(1)` are *not* structurally equal, even though both
+ * represent the integer 1. Use the integer value accessors (`cbor_get_uint64`
+ * etc.) if you need value-level comparison.
+ * - **Definite vs. indefinite length**: a definite-length array and an
+ *   indefinite-length array with the same elements are *not* structurally
+ * equal.
+ * - **Chunk boundaries**: two indefinite bytestrings or strings that carry the
+ *   same bytes but split them across a different number of chunks are *not*
+ *   structurally equal.
+ * - **Map entry order**: maps are compared positionally — entry at index i in
+ *   \p item1 must match entry at index i in \p item2. Maps that carry the same
+ *   key-value pairs in a different order are *not* structurally equal. (CBOR
+ *   maps are unordered in the data model; for data-model equality see RFC 8949
+ *   §5.6.1.)
+ * - **Float encoding width**: `cbor_build_float2(1.5)` and
+ *   `cbor_build_float4(1.5)` are *not* structurally equal.
+ * - **NaN payload**: floating-point NaN values with different bit patterns are
+ *   *not* structurally equal.
+ * - **Tag number**: tags with different tag numbers are *not* structurally
+ * equal.
+ *
+ * \rst
+ * .. note::
+ *   This function implements *structural* equality, not the data-model equality
+ *   defined by RFC 8949. In the CBOR data model, encoding width is invisible
+ *   and maps are unordered sets of key-value pairs. If you need data-model
+ *   equality (e.g., ``uint8(1) == uint64(1)``), you must implement it on top
+ *   of this library.
+ * \endrst
+ *
+ * Neither \p item1 nor \p item2 may be `NULL`. Passing `NULL` is a
+ * programming error and will trigger an assertion failure in debug builds.
+ *
+ * @param item1[borrow] First item; must not be `NULL`
+ * @param item2[borrow] Second item; must not be `NULL`
+ * @return `true` if \p item1 and \p item2 are structurally equal
+ */
+_CBOR_NODISCARD
+CBOR_EXPORT bool cbor_structurally_equal(const cbor_item_t* item1,
+                                         const cbor_item_t* item2);
 
 #ifdef __cplusplus
 }

--- a/test/structurally_equal_test.c
+++ b/test/structurally_equal_test.c
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) 2014-2020 Pavel Kalvoda <me@pavelkalvoda.com>
+ *
+ * libcbor is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <cmocka.h>
+
+#include "assertions.h"
+#include "cbor.h"
+
+/* -------------------------------------------------------------------------
+ * Integers
+ * ---------------------------------------------------------------------- */
+
+static void test_uint_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_uint8(10);
+  cbor_item_t* b = cbor_build_uint8(10);
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_uint_different_value(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_uint8(10);
+  cbor_item_t* b = cbor_build_uint8(11);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_uint_different_width(void** state _CBOR_UNUSED) {
+  /* uint8(1) and uint16(1) represent the same integer value but are
+   * structurally distinct because the encoding width differs. */
+  cbor_item_t* a = cbor_build_uint8(1);
+  cbor_item_t* b = cbor_build_uint16(1);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+
+  cbor_item_t* c = cbor_build_uint16(1);
+  cbor_item_t* d = cbor_build_uint32(1);
+  assert_false(cbor_structurally_equal(c, d));
+  cbor_decref(&c);
+  cbor_decref(&d);
+
+  cbor_item_t* e = cbor_build_uint32(1);
+  cbor_item_t* f = cbor_build_uint64(1);
+  assert_false(cbor_structurally_equal(e, f));
+  cbor_decref(&e);
+  cbor_decref(&f);
+}
+
+static void test_negint_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_negint8(5);
+  cbor_item_t* b = cbor_build_negint8(5);
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_negint_different_width(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_negint8(1);
+  cbor_item_t* b = cbor_build_negint16(1);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_uint_vs_negint(void** state _CBOR_UNUSED) {
+  /* Major type distinguishes UINT from NEGINT. */
+  cbor_item_t* a = cbor_build_uint8(0);
+  cbor_item_t* b = cbor_build_negint8(0);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+/* -------------------------------------------------------------------------
+ * Bytestrings
+ * ---------------------------------------------------------------------- */
+
+static void test_bytestring_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_bytestring((cbor_mutable_data) "hello", 5);
+  cbor_item_t* b = cbor_build_bytestring((cbor_mutable_data) "hello", 5);
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_bytestring_different_content(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_bytestring((cbor_mutable_data) "hello", 5);
+  cbor_item_t* b = cbor_build_bytestring((cbor_mutable_data) "world", 5);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_bytestring_different_length(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_bytestring((cbor_mutable_data) "hello", 5);
+  cbor_item_t* b = cbor_build_bytestring((cbor_mutable_data) "hello", 4);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_bytestring_definite_vs_indefinite(void** state _CBOR_UNUSED) {
+  /* A definite and an indefinite bytestring with the same bytes are
+   * structurally distinct. */
+  cbor_item_t* definite = cbor_build_bytestring((cbor_mutable_data) "hello", 5);
+
+  cbor_item_t* indefinite = cbor_new_indefinite_bytestring();
+  cbor_item_t* chunk = cbor_build_bytestring((cbor_mutable_data) "hello", 5);
+  assert_true(cbor_bytestring_add_chunk(indefinite, cbor_move(chunk)));
+
+  assert_false(cbor_structurally_equal(definite, indefinite));
+  cbor_decref(&definite);
+  cbor_decref(&indefinite);
+}
+
+static void test_bytestring_indefinite_chunk_structure(
+    void** state _CBOR_UNUSED) {
+  /* Two indefinite bytestrings with the same bytes but different chunk
+   * boundaries are structurally distinct. */
+  cbor_item_t* a = cbor_new_indefinite_bytestring();
+  cbor_item_t* a1 = cbor_build_bytestring((cbor_mutable_data) "he", 2);
+  cbor_item_t* a2 = cbor_build_bytestring((cbor_mutable_data) "llo", 3);
+  assert_true(cbor_bytestring_add_chunk(a, cbor_move(a1)));
+  assert_true(cbor_bytestring_add_chunk(a, cbor_move(a2)));
+
+  cbor_item_t* b = cbor_new_indefinite_bytestring();
+  cbor_item_t* b1 = cbor_build_bytestring((cbor_mutable_data) "hello", 5);
+  assert_true(cbor_bytestring_add_chunk(b, cbor_move(b1)));
+
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_bytestring_indefinite_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_indefinite_bytestring();
+  cbor_item_t* a1 = cbor_build_bytestring((cbor_mutable_data) "he", 2);
+  cbor_item_t* a2 = cbor_build_bytestring((cbor_mutable_data) "llo", 3);
+  assert_true(cbor_bytestring_add_chunk(a, cbor_move(a1)));
+  assert_true(cbor_bytestring_add_chunk(a, cbor_move(a2)));
+
+  cbor_item_t* b = cbor_new_indefinite_bytestring();
+  cbor_item_t* b1 = cbor_build_bytestring((cbor_mutable_data) "he", 2);
+  cbor_item_t* b2 = cbor_build_bytestring((cbor_mutable_data) "llo", 3);
+  assert_true(cbor_bytestring_add_chunk(b, cbor_move(b1)));
+  assert_true(cbor_bytestring_add_chunk(b, cbor_move(b2)));
+
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+/* -------------------------------------------------------------------------
+ * Strings
+ * ---------------------------------------------------------------------- */
+
+static void test_string_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_string("hello");
+  cbor_item_t* b = cbor_build_string("hello");
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_string_different(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_string("hello");
+  cbor_item_t* b = cbor_build_string("world");
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_string_vs_bytestring(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_string("hi");
+  cbor_item_t* b = cbor_build_bytestring((cbor_mutable_data) "hi", 2);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_string_definite_vs_indefinite(void** state _CBOR_UNUSED) {
+  cbor_item_t* definite = cbor_build_string("hello");
+
+  cbor_item_t* indefinite = cbor_new_indefinite_string();
+  cbor_item_t* chunk = cbor_build_string("hello");
+  assert_true(cbor_string_add_chunk(indefinite, cbor_move(chunk)));
+
+  assert_false(cbor_structurally_equal(definite, indefinite));
+  cbor_decref(&definite);
+  cbor_decref(&indefinite);
+}
+
+/* -------------------------------------------------------------------------
+ * Arrays
+ * ---------------------------------------------------------------------- */
+
+static void test_array_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_definite_array(2);
+  assert_true(cbor_array_push(a, cbor_move(cbor_build_uint8(1))));
+  assert_true(cbor_array_push(a, cbor_move(cbor_build_uint8(2))));
+
+  cbor_item_t* b = cbor_new_definite_array(2);
+  assert_true(cbor_array_push(b, cbor_move(cbor_build_uint8(1))));
+  assert_true(cbor_array_push(b, cbor_move(cbor_build_uint8(2))));
+
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_array_different_order(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_definite_array(2);
+  assert_true(cbor_array_push(a, cbor_move(cbor_build_uint8(1))));
+  assert_true(cbor_array_push(a, cbor_move(cbor_build_uint8(2))));
+
+  cbor_item_t* b = cbor_new_definite_array(2);
+  assert_true(cbor_array_push(b, cbor_move(cbor_build_uint8(2))));
+  assert_true(cbor_array_push(b, cbor_move(cbor_build_uint8(1))));
+
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_array_definite_vs_indefinite(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_definite_array(1);
+  assert_true(cbor_array_push(a, cbor_move(cbor_build_uint8(42))));
+
+  cbor_item_t* b = cbor_new_indefinite_array();
+  assert_true(cbor_array_push(b, cbor_move(cbor_build_uint8(42))));
+
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_array_element_width_matters(void** state _CBOR_UNUSED) {
+  /* Elements' encoding widths are part of the structure. */
+  cbor_item_t* a = cbor_new_definite_array(1);
+  assert_true(cbor_array_push(a, cbor_move(cbor_build_uint8(1))));
+
+  cbor_item_t* b = cbor_new_definite_array(1);
+  assert_true(cbor_array_push(b, cbor_move(cbor_build_uint16(1))));
+
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+/* -------------------------------------------------------------------------
+ * Maps
+ * ---------------------------------------------------------------------- */
+
+static void test_map_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_definite_map(2);
+  assert_true(cbor_map_add(
+      a, (struct cbor_pair){.key = cbor_move(cbor_build_string("x")),
+                            .value = cbor_move(cbor_build_uint8(1))}));
+  assert_true(cbor_map_add(
+      a, (struct cbor_pair){.key = cbor_move(cbor_build_string("y")),
+                            .value = cbor_move(cbor_build_uint8(2))}));
+
+  cbor_item_t* b = cbor_new_definite_map(2);
+  assert_true(cbor_map_add(
+      b, (struct cbor_pair){.key = cbor_move(cbor_build_string("x")),
+                            .value = cbor_move(cbor_build_uint8(1))}));
+  assert_true(cbor_map_add(
+      b, (struct cbor_pair){.key = cbor_move(cbor_build_string("y")),
+                            .value = cbor_move(cbor_build_uint8(2))}));
+
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_map_different_order(void** state _CBOR_UNUSED) {
+  /* Structural equality is positional: the same key-value pairs in a different
+   * encoded order are not structurally equal. */
+  cbor_item_t* a = cbor_new_definite_map(2);
+  assert_true(cbor_map_add(
+      a, (struct cbor_pair){.key = cbor_move(cbor_build_string("x")),
+                            .value = cbor_move(cbor_build_uint8(1))}));
+  assert_true(cbor_map_add(
+      a, (struct cbor_pair){.key = cbor_move(cbor_build_string("y")),
+                            .value = cbor_move(cbor_build_uint8(2))}));
+
+  cbor_item_t* b = cbor_new_definite_map(2);
+  assert_true(cbor_map_add(
+      b, (struct cbor_pair){.key = cbor_move(cbor_build_string("y")),
+                            .value = cbor_move(cbor_build_uint8(2))}));
+  assert_true(cbor_map_add(
+      b, (struct cbor_pair){.key = cbor_move(cbor_build_string("x")),
+                            .value = cbor_move(cbor_build_uint8(1))}));
+
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_map_key_width_matters(void** state _CBOR_UNUSED) {
+  /* uint8(1) and uint16(1) are structurally distinct keys. */
+  cbor_item_t* a = cbor_new_definite_map(1);
+  assert_true(cbor_map_add(
+      a, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(1)),
+                            .value = cbor_move(cbor_build_uint8(0))}));
+
+  cbor_item_t* b = cbor_new_definite_map(1);
+  assert_true(cbor_map_add(
+      b, (struct cbor_pair){.key = cbor_move(cbor_build_uint16(1)),
+                            .value = cbor_move(cbor_build_uint8(0))}));
+
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_map_definite_vs_indefinite(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_definite_map(1);
+  assert_true(cbor_map_add(
+      a, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(0)),
+                            .value = cbor_move(cbor_build_uint8(0))}));
+
+  cbor_item_t* b = cbor_new_indefinite_map();
+  assert_true(cbor_map_add(
+      b, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(0)),
+                            .value = cbor_move(cbor_build_uint8(0))}));
+
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+/* -------------------------------------------------------------------------
+ * Tags
+ * ---------------------------------------------------------------------- */
+
+static void test_tag_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_tag(1, cbor_move(cbor_build_uint32(1000000)));
+  cbor_item_t* b = cbor_build_tag(1, cbor_move(cbor_build_uint32(1000000)));
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_tag_different_number(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_tag(1, cbor_move(cbor_build_uint32(0)));
+  cbor_item_t* b = cbor_build_tag(2, cbor_move(cbor_build_uint32(0)));
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_tag_different_content_width(void** state _CBOR_UNUSED) {
+  /* The tagged item's encoding width is part of the structure. */
+  cbor_item_t* a = cbor_build_tag(1, cbor_move(cbor_build_uint8(42)));
+  cbor_item_t* b = cbor_build_tag(1, cbor_move(cbor_build_uint16(42)));
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+/* -------------------------------------------------------------------------
+ * Floats and control values
+ * ---------------------------------------------------------------------- */
+
+static void test_float_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_float4(1.5f);
+  cbor_item_t* b = cbor_build_float4(1.5f);
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_float_different_width(void** state _CBOR_UNUSED) {
+  /* float2(1.5) and float4(1.5) encode the same numeric value but use
+   * different encoding widths, so they are not structurally equal. */
+  cbor_item_t* a = cbor_build_float2(1.5f);
+  cbor_item_t* b = cbor_build_float4(1.5f);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+
+  cbor_item_t* c = cbor_build_float4(1.5f);
+  cbor_item_t* d = cbor_build_float8(1.5);
+  assert_false(cbor_structurally_equal(c, d));
+  cbor_decref(&c);
+  cbor_decref(&d);
+}
+
+static void test_bool_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_bool(true);
+  cbor_item_t* b = cbor_build_bool(true);
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_bool_different(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_bool(true);
+  cbor_item_t* b = cbor_build_bool(false);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_null_equal(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_null();
+  cbor_item_t* b = cbor_new_null();
+  assert_true(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_null_vs_undef(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_new_null();
+  cbor_item_t* b = cbor_new_undef();
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+static void test_float_vs_int(void** state _CBOR_UNUSED) {
+  /* In the CBOR data model, integers and floats are distinct types. */
+  cbor_item_t* a = cbor_build_uint8(1);
+  cbor_item_t* b = cbor_build_float4(1.0f);
+  assert_false(cbor_structurally_equal(a, b));
+  cbor_decref(&a);
+  cbor_decref(&b);
+}
+
+/* -------------------------------------------------------------------------
+ * Reflexivity spot-checks
+ * ---------------------------------------------------------------------- */
+
+static void test_reflexivity(void** state _CBOR_UNUSED) {
+  cbor_item_t* items[] = {
+      cbor_build_uint64(UINT64_MAX),
+      cbor_build_negint32(12345),
+      cbor_build_string("reflexive"),
+      cbor_build_bytestring((cbor_mutable_data) "\x00\xff", 2),
+      cbor_build_bool(false),
+      cbor_new_null(),
+      cbor_build_float8(3.14159265358979323846),
+  };
+  for (size_t i = 0; i < sizeof(items) / sizeof(items[0]); i++) {
+    assert_true(cbor_structurally_equal(items[i], items[i]));
+    cbor_decref(&items[i]);
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * Cross-type spot-checks
+ * ---------------------------------------------------------------------- */
+
+static void test_cross_type(void** state _CBOR_UNUSED) {
+  cbor_item_t* a = cbor_build_uint8(0);
+  cbor_item_t* b = cbor_build_string("0");
+  cbor_item_t* c = cbor_new_null();
+  cbor_item_t* d = cbor_build_bool(false);
+
+  assert_false(cbor_structurally_equal(a, b));
+  assert_false(cbor_structurally_equal(a, c));
+  assert_false(cbor_structurally_equal(c, d));
+
+  cbor_decref(&a);
+  cbor_decref(&b);
+  cbor_decref(&c);
+  cbor_decref(&d);
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+      /* Integers */
+      cmocka_unit_test(test_uint_equal),
+      cmocka_unit_test(test_uint_different_value),
+      cmocka_unit_test(test_uint_different_width),
+      cmocka_unit_test(test_negint_equal),
+      cmocka_unit_test(test_negint_different_width),
+      cmocka_unit_test(test_uint_vs_negint),
+      /* Bytestrings */
+      cmocka_unit_test(test_bytestring_equal),
+      cmocka_unit_test(test_bytestring_different_content),
+      cmocka_unit_test(test_bytestring_different_length),
+      cmocka_unit_test(test_bytestring_definite_vs_indefinite),
+      cmocka_unit_test(test_bytestring_indefinite_chunk_structure),
+      cmocka_unit_test(test_bytestring_indefinite_equal),
+      /* Strings */
+      cmocka_unit_test(test_string_equal),
+      cmocka_unit_test(test_string_different),
+      cmocka_unit_test(test_string_vs_bytestring),
+      cmocka_unit_test(test_string_definite_vs_indefinite),
+      /* Arrays */
+      cmocka_unit_test(test_array_equal),
+      cmocka_unit_test(test_array_different_order),
+      cmocka_unit_test(test_array_definite_vs_indefinite),
+      cmocka_unit_test(test_array_element_width_matters),
+      /* Maps */
+      cmocka_unit_test(test_map_equal),
+      cmocka_unit_test(test_map_different_order),
+      cmocka_unit_test(test_map_key_width_matters),
+      cmocka_unit_test(test_map_definite_vs_indefinite),
+      /* Tags */
+      cmocka_unit_test(test_tag_equal),
+      cmocka_unit_test(test_tag_different_number),
+      cmocka_unit_test(test_tag_different_content_width),
+      /* Floats and ctrl */
+      cmocka_unit_test(test_float_equal),
+      cmocka_unit_test(test_float_different_width),
+      cmocka_unit_test(test_bool_equal),
+      cmocka_unit_test(test_bool_different),
+      cmocka_unit_test(test_null_equal),
+      cmocka_unit_test(test_null_vs_undef),
+      cmocka_unit_test(test_float_vs_int),
+      /* General */
+      cmocka_unit_test(test_reflexivity),
+      cmocka_unit_test(test_cross_type),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary

- Adds `cbor_structurally_equal(const cbor_item_t*, const cbor_item_t*)` to `common.h`/`common.c`
- 36 test cases in `test/structurally_equal_test.c` covering all eight CBOR major types
- RST documentation in `doc/source/api/item_types.rst`

## Design rationale

PR #96 proposed a `cbor_equal` function but left the semantics underspecified. RFC 8949 defines two distinct notions of equality:

- **Data-model equality** (RFC 8949 §2.1, §5.6.1): encoding width is invisible; maps are unordered sets of key-value pairs; `uint8(1)` and `uint64(1)` are the same integer.
- **Structural equality**: every byte of the encoding counts; `uint8(1) ≠ uint16(1)`.

This PR implements **structural equality** under the name `cbor_structurally_equal`, which makes the semantics explicit and avoids surprising callers who might expect data-model behaviour from a function named `cbor_equal`. The function is extensively documented to explain what it does and does not compare, and to point callers toward the value accessors (`cbor_get_uint64` etc.) for data-model comparisons.

Notable structural rules that differ from data-model equality:

| Case | `cbor_structurally_equal` |
|---|---|
| `uint8(1)` vs `uint16(1)` | `false` — encoding width differs |
| `float2(1.5)` vs `float4(1.5)` | `false` — float width differs |
| Definite array vs indefinite array (same elements) | `false` |
| Indefinite bytestring, same bytes, different chunk split | `false` |
| Maps with same pairs in different order | `false` — positional comparison |
| Two NaN with different bit patterns | `false` — bitwise float comparison |

NULL inputs are programming errors; assertions fire in debug builds (consistent with the rest of the libcbor API).

## Test plan

- [ ] `ctest -R structurally_equal_test` passes (36/36)
- [ ] `bash clang-format.sh` produces no diff
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)