### PR TITLE
Fix NULL dereference in cbor_copy/cbor_copy_definite on allocation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Template:
 Next
 ---------------------
 
+- [Fix NULL dereference in `cbor_copy`/`cbor_copy_definite` on allocation failure](https://github.com/PJK/libcbor/pull/419) (reported by [Benjamin608608](https://github.com/Benjamin608608))
 - [Only generate CMake coverage build targets when explicitly enabled](https://github.com/PJK/libcbor/issues/383)
 - [Fix CMake feature macro names and ensure `_CBOR_NODISCARD` is defined with `[[nodiscard]]`](https://github.com/PJK/libcbor/pull/385)
 - [Fix integer overflow in `cbor_copy_definite()` when accumulating indefinite bytestring/string chunk lengths](https://github.com/PJK/libcbor/pull/387)

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -138,6 +138,7 @@ static cbor_item_t* _cbor_copy_int(cbor_item_t* item, bool negative) {
       break;
   }
 
+  if (res == NULL) return NULL;
   if (negative) cbor_mark_negint(res);
 
   return res;
@@ -334,6 +335,10 @@ cbor_item_t* cbor_copy_definite(cbor_item_t* item) {
         }
 
         cbor_item_t* res = cbor_new_definite_bytestring();
+        if (res == NULL) {
+          _cbor_free(combined_data);
+          return NULL;
+        }
         cbor_bytestring_set_handle(res, combined_data, total_length);
         return res;
       }
@@ -365,6 +370,10 @@ cbor_item_t* cbor_copy_definite(cbor_item_t* item) {
         }
 
         cbor_item_t* res = cbor_new_definite_string();
+        if (res == NULL) {
+          _cbor_free(combined_data);
+          return NULL;
+        }
         cbor_string_set_handle(res, combined_data, total_length);
         return res;
       }

--- a/test/copy_test.c
+++ b/test/copy_test.c
@@ -268,6 +268,20 @@ static void test_definite_bytestring_alloc_failure(void** _state _CBOR_UNUSED) {
   cbor_decref(&item);
 }
 
+static void test_definite_bytestring_item_alloc_failure(
+    void** _state _CBOR_UNUSED) {
+  item = cbor_new_indefinite_bytestring();
+  assert_true(cbor_bytestring_add_chunk(
+      item, cbor_move(cbor_build_bytestring((cbor_data) "abc", 3))));
+
+  // combined_data malloc succeeds, cbor_new_definite_bytestring fails
+  WITH_MOCK_MALLOC({ assert_null(cbor_copy_definite(item)); }, 2, MALLOC,
+                   MALLOC_FAIL);
+  assert_size_equal(cbor_refcount(item), 1);
+
+  cbor_decref(&item);
+}
+
 static void test_definite_string(void** _state _CBOR_UNUSED) {
   item = cbor_build_string("abc");
   assert_memory_equal(cbor_string_handle(copy = cbor_copy_definite(item)),
@@ -295,6 +309,19 @@ static void test_definite_string_alloc_failure(void** _state _CBOR_UNUSED) {
   assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
 
   WITH_FAILING_MALLOC({ assert_null(cbor_copy_definite(item)); });
+  assert_size_equal(cbor_refcount(item), 1);
+
+  cbor_decref(&item);
+}
+
+static void test_definite_string_item_alloc_failure(
+    void** _state _CBOR_UNUSED) {
+  item = cbor_new_indefinite_string();
+  assert_true(cbor_string_add_chunk(item, cbor_move(cbor_build_string("abc"))));
+
+  // combined_data malloc succeeds, cbor_new_definite_string fails
+  WITH_MOCK_MALLOC({ assert_null(cbor_copy_definite(item)); }, 2, MALLOC,
+                   MALLOC_FAIL);
   assert_size_equal(cbor_refcount(item), 1);
 
   cbor_decref(&item);
@@ -546,6 +573,34 @@ static void test_alloc_failure_simple(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
   assert_size_equal(cbor_refcount(item), 1);
 
+  cbor_decref(&item);
+}
+
+static void test_negint8_alloc_failure(void** _state _CBOR_UNUSED) {
+  item = cbor_build_negint8(10);
+  WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
+  assert_size_equal(cbor_refcount(item), 1);
+  cbor_decref(&item);
+}
+
+static void test_negint16_alloc_failure(void** _state _CBOR_UNUSED) {
+  item = cbor_build_negint16(10);
+  WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
+  assert_size_equal(cbor_refcount(item), 1);
+  cbor_decref(&item);
+}
+
+static void test_negint32_alloc_failure(void** _state _CBOR_UNUSED) {
+  item = cbor_build_negint32(10);
+  WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
+  assert_size_equal(cbor_refcount(item), 1);
+  cbor_decref(&item);
+}
+
+static void test_negint64_alloc_failure(void** _state _CBOR_UNUSED) {
+  item = cbor_build_negint64(10);
+  WITH_FAILING_MALLOC({ assert_null(cbor_copy(item)); });
+  assert_size_equal(cbor_refcount(item), 1);
   cbor_decref(&item);
 }
 
@@ -808,6 +863,10 @@ int main(void) {
       cmocka_unit_test(test_ctrls),
       cmocka_unit_test(test_floats),
       cmocka_unit_test(test_alloc_failure_simple),
+      cmocka_unit_test(test_negint8_alloc_failure),
+      cmocka_unit_test(test_negint16_alloc_failure),
+      cmocka_unit_test(test_negint32_alloc_failure),
+      cmocka_unit_test(test_negint64_alloc_failure),
       cmocka_unit_test(test_bytestring_alloc_failure),
       cmocka_unit_test(test_bytestring_chunk_alloc_failure),
       cmocka_unit_test(test_bytestring_chunk_append_failure),
@@ -831,12 +890,14 @@ int main(void) {
       cmocka_unit_test(test_definite_negints),
       cmocka_unit_test(test_definite_bytestring),
       cmocka_unit_test(test_definite_bytestring_alloc_failure),
+      cmocka_unit_test(test_definite_bytestring_item_alloc_failure),
       cmocka_unit_test(test_definite_indef_bytestring),
       cmocka_unit_test(test_definite_indef_bytestring_chunk_length_overflow),
       cmocka_unit_test(test_definite_string),
       cmocka_unit_test(test_definite_indef_string),
       cmocka_unit_test(test_definite_indef_string_chunk_length_overflow),
       cmocka_unit_test(test_definite_string_alloc_failure),
+      cmocka_unit_test(test_definite_string_item_alloc_failure),
       cmocka_unit_test(test_definite_array),
       cmocka_unit_test(test_definite_indef_array),
       cmocka_unit_test(test_definite_indef_array_nested),


### PR DESCRIPTION
Fixes #417.

## Summary

- `_cbor_copy_int`: `cbor_mark_negint(res)` was called unconditionally after the switch, even if the preceding `cbor_build_uint*()` returned NULL on allocation failure. Added early `return NULL` before the dereference.
- `cbor_copy_definite` bytestring: `cbor_bytestring_set_handle` was called on a potentially-NULL `res` from `cbor_new_definite_bytestring()`. Added early return with `_cbor_free(combined_data)` to avoid the dereference and the buffer leak.
- `cbor_copy_definite` string: identical pattern to the bytestring case, same fix.

## Test plan

- [ ] New tests added for all four negint widths (`test_negint{8,16,32,64}_alloc_failure`) — confirm `cbor_copy` returns NULL rather than crashing when allocation fails
- [ ] New `test_definite_bytestring_item_alloc_failure` — covers the path where `combined_data` malloc succeeds but `cbor_new_definite_bytestring` fails
- [ ] New `test_definite_string_item_alloc_failure` — same for strings
- [ ] All 65 `copy_test` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)