### PR TITLE
Replay fuzz inputs with malloc and realloc failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Template:
 Next
 ---------------------
 
+- [Replay fuzz test inputs with allocation failures](https://github.com/PJK/libcbor/issues/86), checking decoder error reporting and cleanup for every `malloc` and `realloc` failure.
+
 - ABI BREAKING: [Inline `cbor_incref` and `cbor_decref` fast paths](https://github.com/PJK/libcbor/pull/434)
   - `cbor_incref` and `cbor_decref` are now `static inline` in `cbor/common.h`; the deallocation branch of `cbor_decref` moved into a new exported helper `_cbor_decref_free`. Source-compatible — same signatures and semantics — but the two symbols are no longer exported from the shared library, so binaries relying on their extern resolution (including `dlsym`) will fail to link against the new `.so`. Rebuilding against the updated headers is sufficient.
 

--- a/doc/source/tests.rst
+++ b/doc/source/tests.rst
@@ -37,3 +37,10 @@ Fuzz testing
 -----------------
 
 Every release is tested using a fuzz test. In this test, a huge buffer filled with random data is passed to the decoder. We require that it either succeeds or fail with a sensible error, without leaking any memory. This is intended to simulate real-world situations where data received from the network are CBOR-decoded before any further processing.
+
+Each input is also replayed with every allocation failing in turn, including
+``realloc`` calls. These runs must return ``CBOR_ERR_MEMERROR`` and release all
+allocations made before the failure. A fixed nested input exercises container
+growth and partial cleanup even when the random inputs fail to parse early.
+The test accepts an optional random seed (for example, ``test/fuzz_test 42``)
+to reproduce a run.

--- a/test/fuzz_test.c
+++ b/test/fuzz_test.c
@@ -25,18 +25,71 @@ static void printmem(const unsigned char* ptr, size_t length) {
 #endif
 
 unsigned seed;
+static size_t allocation_count;
+static size_t fail_at;
+static size_t live_allocations;
 
-void* mock_malloc(size_t size) {
-  if (size > (1 << 19))
-    return NULL;
-  else
-    return malloc(size);
+static bool fail_allocation(size_t size) {
+  allocation_count++;
+  return allocation_count == fail_at || size > (1 << 19);
+}
+
+static void* mock_malloc(size_t size) {
+  if (fail_allocation(size)) return NULL;
+  void* ptr = malloc(size);
+  if (ptr != NULL) live_allocations++;
+  return ptr;
+}
+
+static void* mock_realloc(void* ptr, size_t size) {
+  if (fail_allocation(size)) return NULL;
+  // The decoder only requests nonzero realloc sizes.
+  assert_true(size > 0);
+  bool new_allocation = ptr == NULL;
+  void* result = realloc(ptr, size);
+  if (result != NULL && new_allocation) live_allocations++;
+  return result;
+}
+
+static void mock_free(void* ptr) {
+  if (ptr != NULL) {
+    assert_true(live_allocations > 0);
+    live_allocations--;
+  }
+  free(ptr);
+}
+
+static cbor_error_code load_with_failure(cbor_data data, size_t length,
+                                         size_t failure) {
+  allocation_count = 0;
+  fail_at = failure;
+  struct cbor_load_result res;
+  cbor_item_t* item = cbor_load(data, length, &res);
+  if (failure != 0) {
+    assert_true(allocation_count >= failure);
+    assert_int_equal(res.error.code, CBOR_ERR_MEMERROR);
+  }
+  if (res.error.code == CBOR_ERR_NONE) {
+    assert_non_null(item);
+    cbor_decref(&item);
+  } else {
+    assert_null(item);
+  }
+  assert_size_equal(live_allocations, 0);
+  return res.error.code;
+}
+
+static void run_input(cbor_data data, size_t length) {
+  // Count the allocations on the original path, then replay the same input
+  // with each malloc/realloc failing in turn. No PRNG calls during replay.
+  load_with_failure(data, length, 0);
+  size_t allocations = allocation_count;
+  for (size_t failure = 1; failure <= allocations; failure++) {
+    load_with_failure(data, length, failure);
+  }
 }
 
 static void run_round(void) {
-  cbor_item_t* item;
-  struct cbor_load_result res;
-
   size_t length = rand() % MAXLEN + 1;
   unsigned char* data = malloc(length);
   for (size_t i = 0; i < length; i++) {
@@ -47,24 +100,39 @@ static void run_round(void) {
   printmem(data, length);
 #endif
 
-  item = cbor_load(data, length, &res);
-
-  if (res.error.code == CBOR_ERR_NONE) cbor_decref(&item);
-  /* Otherwise there should be nothing left behind by the decoder */
+  run_input(data, length);
 
   free(data);
 }
 
 static void fuzz(void** _state _CBOR_UNUSED) {
-  cbor_set_allocs(mock_malloc, realloc, free);
+  cbor_set_allocs(mock_malloc, mock_realloc, mock_free);
   printf("Fuzzing %llu rounds of up to %llu bytes with seed %u\n", ROUNDS,
          MAXLEN, seed);
   srand(seed);
 
   for (size_t i = 0; i < ROUNDS; i++) run_round();
 
+  cbor_set_allocs(malloc, realloc, free);
+
   printf("Successfully fuzzed through %llu kB of data\n",
          (ROUNDS * MAXLEN) / 1024);
+}
+
+static void fuzz_nested_allocations(void** _state _CBOR_UNUSED) {
+  // Valid nested input ensures that realloc and cleanup of partially built
+  // maps, arrays, tags, and chunked strings are exercised on every invocation.
+  const unsigned char data[] = {
+      0x9f,                                // Indefinite array
+      0xa1, 0x01, 0x82, 0x02, 0x03,        // Definite map and array
+      0xbf, 0x04, 0xc0, 0x05, 0xff,        // Indefinite map and tag
+      0x5f, 0x41, 0x01, 0x41, 0x02, 0xff,  // Chunked byte string
+      0x7f, 0x61, 0x61, 0x61, 0x62, 0xff,  // Chunked text string
+      0xff};
+  cbor_set_allocs(mock_malloc, mock_realloc, mock_free);
+  assert_int_equal(load_with_failure(data, sizeof(data), 0), CBOR_ERR_NONE);
+  run_input(data, sizeof(data));
+  cbor_set_allocs(malloc, realloc, free);
 }
 
 int main(int argc, char* argv[]) {
@@ -73,6 +141,7 @@ int main(int argc, char* argv[]) {
   else
     seed = (unsigned)time(NULL);
 
-  const struct CMUnitTest tests[] = {cmocka_unit_test(fuzz)};
+  const struct CMUnitTest tests[] = {cmocka_unit_test(fuzz_nested_allocations),
+                                     cmocka_unit_test(fuzz)};
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
The fuzz test currently rejects large malloc requests but does not systematically exercise allocation failures. Count the allocations made while decoding each input, then replay it with each malloc/realloc failing in turn. Check that the decoder returns `CBOR_ERR_MEMERROR` and NULL and releases every allocation made before the failure.

A fixed nested input exercises map/array growth, tags and chunked strings on every run; random inputs use the existing seed mechanism. Update the test documentation and changelog.

Closes #86.

Validation: all 28 tests passed in a Debug build with ASan/UBSan, plus explicit fuzz seeds 1, 42 and 4294967295. Disabling allocation failure injection makes the fixed fixture fail its error-code assertion; restoring it passes.

Developed with AI assistance; the patch was reviewed and tested locally.
