### PR TITLE
Add cbor_map_get with parameterized equality function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Next
 - [Modernize CMake build: use `project(VERSION ...)`, replace `add_definitions()` with target-scoped `target_compile_definitions()`, remove redundant `include_directories()`](https://github.com/PJK/libcbor/pull/402)
 - [Replace global `CMAKE_C_FLAGS` mutations with target-scoped `target_compile_options()` via an INTERFACE library, and simplify LTO configuration](https://github.com/PJK/libcbor/pull/403)
 - [Fix Windows CI: propagate `_CRT_SECURE_NO_WARNINGS` to examples/tests, restrict LTO to Release builds, parallelize Windows CI build](https://github.com/PJK/libcbor/pull/404)
+- [Add `cbor_map_get` for key-based map lookup with a caller-supplied equality function](https://github.com/PJK/libcbor/pull/409)
+  - Signature: `cbor_map_get(map, key, eq)` — pass any equality predicate, e.g. `cbor_structurally_equal`
+  - Parameterised equality allows type-specific comparators or custom data-model semantics without library changes
+  - See also: #96
 - [Add `cbor_structurally_equal` for encoding-level item comparison](https://github.com/PJK/libcbor/pull/408)
   - Compares two items structurally: encoding width, definite-vs-indefinite length, chunk boundaries, and map entry order all count
   - Runs in O(n) time in the encoded byte size with no additional allocations

--- a/doc/source/api/type_5_maps.rst
+++ b/doc/source/api/type_5_maps.rst
@@ -48,6 +48,27 @@ Reading data
 ~~~~~~~~~~~~~
 
 .. doxygenfunction:: cbor_map_handle
+.. doxygenfunction:: cbor_map_get
+
+.. note::
+
+   The equality function passed to :func:`cbor_map_get` is intentionally
+   parameterized. Most applications constrain their map keys to a single
+   type (e.g., always text strings, or always small integers), so a
+   type-specific comparator can be both simpler and faster than a fully
+   generic one.  The parameter also lets callers choose between structural
+   equality (:func:`cbor_structurally_equal`) and any data-model or
+   application-level semantics they need — the library does not need to
+   anticipate every use case.
+
+   Examples of equality functions that can be passed:
+
+   * :func:`cbor_structurally_equal` — encoding-level identity; encoding
+     width, definite/indefinite, and map entry order all count.
+   * A custom integer comparator that ignores encoding width, so that
+     ``uint8(1)`` and ``uint64(1)`` are treated as the same key.
+   * A text-string comparator that skips the type check, useful when the
+     protocol guarantees that all keys are text strings.
 
 Creating new items
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/cbor/common.h
+++ b/src/cbor/common.h
@@ -406,8 +406,8 @@ CBOR_EXPORT cbor_item_t* cbor_move(cbor_item_t* item);
  * Neither \p item1 nor \p item2 may be `NULL`. Passing `NULL` is a
  * programming error and will trigger an assertion failure in debug builds.
  *
- * @param item1[borrow] First item; must not be `NULL`
- * @param item2[borrow] Second item; must not be `NULL`
+ * @param item1 First item; must not be `NULL`
+ * @param item2 Second item; must not be `NULL`
  * @return `true` if \p item1 and \p item2 are structurally equal
  */
 _CBOR_NODISCARD

--- a/src/cbor/maps.c
+++ b/src/cbor/maps.c
@@ -123,3 +123,17 @@ struct cbor_pair* cbor_map_handle(const cbor_item_t* item) {
   CBOR_ASSERT(cbor_isa_map(item));
   return (struct cbor_pair*)item->data;
 }
+
+cbor_item_t* cbor_map_get(const cbor_item_t* map, const cbor_item_t* key,
+                          bool (*eq)(const cbor_item_t*, const cbor_item_t*)) {
+  CBOR_ASSERT(cbor_isa_map(map));
+  CBOR_ASSERT(key != NULL);
+  CBOR_ASSERT(eq != NULL);
+  struct cbor_pair* pairs = cbor_map_handle(map);
+  for (size_t i = 0; i < cbor_map_size(map); i++) {
+    if (eq(pairs[i].key, key)) {
+      return cbor_incref(pairs[i].value);
+    }
+  }
+  return NULL;
+}

--- a/src/cbor/maps.h
+++ b/src/cbor/maps.h
@@ -114,6 +114,45 @@ _CBOR_NODISCARD CBOR_EXPORT bool cbor_map_is_indefinite(
 _CBOR_NODISCARD CBOR_EXPORT struct cbor_pair* cbor_map_handle(
     const cbor_item_t* item);
 
+/** Look up a value in a map by key using a caller-supplied equality function
+ *
+ * Scans the map linearly and returns the first value whose key compares equal
+ * to \p key under \p eq. This is O(n) in the number of entries.
+ *
+ * The equality function is intentionally parameterized. Most applications
+ * constrain their map keys to a single type (e.g., text strings or small
+ * integers), which lets them implement a cheaper, type-specific comparator
+ * instead of a fully generic one. The parameter also allows callers to plug
+ * in any desired semantics — structural equality via
+ * #cbor_structurally_equal, a data-model comparator that ignores encoding
+ * width, a case-insensitive string comparator, etc. — without the library
+ * having to anticipate every use case.
+ *
+ * \rst
+ * .. code-block:: c
+ *
+ *    // Look up a text-string key using structural equality
+ *    cbor_item_t *key = cbor_build_string("alg");
+ *    cbor_item_t *value = cbor_map_get(map, key, cbor_structurally_equal);
+ *    if (value != NULL) {
+ *        // use value ...
+ *        cbor_decref(&value);
+ *    }
+ *    cbor_decref(&key);
+ * \endrst
+ *
+ * @param map[borrow]  A map item; must not be `NULL`
+ * @param key[borrow]  The key to search for; must not be `NULL`
+ * @param eq           Equality predicate, called as `eq(candidate_key, key)`;
+ *                     must not be `NULL`
+ * @return[transfer] The first matching value with its reference count
+ *         incremented by one, or `NULL` if no key matched. The caller is
+ *         responsible for releasing the returned item with #cbor_decref.
+ */
+_CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_map_get(
+    const cbor_item_t* map, const cbor_item_t* key,
+    bool (*eq)(const cbor_item_t*, const cbor_item_t*));
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cbor/maps.h
+++ b/src/cbor/maps.h
@@ -117,7 +117,8 @@ _CBOR_NODISCARD CBOR_EXPORT struct cbor_pair* cbor_map_handle(
 /** Look up a value in a map by key using a caller-supplied equality function
  *
  * Scans the map linearly and returns the first value whose key compares equal
- * to \p key under \p eq. This is O(n) in the number of entries.
+ * to \p key under \p eq. Makes at most n calls to \p eq, where n is the number
+ * of entries (fewer if a match is found early).
  *
  * The equality function is intentionally parameterized. Most applications
  * constrain their map keys to a single type (e.g., text strings or small

--- a/src/cbor/maps.h
+++ b/src/cbor/maps.h
@@ -142,13 +142,13 @@ _CBOR_NODISCARD CBOR_EXPORT struct cbor_pair* cbor_map_handle(
  *    cbor_decref(&key);
  * \endrst
  *
- * @param map[borrow]  A map item; must not be `NULL`
- * @param key[borrow]  The key to search for; must not be `NULL`
- * @param eq           Equality predicate, called as `eq(candidate_key, key)`;
- *                     must not be `NULL`
- * @return[transfer] The first matching value with its reference count
- *         incremented by one, or `NULL` if no key matched. The caller is
- *         responsible for releasing the returned item with #cbor_decref.
+ * @param map  A map item; must not be `NULL`
+ * @param key  The key to search for; must not be `NULL`
+ * @param eq   Equality predicate, called as `eq(candidate_key, key)`;
+ *             must not be `NULL`
+ * @return The first matching value with its reference count incremented by
+ *         one, or `NULL` if no key matched. The caller is responsible for
+ *         releasing the returned item with #cbor_decref.
  */
 _CBOR_NODISCARD CBOR_EXPORT cbor_item_t* cbor_map_get(
     const cbor_item_t* map, const cbor_item_t* key,

--- a/test/map_get_test.c
+++ b/test/map_get_test.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2014-2020 Pavel Kalvoda <me@pavelkalvoda.com>
+ *
+ * libcbor is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <cmocka.h>
+
+#include "assertions.h"
+#include "cbor.h"
+
+/* -------------------------------------------------------------------------
+ * Custom equality functions used in tests
+ * ---------------------------------------------------------------------- */
+
+/* Text-string equality that only compares byte content, ignoring encoding
+ * width. Suitable for maps whose keys are always text strings. */
+static bool str_eq(const cbor_item_t* a, const cbor_item_t* b) {
+  if (!cbor_isa_string(a) || !cbor_isa_string(b)) return false;
+  if (!cbor_string_is_definite(a) || !cbor_string_is_definite(b)) return false;
+  if (cbor_string_length(a) != cbor_string_length(b)) return false;
+  return memcmp(cbor_string_handle(a), cbor_string_handle(b),
+                cbor_string_length(a)) == 0;
+}
+
+/* Integer equality that ignores encoding width: uint8(1) == uint16(1).
+ * UINT and NEGINT remain distinct (they have different CBOR major types and
+ * therefore different abstract values). Demonstrates that a caller-supplied
+ * equality function can implement any desired data-model semantics. */
+static bool int_value_eq(const cbor_item_t* a, const cbor_item_t* b) {
+  if (!cbor_is_int(a) || !cbor_is_int(b)) return false;
+  if (cbor_typeof(a) != cbor_typeof(b)) return false;
+  return cbor_get_int(a) == cbor_get_int(b);
+}
+
+/* -------------------------------------------------------------------------
+ * Helpers
+ * ---------------------------------------------------------------------- */
+
+static cbor_item_t* build_map(void) {
+  /* {  "one": uint8(1),  "two": uint8(2),  negint8(0): "neg"  } */
+  cbor_item_t* map = cbor_new_definite_map(3);
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_string("one")),
+                              .value = cbor_move(cbor_build_uint8(1))}));
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_string("two")),
+                              .value = cbor_move(cbor_build_uint8(2))}));
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_negint8(0)),
+                              .value = cbor_move(cbor_build_string("neg"))}));
+  return map;
+}
+
+/* -------------------------------------------------------------------------
+ * Tests
+ * ---------------------------------------------------------------------- */
+
+static void test_get_existing_key(void** state _CBOR_UNUSED) {
+  cbor_item_t* map = build_map();
+
+  cbor_item_t* key = cbor_build_string("one");
+  cbor_item_t* val = cbor_map_get(map, key, cbor_structurally_equal);
+  assert_non_null(val);
+  assert_true(cbor_isa_uint(val));
+  assert_true(cbor_get_uint8(val) == 1);
+  cbor_decref(&key);
+  cbor_decref(&val);
+
+  key = cbor_build_string("two");
+  val = cbor_map_get(map, key, cbor_structurally_equal);
+  assert_non_null(val);
+  assert_true(cbor_get_uint8(val) == 2);
+  cbor_decref(&key);
+  cbor_decref(&val);
+
+  cbor_decref(&map);
+}
+
+static void test_get_missing_key(void** state _CBOR_UNUSED) {
+  cbor_item_t* map = build_map();
+
+  cbor_item_t* key = cbor_build_string("three");
+  cbor_item_t* val = cbor_map_get(map, key, cbor_structurally_equal);
+  assert_null(val);
+  cbor_decref(&key);
+
+  cbor_decref(&map);
+}
+
+static void test_get_empty_map(void** state _CBOR_UNUSED) {
+  cbor_item_t* map = cbor_new_definite_map(0);
+  cbor_item_t* key = cbor_build_string("x");
+  assert_null(cbor_map_get(map, key, cbor_structurally_equal));
+  cbor_decref(&key);
+  cbor_decref(&map);
+}
+
+static void test_get_wrong_type(void** state _CBOR_UNUSED) {
+  /* Looking up a string key in a map that has an integer key for the same
+   * encoded bytes: structural equality correctly returns NULL. */
+  cbor_item_t* map = build_map();
+  cbor_item_t* key = cbor_build_uint8(1);
+  assert_null(cbor_map_get(map, key, cbor_structurally_equal));
+  cbor_decref(&key);
+  cbor_decref(&map);
+}
+
+static void test_get_encoding_width_matters_with_structural_eq(
+    void** state _CBOR_UNUSED) {
+  /* With structural equality: uint8(1) and uint16(1) are different keys. */
+  cbor_item_t* map = cbor_new_definite_map(1);
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(1)),
+                              .value = cbor_move(cbor_build_string("found"))}));
+
+  cbor_item_t* key8 = cbor_build_uint8(1);
+  cbor_item_t* val = cbor_map_get(map, key8, cbor_structurally_equal);
+  assert_non_null(val);
+  cbor_decref(&val);
+  cbor_decref(&key8);
+
+  cbor_item_t* key16 = cbor_build_uint16(1);
+  assert_null(cbor_map_get(map, key16, cbor_structurally_equal));
+  cbor_decref(&key16);
+
+  cbor_decref(&map);
+}
+
+static void test_get_custom_eq_ignores_width(void** state _CBOR_UNUSED) {
+  /* With int_value_eq: uint8(1) and uint16(1) are equivalent keys,
+   * so a map keyed with uint8(1) can be looked up via uint16(1). */
+  cbor_item_t* map = cbor_new_definite_map(1);
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_uint8(1)),
+                              .value = cbor_move(cbor_build_string("found"))}));
+
+  cbor_item_t* key = cbor_build_uint16(1);
+  cbor_item_t* val = cbor_map_get(map, key, int_value_eq);
+  assert_non_null(val);
+  assert_true(cbor_isa_string(val));
+  cbor_decref(&val);
+  cbor_decref(&key);
+
+  cbor_decref(&map);
+}
+
+static void test_get_custom_str_eq(void** state _CBOR_UNUSED) {
+  /* str_eq is a type-specific comparator that avoids touching non-string
+   * keys at all, demonstrating a lightweight application-specific approach. */
+  cbor_item_t* map = build_map();
+
+  cbor_item_t* key = cbor_build_string("two");
+  cbor_item_t* val = cbor_map_get(map, key, str_eq);
+  assert_non_null(val);
+  assert_true(cbor_get_uint8(val) == 2);
+  cbor_decref(&val);
+  cbor_decref(&key);
+
+  cbor_decref(&map);
+}
+
+static void test_get_first_match_on_duplicate_keys(void** state _CBOR_UNUSED) {
+  /* RFC 8949 §5.3: a map with duplicate keys is well-formed but not valid.
+   * cbor_map_get returns the first matching entry. */
+  cbor_item_t* map = cbor_new_definite_map(2);
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_string("k")),
+                              .value = cbor_move(cbor_build_uint8(1))}));
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_string("k")),
+                              .value = cbor_move(cbor_build_uint8(2))}));
+
+  cbor_item_t* key = cbor_build_string("k");
+  cbor_item_t* val = cbor_map_get(map, key, cbor_structurally_equal);
+  assert_non_null(val);
+  assert_true(cbor_get_uint8(val) == 1); /* first entry wins */
+  cbor_decref(&val);
+  cbor_decref(&key);
+
+  cbor_decref(&map);
+}
+
+static void test_get_refcount(void** state _CBOR_UNUSED) {
+  /* The returned value has its reference count incremented. */
+  cbor_item_t* map = build_map();
+
+  cbor_item_t* key = cbor_build_string("one");
+  cbor_item_t* val = cbor_map_get(map, key, cbor_structurally_equal);
+  assert_non_null(val);
+  assert_true(cbor_refcount(val) == 2); /* held by map + returned ref */
+  cbor_decref(&val);
+  cbor_decref(&key);
+
+  cbor_decref(&map);
+}
+
+static void test_get_indefinite_map(void** state _CBOR_UNUSED) {
+  cbor_item_t* map = cbor_new_indefinite_map();
+  assert_true(cbor_map_add(
+      map, (struct cbor_pair){.key = cbor_move(cbor_build_string("x")),
+                              .value = cbor_move(cbor_build_uint8(99))}));
+
+  cbor_item_t* key = cbor_build_string("x");
+  cbor_item_t* val = cbor_map_get(map, key, cbor_structurally_equal);
+  assert_non_null(val);
+  assert_true(cbor_get_uint8(val) == 99);
+  cbor_decref(&val);
+  cbor_decref(&key);
+
+  cbor_decref(&map);
+}
+
+static void test_get_negint_key(void** state _CBOR_UNUSED) {
+  cbor_item_t* map = build_map();
+
+  cbor_item_t* key = cbor_build_negint8(0);
+  cbor_item_t* val = cbor_map_get(map, key, cbor_structurally_equal);
+  assert_non_null(val);
+  assert_true(cbor_isa_string(val));
+  cbor_decref(&val);
+  cbor_decref(&key);
+
+  cbor_decref(&map);
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_get_existing_key),
+      cmocka_unit_test(test_get_missing_key),
+      cmocka_unit_test(test_get_empty_map),
+      cmocka_unit_test(test_get_wrong_type),
+      cmocka_unit_test(test_get_encoding_width_matters_with_structural_eq),
+      cmocka_unit_test(test_get_custom_eq_ignores_width),
+      cmocka_unit_test(test_get_custom_str_eq),
+      cmocka_unit_test(test_get_first_match_on_duplicate_keys),
+      cmocka_unit_test(test_get_refcount),
+      cmocka_unit_test(test_get_indefinite_map),
+      cmocka_unit_test(test_get_negint_key),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary

