### PR TITLE
Drop manual Homebrew update step from release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -90,6 +90,4 @@ echo "Release ready in $OUTDIR"
 echo "Add the release to GitHub at https://github.com/PJK/libcbor/releases/new *now*"
 prompt "Have you added the release to https://github.com/PJK/libcbor/releases/tag/$TAG_NAME?"
 
-echo "Update the Hombrew formula (https://github.com/Homebrew/homebrew-core/blob/master/Formula/libcbor.rb) *now*"
-echo "HOWTO: https://github.com/Linuxbrew/brew/blob/master/docs/How-To-Open-a-Homebrew-Pull-Request.md"
-prompt "Have you updated the formula?"
+echo "The Homebrew formula is updated automatically from the new tag."


### PR DESCRIPTION
## Summary

Homebrew formulas are now updated automatically when a new tag is pushed. Removes the manual prompt and instructions that asked the releaser to open a Homebrew PR by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)