### PR TITLE
Fix NULL dereference when serializing/measuring a tag with no item set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Template:
 Next
 ---------------------
 
+- [Fix NULL dereference in `cbor_move`, `cbor_serialized_size`, and `cbor_serialize_tag` when a tag has no item set](https://github.com/PJK/libcbor/pull/420) (reported by [Benjamin608608](https://github.com/Benjamin608608))
 - [Only generate CMake coverage build targets when explicitly enabled](https://github.com/PJK/libcbor/issues/383)
 - [Fix CMake feature macro names and ensure `_CBOR_NODISCARD` is defined with `[[nodiscard]]`](https://github.com/PJK/libcbor/pull/385)
 - [Fix integer overflow in `cbor_copy_definite()` when accumulating indefinite bytestring/string chunk lengths](https://github.com/PJK/libcbor/pull/387)

--- a/src/cbor/common.c
+++ b/src/cbor/common.c
@@ -162,6 +162,7 @@ void cbor_intermediate_decref(cbor_item_t* item) { cbor_decref(&item); }
 size_t cbor_refcount(const cbor_item_t* item) { return item->refcount; }
 
 cbor_item_t* cbor_move(cbor_item_t* item) {
+  if (item == NULL) return NULL;
   item->refcount--;
   return item;
 }

--- a/src/cbor/serialization.c
+++ b/src/cbor/serialization.c
@@ -141,9 +141,11 @@ size_t cbor_serialized_size(const cbor_item_t* item) {
       return map_size;
     }
     case CBOR_TYPE_TAG: {
+      cbor_item_t* tagged = cbor_tag_item(item);
+      if (tagged == NULL) return 0;
       return _cbor_safe_signaling_add(
           _cbor_encoded_header_size(cbor_tag_value(item)),
-          cbor_serialized_size(cbor_move(cbor_tag_item(item))));
+          cbor_serialized_size(cbor_move(tagged)));
     }
     case CBOR_TYPE_FLOAT_CTRL:
       CBOR_ASSERT(cbor_float_get_width(item) >= CBOR_FLOAT_0 &&
@@ -368,8 +370,10 @@ size_t cbor_serialize_tag(const cbor_item_t* item, unsigned char* buffer,
   size_t written = cbor_encode_tag(cbor_tag_value(item), buffer, buffer_size);
   if (written == 0) return 0;
 
-  size_t item_written = cbor_serialize(cbor_move(cbor_tag_item(item)),
-                                       buffer + written, buffer_size - written);
+  cbor_item_t* tagged = cbor_tag_item(item);
+  if (tagged == NULL) return 0;
+  size_t item_written = cbor_serialize(cbor_move(tagged), buffer + written,
+                                       buffer_size - written);
   if (item_written == 0) return 0;
   return written + item_written;
 }

--- a/test/cbor_serialize_test.c
+++ b/test/cbor_serialize_test.c
@@ -466,6 +466,20 @@ static void test_serialize_tags(void** _state _CBOR_UNUSED) {
   cbor_decref(&one);
 }
 
+static void test_serialized_size_tag_no_item(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_tag(21);
+  // cbor_tag_item returns NULL, cbor_move(NULL) crashes without the fix
+  assert_size_equal(cbor_serialized_size(item), 0);
+  cbor_decref(&item);
+}
+
+static void test_serialize_tag_no_item(void** _state _CBOR_UNUSED) {
+  cbor_item_t* item = cbor_new_tag(21);
+  // cbor_tag_item returns NULL, cbor_move(NULL) crashes without the fix
+  assert_size_equal(cbor_serialize(item, buffer, 512), 0);
+  cbor_decref(&item);
+}
+
 static void test_serialize_tags_no_space(void** _state _CBOR_UNUSED) {
   cbor_item_t* item = cbor_new_tag(21);
   cbor_item_t* one = cbor_build_uint8(1);
@@ -731,6 +745,8 @@ int main(void) {
       cmocka_unit_test(test_serialize_indefinite_map),
       cmocka_unit_test(test_serialize_map_no_space),
       cmocka_unit_test(test_serialize_tags),
+      cmocka_unit_test(test_serialized_size_tag_no_item),
+      cmocka_unit_test(test_serialize_tag_no_item),
       cmocka_unit_test(test_serialize_tags_no_space),
       cmocka_unit_test(test_serialize_half),
       cmocka_unit_test(test_serialize_single),

--- a/test/tag_test.c
+++ b/test/tag_test.c
@@ -169,6 +169,14 @@ static void test_tag_item_null(void** _state _CBOR_UNUSED) {
   cbor_decref(&tag);
 }
 
+static void test_move_null(void** _state _CBOR_UNUSED) {
+  // cbor_tag_item returns NULL on a tag with no item set; cbor_move must
+  // handle NULL without crashing
+  tag = cbor_new_tag(0);
+  assert_null(cbor_move(cbor_tag_item(tag)));
+  cbor_decref(&tag);
+}
+
 static void test_tag_creation(void** _state _CBOR_UNUSED) {
   WITH_FAILING_MALLOC({ assert_null(cbor_new_tag(42)); });
 }
@@ -187,6 +195,7 @@ int main(void) {
       cmocka_unit_test(test_build_tag_failure),
       cmocka_unit_test(test_set_item_replaces_previous),
       cmocka_unit_test(test_tag_item_null),
+      cmocka_unit_test(test_move_null),
       cmocka_unit_test(test_tag_creation),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Fixes #416.

## Summary

Commit e87cc36 changed `cbor_tag_item()` to return `NULL` when called on a tag with no item set, but several call sites using `cbor_move(cbor_tag_item(...))` were not updated. Since `cbor_move` unconditionally does `item->refcount--`, passing `NULL` causes an immediate crash.

- **`cbor_move`** (`common.c`): added `NULL` guard — returns `NULL` when passed `NULL`. This makes the `cbor_move(cbor_tag_item(...))` pattern safe by contract.
- **`cbor_serialized_size`** (`serialization.c`): extract `cbor_tag_item` result into a local, return `0` if `NULL` before calling `cbor_move`.
- **`cbor_serialize_tag`** (`serialization.c`): same — return `0` (serialization failure) if the tag has no item set.

## Test plan

- [ ] `test_move_null` — `cbor_move(cbor_tag_item(empty_tag))` returns `NULL` without crashing
- [ ] `test_serialized_size_tag_no_item` — `cbor_serialized_size` returns `0` for a tag with no item
- [ ] `test_serialize_tag_no_item` — `cbor_serialize` returns `0` for a tag with no item
- [ ] Full test suite (28 targets) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)