- Adds `cbor_map_get(const cbor_item_t *map, const cbor_item_t *key, bool (*eq)(const cbor_item_t *, const cbor_item_t *))` to `maps.h`/`maps.c`
- 11 tests in `test/map_get_test.c`
- Documentation in `doc/source/api/type_5_maps.rst`
- Changelog entry

## Design rationale

The equality function is parameterized on purpose. The two main reasons:

1. **Type-specific comparators are cheaper.** Most protocols constrain map keys to a single type (e.g., WebAuthn/COSE use small integers; JSON-derived formats use text strings). A comparator that only handles one type avoids the full dispatch overhead of a generic comparator and can be inlined by the compiler.

2. **Any data-model semantics can be plugged in.** Callers can pass `cbor_structurally_equal` for exact encoding-level matching, a width-ignoring integer comparator, a case-insensitive string comparator, or anything else — without the library needing to anticipate every use case.

## Usage

```c
// Structural equality (encoding-level): uint8(1) ≠ uint16(1)
cbor_item_t *v = cbor_map_get(map, key, cbor_structurally_equal);

// Custom comparator that ignores integer encoding width
cbor_item_t *v = cbor_map_get(map, key, my_int_value_eq);
```

The returned item has its reference count incremented; caller must `cbor_decref` it. Returns `NULL` if no key matched.

Closes #96 (alongside #408).

## Test plan

- [ ] `ctest -R map_get_test` passes (11/11)
- [ ] `bash clang-format.sh` produces no diff
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)